### PR TITLE
feat: Reserve Quality Score (RQS) composition renderer

### DIFF
--- a/app/composition.py
+++ b/app/composition.py
@@ -142,13 +142,14 @@ def compute_rqs(holdings: list[dict]) -> dict:
     scored_weight = 0.0
     weighted_sum = 0.0
     warnings = []
+    oldest_sii_at = None  # track the oldest SII computed_at
 
     for h in holdings:
         symbol = h.get("symbol", "").upper()
         weight = h.get("weight", 0) / raw_weight_sum  # normalise
 
         sii_row = fetch_one("""
-            SELECT s.overall_score, s.component_count
+            SELECT s.overall_score, s.component_count, s.computed_at
             FROM scores s
             JOIN stablecoins st ON st.id = s.stablecoin_id
             WHERE UPPER(st.symbol) = UPPER(%s)
@@ -160,6 +161,11 @@ def compute_rqs(holdings: list[dict]) -> dict:
             contribution = round(weight * sii_score, 4)
             weighted_sum += contribution
             scored_weight += weight
+
+            sii_at = sii_row.get("computed_at")
+            if sii_at and (oldest_sii_at is None or sii_at < oldest_sii_at):
+                oldest_sii_at = sii_at
+
             breakdown.append({
                 "symbol": symbol,
                 "weight": round(weight, 4),
@@ -193,7 +199,7 @@ def compute_rqs(holdings: list[dict]) -> dict:
     from app.scoring_engine import compute_confidence_tag
     conf = compute_confidence_tag(0, 0, scored_coverage)
 
-    return {
+    result = {
         "composite_id": "rqs",
         "name": "Reserve Quality Score",
         "rqs_score": rqs_score,
@@ -205,6 +211,11 @@ def compute_rqs(holdings: list[dict]) -> dict:
         "method": "weighted_average",
         "formula_version": "composition-v1.0.0",
     }
+
+    if oldest_sii_at:
+        result["sii_scored_at"] = oldest_sii_at.isoformat() if hasattr(oldest_sii_at, "isoformat") else str(oldest_sii_at)
+
+    return result
 
 
 def compute_rqs_for_protocol(protocol_slug: str) -> dict:
@@ -225,9 +236,9 @@ def compute_rqs_for_protocol(protocol_slug: str) -> dict:
     if not psi_row:
         return {"error": f"Protocol '{protocol_slug}' not found in PSI scores"}
 
-    # Fetch stablecoin treasury holdings
+    # Fetch stablecoin treasury holdings + snapshot date
     rows = fetch_all("""
-        SELECT token_symbol, usd_value, sii_score, is_stablecoin
+        SELECT token_symbol, usd_value, sii_score, is_stablecoin, snapshot_date
         FROM protocol_treasury_holdings
         WHERE protocol_slug = %s AND is_stablecoin = TRUE
           AND snapshot_date = (
@@ -244,6 +255,8 @@ def compute_rqs_for_protocol(protocol_slug: str) -> dict:
             "protocol": psi_row.get("protocol_name", protocol_slug),
             "protocol_slug": protocol_slug,
         }
+
+    holdings_snapshot_date = rows[0].get("snapshot_date") if rows else None
 
     # Aggregate by symbol (may appear on multiple chains)
     by_symbol: dict[str, float] = {}
@@ -278,6 +291,22 @@ def compute_rqs_for_protocol(protocol_slug: str) -> dict:
     # Add USD values to breakdown
     for item in result.get("breakdown", []):
         item["usd_value"] = round(by_symbol.get(item["symbol"], 0), 2)
+
+    # Surface staleness: data_as_of = older of holdings snapshot vs SII scores
+    if holdings_snapshot_date:
+        snap_str = holdings_snapshot_date.isoformat() if hasattr(holdings_snapshot_date, "isoformat") else str(holdings_snapshot_date)
+        result["holdings_as_of"] = snap_str
+
+    sii_at_str = result.get("sii_scored_at")
+    if holdings_snapshot_date and sii_at_str:
+        # Compare date portion of both timestamps
+        snap_date_str = str(holdings_snapshot_date)[:10]
+        sii_date_str = sii_at_str[:10]
+        result["data_as_of"] = min(snap_date_str, sii_date_str)
+    elif holdings_snapshot_date:
+        result["data_as_of"] = str(holdings_snapshot_date)[:10]
+    elif sii_at_str:
+        result["data_as_of"] = sii_at_str[:10]
 
     # Attest state
     try:

--- a/app/composition.py
+++ b/app/composition.py
@@ -114,6 +114,218 @@ def compute_cqi(asset_symbol, protocol_slug):
     }
 
 
