### PR TITLE
Fix oracle stress detector: per-feed thresholds replace global 1-hour latency

### DIFF
--- a/app/collectors/oracle_behavior.py
+++ b/app/collectors/oracle_behavior.py
@@ -44,9 +44,10 @@ SYMBOL_TO_COINGECKO = {
     "stETH": "staked-ether",
 }
 
-# Stress thresholds
-DEVIATION_STRESS_THRESHOLD = 0.5   # percent
-LATENCY_STRESS_THRESHOLD = 3600    # seconds (1 hour)
+# Stress thresholds — FALLBACK defaults when per-feed config is missing
+DEVIATION_STRESS_THRESHOLD = 0.5   # percent (fallback)
+LATENCY_STRESS_THRESHOLD = 3600    # seconds (fallback — 1 hour)
+HEARTBEAT_BUFFER = 1.1             # 10% buffer past heartbeat before flagging
 
 # Fallback public RPCs
 FALLBACK_RPCS = {
@@ -283,13 +284,17 @@ def _handle_stress_event(oracle: dict, reading: dict, deviation_pct: float, late
     asset = oracle["asset_symbol"]
     chain = oracle["chain"]
 
-    # Classify event type
+    # Classify event type using per-feed thresholds
     abs_dev = abs(deviation_pct)
-    if latency > LATENCY_STRESS_THRESHOLD and abs_dev < DEVIATION_STRESS_THRESHOLD:
+    feed_dev = float(oracle.get("deviation_threshold_pct") or DEVIATION_STRESS_THRESHOLD)
+    feed_hb = oracle.get("heartbeat_seconds")
+    lat_thresh = int(float(feed_hb) * HEARTBEAT_BUFFER) if feed_hb else LATENCY_STRESS_THRESHOLD
+
+    if latency > lat_thresh and abs_dev < feed_dev:
         event_type = "stale_price"
     elif abs_dev > 5.0:
         event_type = "flash_deviation"
-    elif abs_dev > DEVIATION_STRESS_THRESHOLD:
+    elif abs_dev > feed_dev:
         event_type = "high_deviation"
     else:
         event_type = "stale_price"
@@ -482,9 +487,15 @@ async def collect_oracle_readings() -> dict:
                     deviation_pct = ((oracle_price - cex_price) / cex_price) * 100
                     deviation_abs = abs(oracle_price - cex_price)
 
+                # Per-feed stress thresholds from oracle_registry
+                feed_dev_threshold = oracle.get("deviation_threshold_pct")
+                feed_heartbeat = oracle.get("heartbeat_seconds")
+                dev_thresh = float(feed_dev_threshold) if feed_dev_threshold else DEVIATION_STRESS_THRESHOLD
+                lat_thresh = int(float(feed_heartbeat) * HEARTBEAT_BUFFER) if feed_heartbeat else LATENCY_STRESS_THRESHOLD
+
                 is_stress = (
-                    abs(deviation_pct) > DEVIATION_STRESS_THRESHOLD
-                    or latency > LATENCY_STRESS_THRESHOLD
+                    abs(deviation_pct) > dev_thresh
+                    or latency > lat_thresh
                 )
 
                 now = datetime.now(timezone.utc)

--- a/migrations/081_oracle_registry_feed_config.sql
+++ b/migrations/081_oracle_registry_feed_config.sql
@@ -1,0 +1,37 @@
+-- Migration 081: Per-feed oracle configuration
+-- Adds deviation_threshold_pct and heartbeat_seconds to oracle_registry
+-- so the stress detector uses feed-specific thresholds instead of global constants.
+
+ALTER TABLE oracle_registry ADD COLUMN IF NOT EXISTS deviation_threshold_pct DECIMAL(10,4);
+ALTER TABLE oracle_registry ADD COLUMN IF NOT EXISTS heartbeat_seconds INTEGER;
+
+-- Seed Chainlink feed configs (from Chainlink documentation)
+-- USDC/USD Ethereum: 0.25% deviation, 86400s (24h) heartbeat
+UPDATE oracle_registry SET deviation_threshold_pct = 0.25, heartbeat_seconds = 86400
+WHERE oracle_address = '0x8fFfFfd4AfB6115b954Bd326cbe7B4BA576818f6' AND chain = 'ethereum';
+
+-- USDT/USD Ethereum: 0.25% deviation, 86400s heartbeat
+UPDATE oracle_registry SET deviation_threshold_pct = 0.25, heartbeat_seconds = 86400
+WHERE oracle_address = '0x3E7d1eAB13ad0104d2750B8863b489D65364e32D' AND chain = 'ethereum';
+
+-- DAI/USD Ethereum: 0.25% deviation, 3600s heartbeat
+UPDATE oracle_registry SET deviation_threshold_pct = 0.25, heartbeat_seconds = 3600
+WHERE oracle_address = '0xAed0c38402a5d19df6E4c03F4E2DceD6e29c1ee9' AND chain = 'ethereum';
+
+-- ETH/USD Ethereum: 0.5% deviation, 3600s heartbeat
+UPDATE oracle_registry SET deviation_threshold_pct = 0.5, heartbeat_seconds = 3600
+WHERE oracle_address = '0x5f4eC3Df9cbd43714FE2740f5E3616155c5b8419' AND chain = 'ethereum';
+
+-- stETH/ETH Ethereum: 0.5% deviation, 86400s heartbeat
+UPDATE oracle_registry SET deviation_threshold_pct = 0.5, heartbeat_seconds = 86400
+WHERE oracle_address = '0x86392dC19c0b719886221c78AB11eb8Cf5c52812' AND chain = 'ethereum';
+
+-- ETH/USD Base: 0.15% deviation, 1200s heartbeat (L2 feeds update faster)
+UPDATE oracle_registry SET deviation_threshold_pct = 0.15, heartbeat_seconds = 1200
+WHERE oracle_address = '0x71041dddad3595F9CEd3DcCFBe3D1F4b0a16Bb70' AND chain = 'base';
+
+-- Pyth USDC/USD: 0.1% deviation, 60s heartbeat (Pyth updates much faster)
+UPDATE oracle_registry SET deviation_threshold_pct = 0.1, heartbeat_seconds = 60
+WHERE oracle_address = '0xff1a0f4744e8582DF1aE09D5611b887B6a12925C' AND chain = 'ethereum';
+
+INSERT INTO migrations (name) VALUES ('081_oracle_registry_feed_config') ON CONFLICT DO NOTHING;

--- a/reconnaissance.md
+++ b/reconnaissance.md
@@ -1,0 +1,68 @@
+# Reconnaissance: Oracle Stress Detector False Positives
+
+## Current Threshold Logic
+
+File: `app/collectors/oracle_behavior.py`, lines 48-49 and 485-488.
+
+```python
+DEVIATION_STRESS_THRESHOLD = 0.5   # percent
+LATENCY_STRESS_THRESHOLD = 3600    # seconds (1 hour)
+
+is_stress = (
+    abs(deviation_pct) > DEVIATION_STRESS_THRESHOLD    # 0.5%
+    or latency > LATENCY_STRESS_THRESHOLD              # 1 hour
+)
+```
+
+**The `or` is the bug.** Any feed with latency > 1 hour triggers stress, regardless of deviation. Chainlink stablecoin feeds have 24-hour heartbeats and only update on deviation > 0.25%. During calm markets, 10+ hours of latency with 0.01% deviation is healthy behavior.
+
+## Oracle Registry Schema
+
+Table: `oracle_registry` (migration 073)
+
+| Column | Type | Has per-feed config? |
+|--------|------|---------------------|
+| oracle_address | VARCHAR(42) | — |
+| oracle_name | VARCHAR(200) | — |
+| oracle_provider | VARCHAR(50) | — |
+| chain | VARCHAR(20) | — |
+| asset_symbol | VARCHAR(20) | — |
+| decimals | INTEGER | — |
+| read_function | VARCHAR(100) | — |
+| entity_slug | VARCHAR(100) | — |
+| **deviation_threshold_pct** | — | **MISSING** |
+| **heartbeat_seconds** | — | **MISSING** |
+
+The registry has no per-feed deviation threshold or heartbeat. The detector applies one global threshold to all feeds.
+
+## Seeded Oracles (7 feeds)
+
+1. Chainlink ETH/USD (0x5f4e...) — entity_slug: NULL
+2. Chainlink USDC/USD (0x8fFf...) — entity_slug: usdc
+3. Chainlink USDT/USD (0x3E7d...) — entity_slug: usdt
+4. Chainlink DAI/USD (0xAed0...) — entity_slug: dai
+5. Chainlink stETH/ETH (0x8639...) — entity_slug: steth
+6. Pyth USDC/USD (0xff1a...) — entity_slug: usdc
+7. Chainlink ETH/USD Base (0x7100...) — entity_slug: NULL
+
+## Why the Three Events False-Fired
+
+- USDC/USD: Chainlink heartbeat is 86400s (24h). Deviation threshold is 0.25%. During calm markets, the feed doesn't update for 10-20h. The detector sees latency > 3600s and flags it as stress, even though deviation is 0.01%.
+- USDT/USD: Same mechanism. 24h heartbeat, 0.25% deviation threshold.
+- stETH/ETH: 24h heartbeat, 0.5% deviation threshold.
+
+All three are working correctly. The detector's latency threshold is too aggressive for deviation-based feeds.
+
+## Chosen Fix: Path B
+
+Add `deviation_threshold_pct` and `heartbeat_seconds` columns to oracle_registry. Seed with real Chainlink values. Update detector to use per-feed config instead of global constants.
+
+New stress logic:
+```python
+is_stress = (
+    latency > (heartbeat_seconds * 1.1)      # past heartbeat + 10% buffer
+    or abs(deviation_pct) > deviation_threshold_pct  # past feed's deviation trigger
+)
+```
+
+This means: a feed is stressed if it missed its heartbeat OR its deviation exceeds its configured threshold. For Chainlink USDC/USD, this would be: latency > 95,040s (26.4h) OR deviation > 0.25%.


### PR DESCRIPTION
## Fix oracle stress detector false positives

### Reconnaissance finding (Path B)

The detector uses a global 1-hour latency threshold with an `or` condition:
```python
is_stress = abs(deviation) > 0.5% or latency > 3600s
```

Chainlink stablecoin feeds (USDC/USD, USDT/USD, stETH/ETH) have 24-hour heartbeats and 0.25% deviation triggers. During calm markets, they don't update for 10-20 hours — healthy behavior that the 1-hour threshold incorrectly flags.

The `oracle_registry` table lacked per-feed configuration (deviation threshold, heartbeat). Fix: **Path B** — add columns, seed values, update detector.

### What changed

- **Migration 081**: adds `deviation_threshold_pct` and `heartbeat_seconds` to `oracle_registry`. Seeds all 7 oracles with real Chainlink/Pyth values from their documentation.
- **Detector update**: reads per-feed config instead of global constants. New logic:
  ```python
  is_stress = deviation > feed_threshold or latency > heartbeat * 1.1
  ```

### Currently-open events

Three events should resolve on next cycle after merge:
- Chainlink USDC/USD: was flagging at >1h latency. Now: >26.4h or >0.25% deviation.
- Chainlink USDT/USD: same.
- Chainlink stETH/ETH: was flagging at >1h. Now: >26.4h or >0.5% deviation.

### Track-record side effects

Any auto-logged ledger entries from these events remain in the database. The outcome classifier will handle them at 30/60/90-day checkpoints — likely marking them 'not_borne_out' (detector fired, we recalibrated, the stress was not real). This is honest calibration data.

### Per-feed config seeded

| Feed | Deviation | Heartbeat | Source |
|------|-----------|-----------|--------|
| USDC/USD ETH | 0.25% | 86400s | Chainlink docs |
| USDT/USD ETH | 0.25% | 86400s | Chainlink docs |
| DAI/USD ETH | 0.25% | 3600s | Chainlink docs |
| ETH/USD ETH | 0.5% | 3600s | Chainlink docs |
| stETH/ETH ETH | 0.5% | 86400s | Chainlink docs |
| ETH/USD Base | 0.15% | 1200s | Chainlink docs |
| Pyth USDC/USD | 0.1% | 60s | Pyth docs |

Closes #12.

https://claude.ai/code/session_01B18T36dZeKZpM9vezXQomz