### PR TITLE
feat: protocol parameter history + clustered holder concentration

### DIFF
--- a/app/coherence.py
+++ b/app/coherence.py
@@ -56,6 +56,9 @@ ALL_DOMAINS = [
     "governance_proposals",
     "contract_dependencies",
     "contract_dependencies_snapshot",
+    "protocol_parameter_changes",
+    "protocol_parameter_snapshots",
+    "clustered_concentration",
 ]
 
 DOMAIN_FREQUENCIES = {
@@ -90,6 +93,9 @@ DOMAIN_FREQUENCIES = {
     "governance_proposals": 24,
     "contract_dependencies": 24,
     "contract_dependencies_snapshot": 24,
+    "protocol_parameter_changes": 4,   # checked every fast cycle (~hourly)
+    "protocol_parameter_snapshots": 24,
+    "clustered_concentration": 24,
 }
 
 

--- a/app/collectors/clustered_concentration.py
+++ b/app/collectors/clustered_concentration.py
@@ -1,0 +1,374 @@
+"""
+Graph-Clustered Holder Concentration Collector (Pipeline 14)
+===============================================================
+Computes true holder concentration by merging wallets that share
+common graph counterparties into single economic entities using
+union-find on the relationship graph.
+
+Nominal holder concentration is reconstructable. Graph-clustered
+concentration requires edges that existed at a specific point in
+time — those edges are pruned on a 180-day rolling basis.
+
+Runs daily in the slow cycle.  Never raises — all errors logged and skipped.
+"""
+
+import hashlib
+import json
+import logging
+import time
+from datetime import date, datetime, timezone
+
+from app.database import fetch_all, fetch_one, execute
+
+logger = logging.getLogger(__name__)
+
+# Minimum edge weight to merge two wallets into a cluster.
+# Without this, every wallet that ever sent dust to an exchange
+# gets merged into the exchange cluster, destroying the signal.
+MIN_EDGE_WEIGHT = 0.1
+
+# Max edges to load per stablecoin to avoid memory issues
+MAX_EDGES = 50000
+
+# Max holders to analyze
+MAX_HOLDERS = 500
+
+
+# ---------------------------------------------------------------------------
+# Union-Find with path compression
+# ---------------------------------------------------------------------------
+
+class UnionFind:
+    def __init__(self):
+        self.parent = {}
+        self.rank = {}
+
+    def find(self, x):
+        if x not in self.parent:
+            self.parent[x] = x
+            self.rank[x] = 0
+        if self.parent[x] != x:
+            self.parent[x] = self.find(self.parent[x])  # path compression
+        return self.parent[x]
+
+    def union(self, x, y):
+        rx, ry = self.find(x), self.find(y)
+        if rx == ry:
+            return
+        # union by rank
+        if self.rank[rx] < self.rank[ry]:
+            self.parent[rx] = ry
+        elif self.rank[rx] > self.rank[ry]:
+            self.parent[ry] = rx
+        else:
+            self.parent[ry] = rx
+            self.rank[rx] += 1
+
+    def groups(self, keys):
+        """Return dict mapping root -> list of members."""
+        clusters = {}
+        for k in keys:
+            root = self.find(k)
+            clusters.setdefault(root, []).append(k)
+        return clusters
+
+
+# ---------------------------------------------------------------------------
+# Gini coefficient
+# ---------------------------------------------------------------------------
+
+def _compute_gini(values: list[float]) -> float:
+    """Compute Gini coefficient. Returns 0-1 float."""
+    if not values or len(values) < 2:
+        return 0.0
+    vals = sorted(values)
+    n = len(vals)
+    total = sum(vals)
+    if total <= 0:
+        return 0.0
+    numerator = sum((2 * i - n - 1) * x for i, x in enumerate(vals, 1))
+    return numerator / (n * total)
+
+
+def _top_n_pct(values: list[float], n: int) -> float:
+    """Return percentage of total held by top N entries."""
+    if not values:
+        return 0.0
+    sorted_desc = sorted(values, reverse=True)
+    total = sum(sorted_desc)
+    if total <= 0:
+        return 0.0
+    top = sum(sorted_desc[:n])
+    return round(top / total * 100, 4)
+
+
+# ---------------------------------------------------------------------------
+# Core clustering logic
+# ---------------------------------------------------------------------------
+
+def _compute_clusters(stablecoin_symbol: str, stablecoin_id: int) -> tuple[list[dict], dict]:
+    """
+    Run the full clustering pipeline for one stablecoin.
+    Returns (clusters_list, metrics_dict).
+    """
+    symbol_upper = stablecoin_symbol.upper()
+
+    # Step 1: Load top holders
+    holders = fetch_all(
+        """SELECT DISTINCT ON (wh.wallet_address)
+                  wh.wallet_address, wh.value_usd,
+                  COALESCE(ac.actor_type, 'unknown') AS actor_type
+           FROM wallet_graph.wallet_holdings wh
+           LEFT JOIN wallet_graph.actor_classifications ac
+                  ON wh.wallet_address = ac.wallet_address
+           WHERE UPPER(wh.symbol) = %s
+             AND wh.value_usd > 0
+           ORDER BY wh.wallet_address, wh.indexed_at DESC
+           LIMIT %s""",
+        (symbol_upper, MAX_HOLDERS),
+    )
+
+    if not holders or len(holders) < 10:
+        logger.warning(
+            f"Clustered concentration: {symbol_upper} has {len(holders or [])} holders, "
+            f"skipping (need >= 10)"
+        )
+        return [], {}
+
+    holder_addrs = [h["wallet_address"] for h in holders]
+    balance_map = {h["wallet_address"]: float(h["value_usd"]) for h in holders}
+    actor_map = {h["wallet_address"]: h.get("actor_type", "unknown") for h in holders}
+
+    # Step 2: Load relevant graph edges (respect 180-day pruning)
+    edges = fetch_all(
+        """SELECT from_address, to_address, weight
+           FROM wallet_graph.wallet_edges
+           WHERE (from_address = ANY(%s) OR to_address = ANY(%s))
+             AND last_transfer_at > NOW() - INTERVAL '180 days'
+             AND weight >= %s
+           LIMIT %s""",
+        (holder_addrs, holder_addrs, MIN_EDGE_WEIGHT, MAX_EDGES),
+    )
+
+    # Step 3: Build union-find structure
+    uf = UnionFind()
+    holder_set = set(holder_addrs)
+    for e in (edges or []):
+        from_addr = e["from_address"]
+        to_addr = e["to_address"]
+        # Only merge if BOTH endpoints are in the holder set
+        if from_addr in holder_set and to_addr in holder_set:
+            uf.union(from_addr, to_addr)
+
+    # Step 4: Build clusters
+    groups = uf.groups(holder_addrs)
+    total_supply = sum(balance_map.values())
+
+    raw_clusters = []
+    for root, members in groups.items():
+        cluster_balance = sum(balance_map.get(m, 0) for m in members)
+        seed_wallet = max(members, key=lambda m: balance_map.get(m, 0))
+
+        # Determine cluster type from actor classifications
+        actor_types = [actor_map.get(m, "unknown") for m in members]
+        actor_labels_set = list(set(actor_types))
+
+        if "exchange" in actor_types:
+            cluster_type = "exchange"
+        elif "contract_vault" in actor_types:
+            cluster_type = "contract"
+        elif all(a == "unknown" for a in actor_types):
+            cluster_type = "whale" if cluster_balance > 1_000_000 else "unknown"
+        else:
+            cluster_type = "mixed" if len(set(actor_types)) > 1 else actor_types[0]
+
+        raw_clusters.append({
+            "seed_wallet": seed_wallet,
+            "member_wallets": sorted(members),
+            "member_count": len(members),
+            "total_balance_usd": round(cluster_balance, 2),
+            "pct_of_supply": round(cluster_balance / total_supply * 100, 4) if total_supply > 0 else 0,
+            "cluster_type": cluster_type,
+            "actor_labels": actor_labels_set,
+        })
+
+    # Sort by balance descending and assign cluster_id
+    raw_clusters.sort(key=lambda c: c["total_balance_usd"], reverse=True)
+    for i, c in enumerate(raw_clusters):
+        c["cluster_id"] = i + 1
+
+    # Step 5: Compute concentration metrics
+    nominal_balances = sorted([balance_map[a] for a in holder_addrs if balance_map.get(a, 0) > 0])
+    clustered_balances = sorted([c["total_balance_usd"] for c in raw_clusters if c["total_balance_usd"] > 0])
+
+    nominal_gini = _compute_gini(nominal_balances)
+    clustered_gini = _compute_gini(clustered_balances)
+
+    singleton_count = sum(1 for c in raw_clusters if c["member_count"] == 1)
+
+    exchange_supply = sum(c["total_balance_usd"] for c in raw_clusters if c["cluster_type"] == "exchange")
+    whale_supply = sum(c["total_balance_usd"] for c in raw_clusters if c["cluster_type"] == "whale")
+
+    metrics = {
+        "nominal_gini": round(nominal_gini, 6),
+        "clustered_gini": round(clustered_gini, 6),
+        "nominal_top10_pct": _top_n_pct(nominal_balances, 10),
+        "clustered_top10_pct": _top_n_pct(clustered_balances, 10),
+        "nominal_top50_pct": _top_n_pct(nominal_balances, 50),
+        "clustered_top50_pct": _top_n_pct(clustered_balances, 50),
+        "cluster_count": len(raw_clusters),
+        "singleton_count": singleton_count,
+        "exchange_cluster_pct": round(exchange_supply / total_supply * 100, 4) if total_supply > 0 else 0,
+        "whale_cluster_pct": round(whale_supply / total_supply * 100, 4) if total_supply > 0 else 0,
+        "divergence_score": round(abs(clustered_gini - nominal_gini), 4),
+        "total_wallets_analyzed": len(holder_addrs),
+        "total_supply_tracked_usd": round(total_supply, 2),
+    }
+
+    return raw_clusters, metrics
+
+
+# ---------------------------------------------------------------------------
+# Main collector
+# ---------------------------------------------------------------------------
+
+async def collect_clustered_concentration() -> dict:
+    """
+    Compute graph-clustered holder concentration for all scored stablecoins.
+    Returns summary dict.
+    """
+    results = {
+        "stablecoins_analyzed": 0,
+        "clusters_computed": 0,
+        "snapshots_stored": 0,
+        "errors": [],
+    }
+
+    today = date.today()
+
+    # Load scored stablecoins
+    stablecoins = fetch_all(
+        "SELECT id, symbol FROM stablecoins WHERE scoring_enabled = TRUE"
+    )
+    if not stablecoins:
+        # Fallback: try without scoring_enabled filter
+        stablecoins = fetch_all("SELECT id, symbol FROM stablecoins")
+
+    if not stablecoins:
+        logger.info("Clustered concentration: no stablecoins found")
+        return results
+
+    for coin in stablecoins:
+        symbol = coin["symbol"]
+        coin_id = coin["id"]
+        t0 = time.time()
+
+        try:
+            # Check if today's snapshot already exists
+            existing = fetch_one(
+                """SELECT id FROM concentration_snapshots
+                   WHERE stablecoin_symbol = %s AND snapshot_date = %s""",
+                (symbol.upper(), today),
+            )
+            if existing:
+                continue
+
+            clusters, metrics = _compute_clusters(symbol, coin_id)
+            if not clusters or not metrics:
+                continue
+
+            # Store clusters
+            for cluster in clusters:
+                execute(
+                    """INSERT INTO holder_clusters
+                        (stablecoin_symbol, stablecoin_id, snapshot_date, cluster_id,
+                         seed_wallet, member_wallets, member_count,
+                         total_balance_usd, pct_of_supply, cluster_type, actor_labels)
+                       VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+                       ON CONFLICT (stablecoin_symbol, snapshot_date, cluster_id) DO NOTHING""",
+                    (
+                        symbol.upper(), coin_id, today, cluster["cluster_id"],
+                        cluster["seed_wallet"],
+                        json.dumps(cluster["member_wallets"]),
+                        cluster["member_count"],
+                        cluster["total_balance_usd"],
+                        cluster["pct_of_supply"],
+                        cluster["cluster_type"],
+                        json.dumps(cluster["actor_labels"]),
+                    ),
+                )
+            results["clusters_computed"] += len(clusters)
+
+            # Store concentration snapshot
+            content_data = (
+                f"{symbol.upper()}{today.isoformat()}"
+                f"{metrics['clustered_gini']}{metrics['cluster_count']}"
+            )
+            content_hash = "0x" + hashlib.sha256(content_data.encode()).hexdigest()
+
+            execute(
+                """INSERT INTO concentration_snapshots
+                    (stablecoin_symbol, stablecoin_id, snapshot_date,
+                     nominal_gini, clustered_gini,
+                     nominal_top10_pct, clustered_top10_pct,
+                     nominal_top50_pct, clustered_top50_pct,
+                     cluster_count, singleton_count,
+                     exchange_cluster_pct, whale_cluster_pct,
+                     divergence_score, total_wallets_analyzed,
+                     total_supply_tracked_usd, content_hash, attested_at)
+                   VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, NOW())
+                   ON CONFLICT (stablecoin_symbol, snapshot_date) DO NOTHING""",
+                (
+                    symbol.upper(), coin_id, today,
+                    metrics["nominal_gini"], metrics["clustered_gini"],
+                    metrics["nominal_top10_pct"], metrics["clustered_top10_pct"],
+                    metrics["nominal_top50_pct"], metrics["clustered_top50_pct"],
+                    metrics["cluster_count"], metrics["singleton_count"],
+                    metrics["exchange_cluster_pct"], metrics["whale_cluster_pct"],
+                    metrics["divergence_score"], metrics["total_wallets_analyzed"],
+                    metrics["total_supply_tracked_usd"], content_hash,
+                ),
+            )
+            results["snapshots_stored"] += 1
+
+            # Attest
+            try:
+                from app.state_attestation import attest_state
+                attest_state("clustered_concentration", [{
+                    "stablecoin": symbol.upper(),
+                    "snapshot_date": today.isoformat(),
+                    "clustered_gini": metrics["clustered_gini"],
+                    "divergence_score": metrics["divergence_score"],
+                }], str(coin_id))
+            except Exception:
+                pass
+
+            elapsed = time.time() - t0
+            logger.info(
+                f"Clustered concentration: {symbol.upper()} "
+                f"gini={metrics['clustered_gini']:.4f} "
+                f"divergence={metrics['divergence_score']:.4f} "
+                f"clusters={metrics['cluster_count']} "
+                f"({elapsed:.1f}s)"
+            )
+
+            if metrics["divergence_score"] > 0.1:
+                logger.warning(
+                    f"HIGH CONCENTRATION DIVERGENCE: {symbol.upper()} "
+                    f"divergence={metrics['divergence_score']:.4f} — "
+                    f"graph merging significantly changes concentration picture"
+                )
+
+            results["stablecoins_analyzed"] += 1
+
+        except Exception as e:
+            results["errors"].append(f"{symbol}: {e}")
+            logger.error(f"Clustered concentration failed for {symbol}: {e}")
+
+    logger.info(
+        f"Clustered concentration: analyzed={results['stablecoins_analyzed']} "
+        f"clusters={results['clusters_computed']} "
+        f"snapshots={results['snapshots_stored']} "
+        f"errors={len(results['errors'])}"
+    )
+    return results

--- a/app/collectors/parameter_history.py
+++ b/app/collectors/parameter_history.py
@@ -1,0 +1,576 @@
+"""
+Protocol Parameter Change History Collector (Pipeline 9)
+==========================================================
+Captures on-chain governance parameter changes across scored protocols
+with concurrent SII/PSI score state at time of each change.
+
+Uses Alchemy RPC (eth_call) or Etherscan eth_call fallback for contract reads.
+Runs in both fast cycle (change detection only) and slow cycle (full snapshots).
+Never raises — all errors logged and skipped.
+"""
+
+import hashlib
+import json
+import logging
+import os
+import time
+from datetime import date, datetime, timezone, timedelta
+
+import httpx
+
+from app.database import fetch_all, fetch_one, execute
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# RPC helpers
+# ---------------------------------------------------------------------------
+
+def _get_rpc_url(chain: str = "ethereum") -> str:
+    alchemy_key = os.environ.get("ALCHEMY_API_KEY", "")
+    if not alchemy_key:
+        return ""
+    chain_map = {
+        "ethereum": "eth-mainnet",
+        "arbitrum": "arb-mainnet",
+        "base": "base-mainnet",
+    }
+    network = chain_map.get(chain, "eth-mainnet")
+    return f"https://{network}.g.alchemy.com/v2/{alchemy_key}"
+
+
+def _eth_call_sync(contract: str, data: str, chain: str = "ethereum") -> str:
+    """Execute eth_call via Alchemy RPC (sync). Falls back to Etherscan."""
+    rpc_url = _get_rpc_url(chain)
+    if rpc_url:
+        try:
+            resp = httpx.post(
+                rpc_url,
+                json={
+                    "jsonrpc": "2.0",
+                    "id": 1,
+                    "method": "eth_call",
+                    "params": [{"to": contract, "data": data}, "latest"],
+                },
+                timeout=15,
+            )
+            result = resp.json().get("result", "0x")
+            if result and result != "0x":
+                return result
+        except Exception as e:
+            logger.debug(f"RPC eth_call failed for {contract}: {e}")
+
+    # Etherscan fallback (ethereum only)
+    if chain == "ethereum":
+        api_key = os.environ.get("ETHERSCAN_API_KEY", "")
+        if api_key:
+            try:
+                resp = httpx.get(
+                    "https://api.etherscan.io/api",
+                    params={
+                        "module": "proxy",
+                        "action": "eth_call",
+                        "to": contract,
+                        "data": data,
+                        "tag": "latest",
+                        "apikey": api_key,
+                    },
+                    timeout=15,
+                )
+                result = resp.json().get("result", "0x")
+                if result and result != "0x":
+                    return result
+            except Exception as e:
+                logger.debug(f"Etherscan eth_call fallback failed: {e}")
+
+    return "0x"
+
+
+def _encode_address_param(address: str) -> str:
+    """ABI-encode an address as a 32-byte padded hex param."""
+    return address.lower().replace("0x", "").zfill(64)
+
+
+def _decode_uint256(hex_str: str, offset: int = 0) -> int:
+    """Decode a uint256 from a hex response at a 32-byte word offset."""
+    start = 2 + (offset * 64)  # skip 0x prefix
+    end = start + 64
+    if len(hex_str) < end:
+        return 0
+    return int(hex_str[start:end], 16)
+
+
+# ---------------------------------------------------------------------------
+# Protocol Parameter Registry
+# ---------------------------------------------------------------------------
+
+# Function selectors (first 4 bytes of keccak256 of function signature)
+# getReserveData(address) = 0x35ea6a75
+# getAssetInfoByAddress(address) = 0xc2be3a6c
+# ilks(bytes32) = 0xd9638d36
+
+AAVE_GET_RESERVE_DATA = "0x35ea6a75"
+COMPOUND_GET_ASSET_INFO = "0xc2be3a6c"
+
+WATCHED_ASSETS = {
+    "usdc": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+    "usdt": "0xdAC17F958D2ee523a2206206994597C13D831ec7",
+    "dai": "0x6B175474E89094C44Da98b954EedeAC495271d0F",
+    "weth": "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
+    "wbtc": "0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599",
+}
+
+# Each param spec: (parameter_key, parameter_name, field_index_in_return, value_unit, normalization_factor)
+AAVE_PARAM_SPECS = [
+    ("ltv", "LTV", 1, "percent", 100),
+    ("liquidation_threshold", "Liquidation Threshold", 2, "percent", 100),
+    ("liquidation_bonus", "Liquidation Bonus", 3, "percent", 100),
+    ("supply_cap", "Supply Cap", 11, "token_units", 1),
+    ("borrow_cap", "Borrow Cap", 12, "token_units", 1),
+]
+
+COMPOUND_ASSETS = {
+    "weth": "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
+    "wbtc": "0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599",
+}
+
+COMPOUND_PARAM_SPECS = [
+    ("borrow_collateral_factor", "Borrow Collateral Factor", 1, "percent", 10**18),
+    ("liquidate_collateral_factor", "Liquidate Collateral Factor", 2, "percent", 10**18),
+]
+
+
+def _build_protocol_parameter_registry() -> dict:
+    """Build the full parameter registry. Returns dict of protocol_slug -> list of param dicts."""
+    registry = {}
+
+    # --- Aave V3 Pool ---
+    aave_pool = "0x87870Bca3F3fD6335C3F4ce8392D69350B4fA4E2"
+    aave_params = []
+    for asset_symbol, asset_addr in WATCHED_ASSETS.items():
+        for key, name, field_idx, unit, norm in AAVE_PARAM_SPECS:
+            aave_params.append({
+                "contract_address": aave_pool,
+                "chain": "ethereum",
+                "parameter_key": f"aave_{asset_symbol}_{key}",
+                "parameter_name": f"{asset_symbol.upper()} {name}",
+                "function_selector": AAVE_GET_RESERVE_DATA,
+                "asset_address": asset_addr,
+                "asset_symbol": asset_symbol.upper(),
+                "field_index": field_idx,
+                "value_unit": unit,
+                "normalization_factor": norm,
+            })
+    registry["aave"] = aave_params
+
+    # --- Compound V3 Comet USDC ---
+    compound_comet = "0xc3d688B66703497DAA19211EEdff47f25384cdc3"
+    compound_params = []
+    for asset_symbol, asset_addr in COMPOUND_ASSETS.items():
+        for key, name, field_idx, unit, norm in COMPOUND_PARAM_SPECS:
+            compound_params.append({
+                "contract_address": compound_comet,
+                "chain": "ethereum",
+                "parameter_key": f"compound_{asset_symbol}_{key}",
+                "parameter_name": f"{asset_symbol.upper()} {name}",
+                "function_selector": COMPOUND_GET_ASSET_INFO,
+                "asset_address": asset_addr,
+                "asset_symbol": asset_symbol.upper(),
+                "field_index": field_idx,
+                "value_unit": unit,
+                "normalization_factor": norm,
+            })
+    registry["compound-finance"] = compound_params
+
+    # --- Morpho Blue ---
+    # Morpho uses market(bytes32) which requires market IDs. Placeholder for
+    # known markets — will need market ID discovery for full coverage.
+    # Skipping for initial launch; add when market IDs are catalogued.
+
+    return registry
+
+
+PROTOCOL_PARAMETER_REGISTRY = _build_protocol_parameter_registry()
+
+
+# ---------------------------------------------------------------------------
+# On-chain parameter reading
+# ---------------------------------------------------------------------------
+
+def _read_parameter_value(param_spec: dict) -> tuple[str | None, int | None]:
+    """
+    Read a single parameter value from on-chain.
+    Returns (raw_hex_value, decoded_int) or (None, None) on failure.
+    """
+    contract = param_spec["contract_address"]
+    chain = param_spec["chain"]
+    selector = param_spec["function_selector"]
+    asset_addr = param_spec.get("asset_address")
+
+    # Build calldata
+    if asset_addr:
+        calldata = selector + _encode_address_param(asset_addr)
+    else:
+        calldata = selector
+
+    result = _eth_call_sync(contract, calldata, chain)
+    if not result or result == "0x":
+        return None, None
+
+    field_idx = param_spec["field_index"]
+    raw_value = _decode_uint256(result, field_idx)
+    return str(raw_value), raw_value
+
+
+# ---------------------------------------------------------------------------
+# Score context
+# ---------------------------------------------------------------------------
+
+def _get_concurrent_scores(protocol_slug: str, asset_symbol: str | None) -> dict:
+    """Fetch concurrent SII/PSI scores and compute change context."""
+    context = {
+        "concurrent_sii_score": None,
+        "concurrent_psi_score": None,
+        "hours_since_last_sii_change": None,
+        "sii_trend_7d": None,
+        "change_context": "unknown",
+    }
+
+    # PSI score
+    try:
+        psi_row = fetch_one(
+            """SELECT overall_score FROM psi_scores
+               WHERE protocol_slug = %s
+               ORDER BY computed_at DESC LIMIT 1""",
+            (protocol_slug,),
+        )
+        if psi_row:
+            context["concurrent_psi_score"] = float(psi_row["overall_score"])
+    except Exception:
+        pass
+
+    if not asset_symbol:
+        return context
+
+    # SII score
+    try:
+        sii_row = fetch_one(
+            """SELECT overall_score FROM scores
+               WHERE stablecoin_id = LOWER(%s)
+               ORDER BY scored_at DESC LIMIT 1""",
+            (asset_symbol,),
+        )
+        if sii_row:
+            context["concurrent_sii_score"] = float(sii_row["overall_score"])
+    except Exception:
+        pass
+
+    # 7-day SII trend
+    try:
+        trend_rows = fetch_all(
+            """SELECT overall_score, score_date FROM score_history
+               WHERE stablecoin = LOWER(%s)
+                 AND score_date > CURRENT_DATE - INTERVAL '7 days'
+               ORDER BY score_date ASC""",
+            (asset_symbol,),
+        )
+        if trend_rows and len(trend_rows) >= 2:
+            first = float(trend_rows[0]["overall_score"])
+            last = float(trend_rows[-1]["overall_score"])
+            context["sii_trend_7d"] = round(last - first, 2)
+    except Exception:
+        pass
+
+    # Hours since last SII change (>1 point move)
+    try:
+        last_move = fetch_one(
+            """SELECT score_date FROM score_history
+               WHERE stablecoin = LOWER(%s)
+                 AND ABS(daily_change) > 1
+               ORDER BY score_date DESC LIMIT 1""",
+            (asset_symbol,),
+        )
+        if last_move and last_move.get("score_date"):
+            move_date = last_move["score_date"]
+            if hasattr(move_date, "isoformat"):
+                delta = datetime.now(timezone.utc) - datetime.combine(
+                    move_date, datetime.min.time(), tzinfo=timezone.utc
+                )
+                context["hours_since_last_sii_change"] = round(delta.total_seconds() / 3600, 2)
+    except Exception:
+        pass
+
+    # Determine change context
+    trend = context.get("sii_trend_7d")
+    if trend is not None:
+        if trend < -1:
+            context["change_context"] = "reactive"
+        elif trend >= 0:
+            context["change_context"] = "proactive"
+
+    return context
+
+
+# ---------------------------------------------------------------------------
+# Change handling
+# ---------------------------------------------------------------------------
+
+def _handle_parameter_change(
+    protocol_slug: str,
+    protocol_id: int,
+    param_spec: dict,
+    old_value: float,
+    old_raw: str,
+    new_value: float,
+    new_raw: str,
+    results: dict,
+):
+    """Record a parameter change with concurrent score context."""
+    now = datetime.now(timezone.utc)
+    change_magnitude = round(abs(new_value - old_value), 4)
+    change_direction = "increase" if new_value > old_value else "decrease" if new_value < old_value else "unchanged"
+
+    # Get concurrent score state
+    asset_symbol = param_spec.get("asset_symbol")
+    score_ctx = _get_concurrent_scores(protocol_slug, asset_symbol)
+
+    content_data = (
+        f"{protocol_slug}{param_spec['parameter_key']}"
+        f"{param_spec.get('asset_address', '')}{new_raw}{now.isoformat()}"
+    )
+    content_hash = "0x" + hashlib.sha256(content_data.encode()).hexdigest()
+
+    execute(
+        """INSERT INTO protocol_parameter_changes
+            (protocol_slug, protocol_id, parameter_name, parameter_key,
+             asset_address, asset_symbol, contract_address, chain,
+             previous_value, previous_value_raw, new_value, new_value_raw,
+             value_unit, change_magnitude, change_direction,
+             changed_at, concurrent_sii_score, concurrent_psi_score,
+             hours_since_last_sii_change, sii_trend_7d, change_context,
+             content_hash, attested_at)
+           VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s,
+                   %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, NOW())""",
+        (
+            protocol_slug, protocol_id,
+            param_spec["parameter_name"], param_spec["parameter_key"],
+            param_spec.get("asset_address"), asset_symbol,
+            param_spec["contract_address"], param_spec["chain"],
+            old_value, old_raw, new_value, new_raw,
+            param_spec["value_unit"], change_magnitude, change_direction,
+            now,
+            score_ctx["concurrent_sii_score"], score_ctx["concurrent_psi_score"],
+            score_ctx["hours_since_last_sii_change"], score_ctx["sii_trend_7d"],
+            score_ctx["change_context"],
+            content_hash,
+        ),
+    )
+
+    try:
+        from app.state_attestation import attest_state
+        attest_state("protocol_parameter_changes", [{
+            "protocol_slug": protocol_slug,
+            "parameter_key": param_spec["parameter_key"],
+            "new_value": new_value,
+            "change_context": score_ctx["change_context"],
+            "changed_at": now.isoformat(),
+        }], str(protocol_id))
+    except Exception:
+        pass
+
+    logger.info(
+        f"PARAMETER CHANGE: {protocol_slug} {param_spec['parameter_name']} "
+        f"{old_value} -> {new_value} ({change_direction}, "
+        f"context={score_ctx['change_context']})"
+    )
+    results["changes_detected"] += 1
+
+
+# ---------------------------------------------------------------------------
+# Snapshot storage
+# ---------------------------------------------------------------------------
+
+def _store_daily_snapshot(protocol_slug: str, protocol_id: int, results: dict):
+    """Store a daily point-in-time snapshot of all parameter values."""
+    today = date.today()
+
+    existing = fetch_one(
+        """SELECT id FROM protocol_parameter_snapshots
+           WHERE protocol_slug = %s AND snapshot_date = %s""",
+        (protocol_slug, today),
+    )
+    if existing:
+        return
+
+    params = fetch_all(
+        """SELECT parameter_key, current_value, value_unit, asset_symbol
+           FROM protocol_parameters WHERE protocol_slug = %s""",
+        (protocol_slug,),
+    )
+    if not params:
+        return
+
+    param_dict = {}
+    for p in params:
+        param_dict[p["parameter_key"]] = {
+            "value": float(p["current_value"]) if p.get("current_value") is not None else None,
+            "unit": p.get("value_unit"),
+            "asset_symbol": p.get("asset_symbol"),
+        }
+
+    content_data = f"{protocol_slug}{today.isoformat()}{json.dumps(param_dict, sort_keys=True)}"
+    content_hash = "0x" + hashlib.sha256(content_data.encode()).hexdigest()
+
+    execute(
+        """INSERT INTO protocol_parameter_snapshots
+            (protocol_slug, protocol_id, snapshot_date, parameters,
+             parameter_count, content_hash, attested_at)
+           VALUES (%s, %s, %s, %s, %s, %s, NOW())
+           ON CONFLICT (protocol_slug, snapshot_date) DO NOTHING""",
+        (
+            protocol_slug, protocol_id, today,
+            json.dumps(param_dict), len(param_dict), content_hash,
+        ),
+    )
+
+    try:
+        from app.state_attestation import attest_state
+        attest_state("protocol_parameter_snapshots", [{
+            "protocol_slug": protocol_slug,
+            "snapshot_date": today.isoformat(),
+            "parameter_count": len(param_dict),
+        }], str(protocol_id))
+    except Exception:
+        pass
+
+    results["snapshots_stored"] += 1
+
+
+# ---------------------------------------------------------------------------
+# Core check (used by both fast and slow cycle)
+# ---------------------------------------------------------------------------
+
+def check_parameter_changes() -> dict:
+    """
+    Check all watched parameters for changes. Used in fast cycle.
+    Does NOT store daily snapshots — that's done in the slow cycle.
+    Returns summary dict.
+    """
+    results = {
+        "protocols_checked": 0,
+        "parameters_checked": 0,
+        "changes_detected": 0,
+        "errors": [],
+    }
+
+    for protocol_slug, param_specs in PROTOCOL_PARAMETER_REGISTRY.items():
+        try:
+            protocol_id = 0
+
+            for spec in param_specs:
+                try:
+                    raw_str, raw_int = _read_parameter_value(spec)
+                    if raw_int is None:
+                        continue
+
+                    norm = spec["normalization_factor"]
+                    normalized = raw_int / norm if norm else raw_int
+                    results["parameters_checked"] += 1
+
+                    # Look up stored value
+                    stored = fetch_one(
+                        """SELECT current_value, current_value_raw
+                           FROM protocol_parameters
+                           WHERE protocol_slug = %s AND parameter_key = %s
+                             AND COALESCE(asset_address, '') = COALESCE(%s, '')
+                             AND chain = %s""",
+                        (protocol_slug, spec["parameter_key"],
+                         spec.get("asset_address"), spec["chain"]),
+                    )
+
+                    if not stored:
+                        # First capture
+                        execute(
+                            """INSERT INTO protocol_parameters
+                                (protocol_slug, protocol_id, parameter_name, parameter_key,
+                                 asset_address, asset_symbol, contract_address, chain,
+                                 current_value, current_value_raw, value_unit)
+                               VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+                               ON CONFLICT (protocol_slug, parameter_key, asset_address, chain)
+                               DO NOTHING""",
+                            (
+                                protocol_slug, protocol_id,
+                                spec["parameter_name"], spec["parameter_key"],
+                                spec.get("asset_address"), spec.get("asset_symbol"),
+                                spec["contract_address"], spec["chain"],
+                                normalized, raw_str, spec["value_unit"],
+                            ),
+                        )
+                        continue
+
+                    stored_value = float(stored["current_value"]) if stored.get("current_value") is not None else None
+                    if stored_value is not None and abs(normalized - stored_value) > 1e-8:
+                        # Change detected
+                        _handle_parameter_change(
+                            protocol_slug, protocol_id, spec,
+                            stored_value, stored.get("current_value_raw", ""),
+                            normalized, raw_str,
+                            results,
+                        )
+                        # Update current value
+                        execute(
+                            """UPDATE protocol_parameters
+                               SET current_value = %s, current_value_raw = %s,
+                                   last_updated_at = NOW()
+                               WHERE protocol_slug = %s AND parameter_key = %s
+                                 AND COALESCE(asset_address, '') = COALESCE(%s, '')
+                                 AND chain = %s""",
+                            (
+                                normalized, raw_str,
+                                protocol_slug, spec["parameter_key"],
+                                spec.get("asset_address"), spec["chain"],
+                            ),
+                        )
+
+                    time.sleep(0.3)  # Rate limit RPC calls
+
+                except Exception as e:
+                    logger.debug(f"Parameter read failed: {protocol_slug}/{spec['parameter_key']}: {e}")
+
+            results["protocols_checked"] += 1
+
+        except Exception as e:
+            results["errors"].append(f"{protocol_slug}: {e}")
+            logger.error(f"Parameter history failed for {protocol_slug}: {e}")
+
+    return results
+
+
+# ---------------------------------------------------------------------------
+# Main collector (slow cycle — full run with snapshots)
+# ---------------------------------------------------------------------------
+
+async def collect_parameter_history() -> dict:
+    """
+    Full parameter history collection: check for changes + store daily snapshots.
+    Returns summary dict.
+    """
+    results = check_parameter_changes()
+    results["snapshots_stored"] = 0
+
+    # Store daily snapshots for each protocol
+    for protocol_slug in PROTOCOL_PARAMETER_REGISTRY:
+        try:
+            _store_daily_snapshot(protocol_slug, 0, results)
+        except Exception as e:
+            logger.debug(f"Parameter snapshot failed for {protocol_slug}: {e}")
+
+    logger.info(
+        f"Parameter history: protocols={results['protocols_checked']} "
+        f"params={results['parameters_checked']} "
+        f"changes={results['changes_detected']} "
+        f"snapshots={results['snapshots_stored']} "
+        f"errors={len(results['errors'])}"
+    )
+    return results

--- a/app/server.py
+++ b/app/server.py
@@ -7883,6 +7883,244 @@ async def contract_dependencies_changes():
     }
 
 