+# =============================================================================
+# RQS (Reserve Quality Score) — weighted-average SII over protocol holdings
+# =============================================================================
+
+
+def compute_rqs(holdings: list[dict]) -> dict:
+    """
+    Compute Reserve Quality Score from a list of stablecoin holdings.
+
+    Each holding dict must have:
+      - symbol: stablecoin ticker (e.g. "USDC")
+      - weight: proportion of portfolio (0-1, must sum to ~1)
+
+    Fetches current SII score for each stablecoin.
+    Returns weighted-average SII as the RQS, plus component breakdown.
+    """
+    if not holdings:
+        return {"error": "No holdings provided"}
+
+    # Normalise weights to ensure they sum to 1
+    raw_weight_sum = sum(h.get("weight", 0) for h in holdings)
+    if raw_weight_sum <= 0:
+        return {"error": "Holdings weights must be positive"}
+
+    breakdown = []
+    scored_weight = 0.0
+    weighted_sum = 0.0
+    warnings = []
+
+    for h in holdings:
+        symbol = h.get("symbol", "").upper()
+        weight = h.get("weight", 0) / raw_weight_sum  # normalise
+
+        sii_row = fetch_one("""
+            SELECT s.overall_score, s.component_count
+            FROM scores s
+            JOIN stablecoins st ON st.id = s.stablecoin_id
+            WHERE UPPER(st.symbol) = UPPER(%s)
+        """, (symbol,))
+
+        sii_score = None
+        if sii_row and sii_row.get("overall_score") is not None:
+            sii_score = float(sii_row["overall_score"])
+            contribution = round(weight * sii_score, 4)
+            weighted_sum += contribution
+            scored_weight += weight
+            breakdown.append({
+                "symbol": symbol,
+                "weight": round(weight, 4),
+                "sii_score": round(sii_score, 2),
+                "contribution": contribution,
+                "scored": True,
+            })
+        else:
+            warnings.append(f"{symbol} has no SII score — excluded from RQS")
+            breakdown.append({
+                "symbol": symbol,
+                "weight": round(weight, 4),
+                "sii_score": None,
+                "contribution": 0,
+                "scored": False,
+            })
+
+    scored_coverage = round(scored_weight, 4)
+
+    if scored_weight <= 0:
+        return {
+            "error": "None of the provided holdings have SII scores",
+            "breakdown": breakdown,
+            "warnings": warnings,
+        }
+
+    # Re-normalise over scored-only weight so RQS stays on 0-100 scale
+    rqs_score = round(weighted_sum / scored_weight, 2)
+
+    # Confidence based on how much of the portfolio is scored
+    from app.scoring_engine import compute_confidence_tag
+    conf = compute_confidence_tag(0, 0, scored_coverage)
+
+    return {
+        "composite_id": "rqs",
+        "name": "Reserve Quality Score",
+        "rqs_score": rqs_score,
+        "scored_coverage": scored_coverage,
+        "confidence": conf["confidence"],
+        "confidence_tag": conf["tag"],
+        "breakdown": sorted(breakdown, key=lambda x: x["contribution"], reverse=True),
+        "warnings": warnings,
+        "method": "weighted_average",
+        "formula_version": "composition-v1.0.0",
+    }
+
+
+def compute_rqs_for_protocol(protocol_slug: str) -> dict:
+    """
+    Compute RQS for a specific PSI-scored protocol using its treasury holdings.
+
+    Reads from protocol_treasury_holdings table (stablecoin rows with SII scores).
+    Weights are proportional to USD value held.
+    """
+    # Verify protocol exists in PSI
+    psi_row = fetch_one("""
+        SELECT protocol_name, overall_score
+        FROM psi_scores
+        WHERE protocol_slug = %s
+        ORDER BY computed_at DESC LIMIT 1
+    """, (protocol_slug,))
+
+    if not psi_row:
+        return {"error": f"Protocol '{protocol_slug}' not found in PSI scores"}
+
+    # Fetch stablecoin treasury holdings
+    rows = fetch_all("""
+        SELECT token_symbol, usd_value, sii_score, is_stablecoin
+        FROM protocol_treasury_holdings
+        WHERE protocol_slug = %s AND is_stablecoin = TRUE
+          AND snapshot_date = (
+              SELECT MAX(snapshot_date)
+              FROM protocol_treasury_holdings
+              WHERE protocol_slug = %s
+          )
+        ORDER BY usd_value DESC
+    """, (protocol_slug, protocol_slug))
+
+    if not rows:
+        return {
+            "error": f"No stablecoin treasury holdings found for '{protocol_slug}'",
+            "protocol": psi_row.get("protocol_name", protocol_slug),
+            "protocol_slug": protocol_slug,
+        }
+
+    # Aggregate by symbol (may appear on multiple chains)
+    by_symbol: dict[str, float] = {}
+    for r in rows:
+        sym = r["token_symbol"].upper()
+        by_symbol[sym] = by_symbol.get(sym, 0.0) + float(r["usd_value"])
+
+    total_usd = sum(by_symbol.values())
+    if total_usd <= 0:
+        return {"error": f"Zero stablecoin value in treasury for '{protocol_slug}'"}
+
+    # Build holdings list with USD-proportional weights
+    holdings = [
+        {"symbol": sym, "weight": usd / total_usd}
+        for sym, usd in by_symbol.items()
+    ]
+
+    result = compute_rqs(holdings)
+
+    if "error" in result and "breakdown" not in result:
+        result["protocol"] = psi_row.get("protocol_name", protocol_slug)
+        result["protocol_slug"] = protocol_slug
+        return result
+
+    # Enrich with protocol context
+    psi_score = float(psi_row["overall_score"]) if psi_row.get("overall_score") else None
+    result["protocol"] = psi_row.get("protocol_name", protocol_slug)
+    result["protocol_slug"] = protocol_slug
+    result["psi_score"] = round(psi_score, 2) if psi_score else None
+    result["treasury_total_usd"] = round(total_usd, 2)
+
+    # Add USD values to breakdown
+    for item in result.get("breakdown", []):
+        item["usd_value"] = round(by_symbol.get(item["symbol"], 0), 2)
+
+    # Attest state
+    try:
+        from app.state_attestation import attest_state
+        attest_state("rqs_composition", [
+            {"protocol": protocol_slug, "rqs_score": result.get("rqs_score")},
+        ], entity_id=protocol_slug)
+    except Exception:
+        pass  # attestation is non-critical
+
+    return result
+
+
+def compute_rqs_all() -> dict:
+    """Compute RQS for all protocols that have treasury holdings data."""
+    from app.index_definitions.psi_v01 import TARGET_PROTOCOLS
+
+    results = []
+    errors = []
+
+    for slug in TARGET_PROTOCOLS:
+        result = compute_rqs_for_protocol(slug)
+        if "error" in result and "rqs_score" not in result:
+            errors.append({"protocol_slug": slug, "error": result["error"]})
+        else:
+            results.append(result)
+
+    results.sort(key=lambda x: x.get("rqs_score", 0), reverse=True)
+
+    # Attest batch
+    try:
+        from app.state_attestation import attest_state
+        if results:
+            attest_state("rqs_compositions", [
+                {"protocol": r["protocol_slug"], "rqs_score": round(r["rqs_score"], 2)}
+                for r in results if r.get("rqs_score") is not None
+            ])
+    except Exception:
+        pass
+
+    return {
+        "protocols": results,
+        "count": len(results),
+        "skipped": errors,
+        "formula_version": "composition-v1.0.0",
+    }
+
+
 def compute_cqi_matrix():
     """Compute CQI for all stablecoin x protocol combinations."""
     stablecoins = fetch_all("""

--- a/app/payments.py
+++ b/app/payments.py
@@ -187,6 +187,9 @@ def create_x402_middleware():
         "GET /api/paid/cqi": _route(
             "$0.001", "Composite Quality Index for a stablecoin-protocol pair"
         ),
+        "GET /api/paid/rqs/{slug}": _route(
+            "$0.001", "Reserve Quality Score for a protocol's stablecoin treasury holdings"
+        ),
         "GET /api/paid/pulse/latest": _route(
             "$0.002", "Latest daily system pulse with integrity status"
         ),
@@ -353,6 +356,17 @@ async def paid_cqi(asset: str = Query(...), protocol: str = Query(...)):
     from app.composition import compute_cqi
     result = compute_cqi(asset, protocol)
     if "error" in result:
+        raise HTTPException(status_code=404, detail=result["error"])
+    result["tier"] = "paid"
+    return result
+
+
+@paid_router.get("/rqs/{slug}")
+async def paid_rqs(slug: str):
+    """Paid: Reserve Quality Score for a protocol's stablecoin treasury."""
+    from app.composition import compute_rqs_for_protocol
+    result = compute_rqs_for_protocol(slug)
+    if "error" in result and "rqs_score" not in result:
         raise HTTPException(status_code=404, detail=result["error"])
     result["tier"] = "paid"
     return result

--- a/app/server.py
+++ b/app/server.py
@@ -4770,6 +4770,27 @@ async def compose_cqi_matrix():
     return compute_cqi_matrix()
 
 
+# =============================================================================
+# RQS (Reserve Quality Score) — Composition API
+# =============================================================================
+
+@app.get("/api/compose/rqs")
+async def compose_rqs_all():
+    """Reserve Quality Score for all PSI-scored protocols."""
+    from app.composition import compute_rqs_all
+    return compute_rqs_all()
+
+
+@app.get("/api/compose/rqs/{slug}")
+async def compose_rqs_protocol(slug: str):
+    """Reserve Quality Score for a single protocol's stablecoin treasury."""
+    from app.composition import compute_rqs_for_protocol
+    result = compute_rqs_for_protocol(slug)
+    if "error" in result and "rqs_score" not in result:
+        raise HTTPException(status_code=404, detail=result["error"])
+    return result
+
+
 @app.get("/api/specs/composition")
 async def get_composition_spec():
     """Published composition grammar specification."""


### PR DESCRIPTION
## Summary
- **RQS = weighted-average SII across a protocol's stablecoin treasury holdings.** No new primitives — composes existing `protocol_treasury_holdings` data with live SII scores.
- Adds `compute_rqs()` (pure computation from `{symbol, weight}` list), `compute_rqs_for_protocol()` (fetches treasury data for a PSI protocol), and `compute_rqs_all()` (batch across all 13 PSI protocols) in `app/composition.py`
- Free endpoints: `GET /api/compose/rqs` and `GET /api/compose/rqs/{slug}` in `app/server.py`
- Paid endpoint: `GET /api/paid/rqs/{slug}` ($0.001 via x402) in `app/payments.py`
- Surfaces data staleness: response includes `holdings_as_of`, `sii_scored_at`, and `data_as_of` (the older of the two input clocks) so consumers know the freshness floor
- State attestation for each RQS computation via existing `attest_state()` infrastructure

## Test plan
- [ ] Verify `GET /api/compose/rqs` returns scored protocols with `rqs_score`, `breakdown`, `data_as_of`
- [ ] Verify `GET /api/compose/rqs/{slug}` returns 404 for unknown slugs and full breakdown for known ones
- [ ] Verify `data_as_of` reflects the older of holdings snapshot vs SII score timestamp
- [ ] Verify unscored stablecoins appear in `warnings` and are excluded from the weighted average
- [ ] Verify `GET /api/paid/rqs/{slug}` returns 402 without payment and includes `"tier": "paid"` with payment

https://claude.ai/code/session_01673RCMEYRCdQWVijGmWAMB