+# --- Pipeline 9: Protocol Parameter History ---
+
+@app.get("/api/parameters/{slug}/history")
+async def parameter_change_history(
+    slug: str,
+    asset_symbol: Optional[str] = None,
+    parameter_name: Optional[str] = None,
+    days: int = Query(default=90, ge=1, le=3650),
+    limit: int = Query(default=200, ge=1, le=1000),
+):
+    """Parameter changes for a protocol with concurrent score context."""
+    conditions = ["protocol_slug = %s", "changed_at > NOW() - INTERVAL '%s days'"]
+    params = [slug, days]
+
+    if asset_symbol:
+        conditions.append("UPPER(asset_symbol) = UPPER(%s)")
+        params.append(asset_symbol)
+    if parameter_name:
+        conditions.append("parameter_name ILIKE %s")
+        params.append(f"%{parameter_name}%")
+
+    where = " AND ".join(conditions)
+    params.append(limit)
+
+    rows = fetch_all(
+        f"""SELECT id, parameter_name, parameter_key, asset_symbol,
+                   previous_value, new_value, value_unit,
+                   change_magnitude, change_direction, changed_at,
+                   concurrent_sii_score, concurrent_psi_score,
+                   hours_since_last_sii_change, sii_trend_7d, change_context
+            FROM protocol_parameter_changes
+            WHERE {where}
+            ORDER BY changed_at DESC LIMIT %s""",
+        tuple(params),
+    )
+    return {"changes": [dict(r) for r in (rows or [])], "count": len(rows or [])}
+
+
+@app.get("/api/parameters/{slug}/current")
+async def parameter_current_values(slug: str):
+    """Current parameter values for all watched parameters."""
+    rows = fetch_all(
+        """SELECT parameter_name, parameter_key, asset_symbol,
+                  current_value, current_value_raw, value_unit,
+                  last_updated_at, first_seen_at
+           FROM protocol_parameters
+           WHERE protocol_slug = %s
+           ORDER BY parameter_key""",
+        (slug,),
+    )
+    return {"parameters": [dict(r) for r in (rows or [])], "count": len(rows or [])}
+
+
+@app.get("/api/parameters/{slug}/snapshots")
+async def parameter_snapshots(
+    slug: str,
+    days: int = Query(default=90, ge=1, le=3650),
+):
+    """Daily parameter snapshots over time."""
+    rows = fetch_all(
+        """SELECT snapshot_date, parameters, parameter_count, content_hash
+           FROM protocol_parameter_snapshots
+           WHERE protocol_slug = %s
+             AND snapshot_date > CURRENT_DATE - INTERVAL '%s days'
+           ORDER BY snapshot_date DESC""",
+        (slug, days),
+    )
+    return {"snapshots": [dict(r) for r in (rows or [])], "count": len(rows or [])}
+
+
+@app.get("/api/parameters/changes")
+async def parameter_changes_all(
+    change_context: Optional[str] = None,
+    days: int = Query(default=30, ge=1, le=365),
+    limit: int = Query(default=100, ge=1, le=500),
+):
+    """Recent parameter changes across all protocols."""
+    conditions = ["changed_at > NOW() - INTERVAL '%s days'"]
+    params = [days]
+
+    if change_context:
+        conditions.append("change_context = %s")
+        params.append(change_context)
+
+    where = " AND ".join(conditions)
+    params.append(limit)
+
+    rows = fetch_all(
+        f"""SELECT protocol_slug, parameter_name, asset_symbol,
+                   previous_value, new_value, value_unit,
+                   change_magnitude, change_direction, changed_at,
+                   concurrent_sii_score, concurrent_psi_score,
+                   change_context
+            FROM protocol_parameter_changes
+            WHERE {where}
+            ORDER BY changed_at DESC LIMIT %s""",
+        tuple(params),
+    )
+    return {"changes": [dict(r) for r in (rows or [])], "count": len(rows or [])}
+
+
+@app.get("/api/parameters/{slug}/context")
+async def parameter_context_analysis(slug: str):
+    """Change context analysis: reactive vs proactive ratio over time."""
+    rows = fetch_all(
+        """SELECT change_context, COUNT(*) AS cnt
+           FROM protocol_parameter_changes
+           WHERE protocol_slug = %s AND change_context IS NOT NULL
+           GROUP BY change_context""",
+        (slug,),
+    )
+    context_counts = {r["change_context"]: r["cnt"] for r in (rows or [])}
+
+    reactive = context_counts.get("reactive", 0)
+    proactive = context_counts.get("proactive", 0)
+    total = reactive + proactive + context_counts.get("unknown", 0)
+
+    avg_lag = fetch_one(
+        """SELECT AVG(hours_since_last_sii_change) AS avg_lag
+           FROM protocol_parameter_changes
+           WHERE protocol_slug = %s AND change_context = 'reactive'
+             AND hours_since_last_sii_change IS NOT NULL""",
+        (slug,),
+    )
+
+    return {
+        "protocol_slug": slug,
+        "total_changes": total,
+        "reactive_count": reactive,
+        "proactive_count": proactive,
+        "reactive_pct": round(reactive / total * 100, 1) if total > 0 else 0,
+        "proactive_pct": round(proactive / total * 100, 1) if total > 0 else 0,
+        "avg_reactive_lag_hours": float(avg_lag["avg_lag"]) if avg_lag and avg_lag.get("avg_lag") else None,
+    }
+
+
+# --- Pipeline 14: Graph-Clustered Holder Concentration ---
+
+@app.get("/api/concentration/{symbol}/latest")
+async def concentration_latest(symbol: str):
+    """Most recent concentration snapshot with top clusters."""
+    snapshot = fetch_one(
+        """SELECT * FROM concentration_snapshots
+           WHERE UPPER(stablecoin_symbol) = UPPER(%s)
+           ORDER BY snapshot_date DESC LIMIT 1""",
+        (symbol,),
+    )
+    if not snapshot:
+        raise HTTPException(status_code=404, detail="No concentration data for this stablecoin")
+
+    clusters = fetch_all(
+        """SELECT cluster_id, seed_wallet, member_count,
+                  total_balance_usd, pct_of_supply, cluster_type, actor_labels
+           FROM holder_clusters
+           WHERE UPPER(stablecoin_symbol) = UPPER(%s) AND snapshot_date = %s
+           ORDER BY total_balance_usd DESC LIMIT 20""",
+        (symbol, snapshot["snapshot_date"]),
+    )
+    result = dict(snapshot)
+    result["top_clusters"] = [dict(c) for c in (clusters or [])]
+    return result
+
+
+@app.get("/api/concentration/{symbol}/history")
+async def concentration_history(
+    symbol: str,
+    days: int = Query(default=90, ge=1, le=3650),
+):
+    """Concentration snapshots over time with nominal and clustered metrics."""
+    rows = fetch_all(
+        """SELECT snapshot_date, nominal_gini, clustered_gini,
+                  nominal_top10_pct, clustered_top10_pct,
+                  nominal_top50_pct, clustered_top50_pct,
+                  cluster_count, singleton_count,
+                  exchange_cluster_pct, whale_cluster_pct,
+                  divergence_score, total_wallets_analyzed
+           FROM concentration_snapshots
+           WHERE UPPER(stablecoin_symbol) = UPPER(%s)
+             AND snapshot_date > CURRENT_DATE - INTERVAL '%s days'
+           ORDER BY snapshot_date DESC""",
+        (symbol, days),
+    )
+    return {"snapshots": [dict(r) for r in (rows or [])], "count": len(rows or [])}
+
+
+@app.get("/api/concentration/{symbol}/clusters/{snapshot_date}")
+async def concentration_clusters(symbol: str, snapshot_date: str):
+    """All clusters for a stablecoin on a specific date."""
+    rows = fetch_all(
+        """SELECT cluster_id, seed_wallet, member_wallets, member_count,
+                  total_balance_usd, pct_of_supply, cluster_type, actor_labels
+           FROM holder_clusters
+           WHERE UPPER(stablecoin_symbol) = UPPER(%s) AND snapshot_date = %s
+           ORDER BY total_balance_usd DESC""",
+        (symbol, snapshot_date),
+    )
+    return {"clusters": [dict(r) for r in (rows or [])], "count": len(rows or [])}
+
+
+@app.get("/api/concentration/divergence")
+async def concentration_divergence():
+    """All stablecoins sorted by divergence_score for most recent snapshot."""
+    rows = fetch_all(
+        """SELECT DISTINCT ON (stablecoin_symbol)
+                  stablecoin_symbol, snapshot_date,
+                  nominal_gini, clustered_gini, divergence_score,
+                  nominal_top10_pct, clustered_top10_pct,
+                  cluster_count, total_wallets_analyzed
+           FROM concentration_snapshots
+           ORDER BY stablecoin_symbol, snapshot_date DESC"""
+    )
+    sorted_rows = sorted((rows or []), key=lambda r: float(r.get("divergence_score") or 0), reverse=True)
+    return {"stablecoins": [dict(r) for r in sorted_rows], "count": len(sorted_rows)}
+
+
+@app.get("/api/concentration/changes")
+async def concentration_changes():
+    """Stablecoins where clustered_gini changed >0.02 in the last 7 days."""
+    rows = fetch_all(
+        """WITH recent AS (
+               SELECT stablecoin_symbol, snapshot_date, clustered_gini,
+                      LAG(clustered_gini) OVER (
+                          PARTITION BY stablecoin_symbol ORDER BY snapshot_date
+                      ) AS prev_gini
+               FROM concentration_snapshots
+               WHERE snapshot_date > CURRENT_DATE - INTERVAL '7 days'
+           )
+           SELECT stablecoin_symbol, snapshot_date,
+                  clustered_gini, prev_gini,
+                  ABS(clustered_gini - prev_gini) AS gini_change
+           FROM recent
+           WHERE prev_gini IS NOT NULL
+             AND ABS(clustered_gini - prev_gini) > 0.02
+           ORDER BY ABS(clustered_gini - prev_gini) DESC"""
+    )
+    return {"changes": [dict(r) for r in (rows or [])], "count": len(rows or [])}
+
+
 # =============================================================================
 
 def _register_spa_catch_all(app_instance):

--- a/app/worker.py
+++ b/app/worker.py
@@ -1100,6 +1100,17 @@ async def run_fast_cycle():
     except Exception as e:
         logger.warning(f"Daily digest failed: {e}")
 
+    # Pipeline 9: Parameter change check (lightweight — every cycle)
+    try:
+        from app.collectors.parameter_history import check_parameter_changes
+        param_result = check_parameter_changes()
+        if param_result.get("changes_detected", 0) > 0:
+            logger.warning(f"Parameter changes detected: {param_result['changes_detected']}")
+        elif param_result.get("parameters_checked", 0) > 0:
+            logger.info(f"Parameter check: {param_result['parameters_checked']} params, no changes")
+    except Exception as e:
+        logger.error(f"Parameter change check failed: {e}")
+
     # Log and persist collector performance stats
     if _current_cycle_stats:
         _current_cycle_stats.log_summary()
@@ -1565,6 +1576,26 @@ async def run_slow_cycle():
             logger.warning(f"Contract dependencies removed: {dep_result['removed_dependencies']}")
     except Exception as e:
         logger.error(f"Contract dependency collector failed: {e}")
+
+    # Pipeline 9: Parameter history (full run with daily snapshots)
+    try:
+        from app.collectors.parameter_history import collect_parameter_history
+        logger.info("Running parameter history collector...")
+        param_full_result = await collect_parameter_history()
+        logger.info(f"Parameter history: {param_full_result}")
+    except Exception as e:
+        logger.error(f"Parameter history collector failed: {e}")
+
+    # Pipeline 14: Graph-clustered holder concentration (daily, computationally heavy)
+    try:
+        from app.collectors.clustered_concentration import collect_clustered_concentration
+        logger.info("Running clustered concentration analysis...")
+        _conc_t0 = time.time()
+        conc_result = await collect_clustered_concentration()
+        _conc_elapsed = time.time() - _conc_t0
+        logger.info(f"Clustered concentration: {conc_result} ({_conc_elapsed:.0f}s)")
+    except Exception as e:
+        logger.error(f"Clustered concentration failed: {e}")
 
     # -------------------------------------------------------------------------
     # Divergence detection — every cycle, store all signals

--- a/migrations/071_protocol_parameter_history.sql
+++ b/migrations/071_protocol_parameter_history.sql
@@ -1,0 +1,79 @@
+-- Migration 071: Protocol Parameter History (Pipeline 9)
+-- Captures on-chain governance parameter changes with concurrent score state.
+
+CREATE TABLE IF NOT EXISTS protocol_parameters (
+    id SERIAL PRIMARY KEY,
+    protocol_slug VARCHAR(100) NOT NULL,
+    protocol_id INTEGER,
+    parameter_name VARCHAR(200) NOT NULL,
+    parameter_key VARCHAR(200) NOT NULL,
+    asset_address VARCHAR(42),
+    asset_symbol VARCHAR(20),
+    contract_address VARCHAR(42) NOT NULL,
+    chain VARCHAR(20) NOT NULL,
+    current_value DECIMAL(30,8),
+    current_value_raw VARCHAR(200),
+    value_unit VARCHAR(50),
+    last_updated_at TIMESTAMPTZ DEFAULT NOW(),
+    first_seen_at TIMESTAMPTZ DEFAULT NOW(),
+    UNIQUE (protocol_slug, parameter_key, asset_address, chain)
+);
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_protocol_params_slug
+    ON protocol_parameters (protocol_slug);
+
+
+CREATE TABLE IF NOT EXISTS protocol_parameter_changes (
+    id SERIAL PRIMARY KEY,
+    protocol_slug VARCHAR(100) NOT NULL,
+    protocol_id INTEGER,
+    parameter_name VARCHAR(200) NOT NULL,
+    parameter_key VARCHAR(200) NOT NULL,
+    asset_address VARCHAR(42),
+    asset_symbol VARCHAR(20),
+    contract_address VARCHAR(42) NOT NULL,
+    chain VARCHAR(20) NOT NULL,
+    previous_value DECIMAL(30,8),
+    previous_value_raw VARCHAR(200),
+    new_value DECIMAL(30,8),
+    new_value_raw VARCHAR(200),
+    value_unit VARCHAR(50),
+    change_magnitude DECIMAL(10,4),
+    change_direction VARCHAR(10),
+    block_number BIGINT,
+    transaction_hash VARCHAR(66),
+    changed_at TIMESTAMPTZ NOT NULL,
+    detected_at TIMESTAMPTZ DEFAULT NOW(),
+    concurrent_sii_score DECIMAL(6,2),
+    concurrent_psi_score DECIMAL(6,2),
+    hours_since_last_sii_change DECIMAL(8,2),
+    sii_trend_7d DECIMAL(6,2),
+    change_context VARCHAR(100),
+    content_hash VARCHAR(66),
+    attested_at TIMESTAMPTZ
+);
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_param_changes_slug_time
+    ON protocol_parameter_changes (protocol_slug, changed_at DESC);
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_param_changes_asset
+    ON protocol_parameter_changes (asset_address);
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_param_changes_time
+    ON protocol_parameter_changes (changed_at DESC);
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_param_changes_context
+    ON protocol_parameter_changes (change_context);
+
+
+CREATE TABLE IF NOT EXISTS protocol_parameter_snapshots (
+    id SERIAL PRIMARY KEY,
+    protocol_slug VARCHAR(100) NOT NULL,
+    protocol_id INTEGER,
+    snapshot_date DATE NOT NULL,
+    parameters JSONB,
+    parameter_count INTEGER,
+    content_hash VARCHAR(66),
+    attested_at TIMESTAMPTZ,
+    UNIQUE (protocol_slug, snapshot_date)
+);
+
+
+INSERT INTO migrations (name) VALUES ('071_protocol_parameter_history') ON CONFLICT DO NOTHING;

--- a/migrations/072_clustered_concentration.sql
+++ b/migrations/072_clustered_concentration.sql
@@ -1,0 +1,54 @@
+-- Migration 072: Graph-Clustered Holder Concentration (Pipeline 14)
+-- Computes true holder concentration by merging wallets that share graph
+-- counterparties into single economic entities.
+
+CREATE TABLE IF NOT EXISTS holder_clusters (
+    id SERIAL PRIMARY KEY,
+    stablecoin_symbol VARCHAR(20) NOT NULL,
+    stablecoin_id INTEGER,
+    snapshot_date DATE NOT NULL,
+    cluster_id INTEGER NOT NULL,
+    seed_wallet VARCHAR(42),
+    member_wallets JSONB,
+    member_count INTEGER,
+    total_balance_usd DECIMAL(20,2),
+    pct_of_supply DECIMAL(8,4),
+    cluster_type VARCHAR(50),
+    actor_labels JSONB,
+    UNIQUE (stablecoin_symbol, snapshot_date, cluster_id)
+);
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_clusters_symbol_date
+    ON holder_clusters (stablecoin_symbol, snapshot_date DESC);
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_clusters_date
+    ON holder_clusters (snapshot_date DESC);
+
+
+CREATE TABLE IF NOT EXISTS concentration_snapshots (
+    id SERIAL PRIMARY KEY,
+    stablecoin_symbol VARCHAR(20) NOT NULL,
+    stablecoin_id INTEGER,
+    snapshot_date DATE NOT NULL,
+    nominal_gini DECIMAL(8,6),
+    clustered_gini DECIMAL(8,6),
+    nominal_top10_pct DECIMAL(8,4),
+    clustered_top10_pct DECIMAL(8,4),
+    nominal_top50_pct DECIMAL(8,4),
+    clustered_top50_pct DECIMAL(8,4),
+    cluster_count INTEGER,
+    singleton_count INTEGER,
+    exchange_cluster_pct DECIMAL(8,4),
+    whale_cluster_pct DECIMAL(8,4),
+    divergence_score DECIMAL(8,4),
+    total_wallets_analyzed INTEGER,
+    total_supply_tracked_usd DECIMAL(20,2),
+    content_hash VARCHAR(66),
+    attested_at TIMESTAMPTZ,
+    UNIQUE (stablecoin_symbol, snapshot_date)
+);
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_concentration_date
+    ON concentration_snapshots (snapshot_date DESC);
+
+
+INSERT INTO migrations (name) VALUES ('072_clustered_concentration') ON CONFLICT DO NOTHING;


### PR DESCRIPTION
## Summary

**Pipeline 9 — Protocol Parameter Change History**
- Migration 071: `protocol_parameters` + `protocol_parameter_changes` + `protocol_parameter_snapshots`
- Reads Aave V3 (LTV, liquidation threshold/bonus, supply/borrow caps for USDC/USDT/DAI/WETH) and Compound V3 (collateral factors for WETH/WBTC) via eth_call
- Records concurrent SII/PSI scores at time of each parameter change
- Classifies changes as `reactive` (SII deterioration preceded change) vs `proactive` (score stable/improving) — this is the novel surface
- Dual worker integration: lightweight check every fast cycle (~hourly), full snapshots in slow cycle (daily)
- 5 API endpoints: history, current, snapshots, cross-protocol changes, context analysis

**Pipeline 14 — Graph-Clustered Holder Concentration**
- Migration 072: `holder_clusters` + `concentration_snapshots`
- Union-find clustering on `wallet_graph.wallet_edges` with min weight 0.1 to prevent dust-transfer false merges
- Computes nominal + clustered Gini, top-10/50%, exchange/whale cluster percentages
- `divergence_score` = how much graph merging changes the concentration picture vs nominal addresses
- Daily snapshots, computationally heavier (logged with timing)
- 5 API endpoints: latest, history, clusters by date, divergence ranking, weekly changes

## Test plan

- [x] All files pass Python syntax check
- [x] Migration numbering verified (070 → 071 → 072)
- [x] Column names verified: `wallet_graph.wallet_edges.last_transfer_at`, `wallet_graph.wallet_holdings.symbol/value_usd`, `wallet_graph.actor_classifications.actor_type`
- [ ] First fast cycle seeds parameter baselines via eth_call
- [ ] First slow cycle stores concentration snapshots for all scored stablecoins
- [ ] All new API endpoints return 200

https://claude.ai/code/session_01NsCVuyEmN17fx1AnBxjDoV