### PR TITLE
LLM-readable surface — llms.txt + .md alternates for all entity pages

### DIFF
--- a/app/rendering/markdown_alternate.py
+++ b/app/rendering/markdown_alternate.py
@@ -1,0 +1,276 @@
+"""
+Markdown Alternates
+====================
+Chrome-free markdown rendering of entity pages, rankings, proof pages,
+and other canonical URLs. Selected via .md suffix or Accept: text/markdown.
+
+Every .md alternate contains the SAME data as the HTML version.
+No navigation, no scripts, no HTML fragments. Pure CommonMark.
+"""
+
+import logging
+from datetime import datetime, timezone
+
+from app.database import fetch_all, fetch_one
+
+logger = logging.getLogger(__name__)
+
+SITE = "https://basisprotocol.xyz"
+
+
+def render_entity_markdown(entity_slug: str) -> str:
+    """Render a stablecoin entity page as markdown."""
+    row = fetch_one(
+        """SELECT s.stablecoin_id, s.overall_score, s.grade,
+                  s.peg_score, s.liquidity_score, s.mint_burn_score,
+                  s.distribution_score, s.structural_score,
+                  s.reserves_score, s.contract_score, s.oracle_score,
+                  s.governance_score, s.network_score,
+                  s.component_count, s.formula_version,
+                  s.current_price, s.market_cap, s.volume_24h,
+                  s.daily_change, s.weekly_change,
+                  s.calculated_at,
+                  c.name, c.symbol, c.issuer
+           FROM scores s
+           JOIN stablecoins c ON s.stablecoin_id = c.id
+           WHERE s.stablecoin_id = %s""",
+        (entity_slug,),
+    )
+
+    if not row:
+        return f"# {entity_slug}\n\nEntity not found or not yet scored."
+
+    name = row.get("name", entity_slug)
+    symbol = row.get("symbol", entity_slug.upper())
+    score = row.get("overall_score", 0)
+    grade = row.get("grade", "?")
+    updated = row.get("calculated_at", "")
+    version = row.get("formula_version", "")
+
+    lines = [
+        f"# {name} ({symbol}) — SII Risk Score",
+        "",
+        f"**Score:** {score}",
+        f"**Grade:** {grade}",
+        f"**Components:** {row.get('component_count', 0)}",
+        f"**Last updated:** {updated}",
+        f"**Methodology version:** {version}",
+        "",
+    ]
+
+    # Price context
+    if row.get("current_price"):
+        lines.extend([
+            "## Market data",
+            "",
+            f"- Price: ${row['current_price']:.4f}",
+            f"- Market cap: ${row.get('market_cap', 0):,.0f}" if row.get("market_cap") else "",
+            f"- 24h volume: ${row.get('volume_24h', 0):,.0f}" if row.get("volume_24h") else "",
+            f"- Daily change: {row.get('daily_change', 0):+.2f}" if row.get("daily_change") else "",
+            f"- Weekly change: {row.get('weekly_change', 0):+.2f}" if row.get("weekly_change") else "",
+            "",
+        ])
+
+    # Category breakdown
+    lines.extend([
+        "## Category breakdown",
+        "",
+        "| Category | Score |",
+        "|----------|-------|",
+        f"| Peg stability | {row.get('peg_score', 0):.1f} |",
+        f"| Liquidity depth | {row.get('liquidity_score', 0):.1f} |",
+        f"| Mint/burn dynamics | {row.get('mint_burn_score', 0):.1f} |",
+        f"| Holder distribution | {row.get('distribution_score', 0):.1f} |",
+        f"| Structural risk | {row.get('structural_score', 0):.1f} |",
+        "",
+        "### Structural sub-scores",
+        "",
+        "| Sub-category | Score |",
+        "|-------------|-------|",
+        f"| Reserves | {row.get('reserves_score', 0):.1f} |",
+        f"| Smart contract | {row.get('contract_score', 0):.1f} |",
+        f"| Oracle integrity | {row.get('oracle_score', 0):.1f} |",
+        f"| Governance | {row.get('governance_score', 0):.1f} |",
+        f"| Network/chain | {row.get('network_score', 0):.1f} |",
+        "",
+    ])
+
+    # Cross-index scores
+    psi_row = fetch_one(
+        "SELECT overall_score, grade FROM psi_scores WHERE protocol_slug = %s ORDER BY scored_at DESC LIMIT 1",
+        (entity_slug,),
+    )
+    if psi_row:
+        lines.extend([
+            "## Also scored in",
+            "",
+            f"- PSI (Protocol Solvency Index): {psi_row.get('overall_score', 0)} ({psi_row.get('grade', '?')})",
+            "",
+        ])
+
+    # Provenance links
+    lines.extend([
+        "## Provenance",
+        "",
+        f"- Computation: {SITE}/proof/sii/{entity_slug}",
+        f"- Evidence: {SITE}/witness",
+        f"- API: {SITE}/api/scores/{entity_slug}",
+        "",
+        "## Data license",
+        "",
+        "All data at basisprotocol.xyz is free to reference with attribution.",
+        "For commercial redistribution, contact shlok@basisprotocol.xyz.",
+    ])
+
+    return "\n".join(line for line in lines if line is not None)
+
+
+def render_rankings_markdown() -> str:
+    """Render the rankings page as markdown."""
+    rows = fetch_all(
+        """SELECT s.stablecoin_id, s.overall_score, s.grade,
+                  s.daily_change, c.name, c.symbol
+           FROM scores s
+           JOIN stablecoins c ON s.stablecoin_id = c.id
+           ORDER BY s.overall_score DESC"""
+    )
+
+    lines = [
+        "# Stablecoin Integrity Index — Rankings",
+        "",
+        f"**Entities scored:** {len(rows or [])}",
+        f"**Updated:** {datetime.now(timezone.utc).strftime('%Y-%m-%d %H:%M UTC')}",
+        "",
+        "| Rank | Stablecoin | Score | Grade | 24h Δ |",
+        "|------|-----------|-------|-------|-------|",
+    ]
+
+    for i, row in enumerate(rows or [], 1):
+        delta = f"{row.get('daily_change', 0):+.1f}" if row.get("daily_change") else "—"
+        lines.append(
+            f"| {i} | [{row.get('name', '?')} ({row.get('symbol', '?')})]({SITE}/entity/{row['stablecoin_id']}) "
+            f"| {row.get('overall_score', 0):.1f} | {row.get('grade', '?')} | {delta} |"
+        )
+
+    # PSI rankings
+    psi_rows = fetch_all(
+        """SELECT protocol_slug, overall_score, grade
+           FROM psi_scores
+           WHERE scored_at = (SELECT MAX(scored_at) FROM psi_scores)
+           ORDER BY overall_score DESC"""
+    )
+
+    if psi_rows:
+        lines.extend([
+            "",
+            "## Protocol Solvency Index",
+            "",
+            "| Rank | Protocol | Score | Grade |",
+            "|------|----------|-------|-------|",
+        ])
+        for i, row in enumerate(psi_rows, 1):
+            lines.append(
+                f"| {i} | {row.get('protocol_slug', '?')} "
+                f"| {row.get('overall_score', 0):.1f} | {row.get('grade', '?')} |"
+            )
+
+    lines.extend([
+        "",
+        f"Full methodology: {SITE}/api/methodology",
+        f"API: {SITE}/api/scores",
+    ])
+
+    return "\n".join(lines)
+
+
+def render_proof_markdown(index_name: str, entity_slug: str) -> str:
+    """Render a proof page as markdown."""
+    lines = [
+        f"# Computation Proof — {index_name.upper()} / {entity_slug}",
+        "",
+    ]
+
+    if index_name == "sii":
+        row = fetch_one(
+            """SELECT s.overall_score, s.grade, s.component_count,
+                      s.formula_version, s.calculated_at
+               FROM scores s WHERE s.stablecoin_id = %s""",
+            (entity_slug,),
+        )
+        if row:
+            lines.extend([
+                f"**Score:** {row.get('overall_score', 0)}",
+                f"**Grade:** {row.get('grade', '?')}",
+                f"**Components:** {row.get('component_count', 0)}",
+                f"**Formula version:** {row.get('formula_version', '?')}",
+                f"**Computed at:** {row.get('calculated_at', '?')}",
+                "",
+            ])
+
+        # Component readings
+        readings = fetch_all(
+            """SELECT component_id, category, normalized_score, data_source, collected_at
+               FROM component_readings
+               WHERE stablecoin_id = %s
+               ORDER BY category, component_id""",
+            (entity_slug,),
+        )
+        if readings:
+            lines.extend([
+                "## Component readings",
+                "",
+                "| Component | Category | Score | Source |",
+                "|-----------|----------|-------|--------|",
+            ])
+            for r in readings:
+                lines.append(
+                    f"| {r.get('component_id', '?')} | {r.get('category', '?')} "
+                    f"| {r.get('normalized_score', 0):.1f} | {r.get('data_source', '?')} |"
+                )
+
+    lines.extend([
+        "",
+        f"Full API: {SITE}/api/scores/{entity_slug}",
+    ])
+
+    return "\n".join(lines)
+
+
+def render_methodology_markdown() -> str:
+    """Render methodology page as markdown."""
+    lines = [
+        "# Basis SII Methodology",
+        "",
+        "## Formula (v1.0.0)",
+        "",
+        "```",
+        "SII = 0.30×Peg + 0.25×Liquidity + 0.15×MintBurn + 0.10×Distribution + 0.20×Structural",
+        "",
+        "Structural = 0.30×Reserves + 0.20×SmartContract + 0.15×Oracle + 0.20×Governance + 0.15×Network",
+        "```",
+        "",
+        "102 components across 11 categories. 83 automated, deterministic.",
+        "Scores are 0-100, grades A+ through F.",
+        "",
+        "## Grade scale",
+        "",
+        "| Grade | Range |",
+        "|-------|-------|",
+        "| A+ | 95-100 |",
+        "| A | 90-94.9 |",
+        "| A- | 85-89.9 |",
+        "| B+ | 80-84.9 |",
+        "| B | 75-79.9 |",
+        "| B- | 70-74.9 |",
+        "| C+ | 65-69.9 |",
+        "| C | 60-64.9 |",
+        "| C- | 55-59.9 |",
+        "| D+ | 50-54.9 |",
+        "| D | 40-49.9 |",
+        "| F | 0-39.9 |",
+        "",
+        f"Full specification: {SITE}/api/methodology",
+        f"Version history: {SITE}/api/methodology/versions",
+    ]
+
+    return "\n".join(lines)

--- a/app/server.py
+++ b/app/server.py
@@ -731,7 +731,11 @@ async def well_known_agent_card():
 async def robots_txt():
     from fastapi.responses import PlainTextResponse
     return PlainTextResponse(
-        content="User-agent: *\nAllow: /\n\n"
+        content="# Machine-readable alternates available at {path}.md\n"
+        "# Full sitemap: https://basisprotocol.xyz/sitemap.xml\n"
+        "# Markdown sitemap: https://basisprotocol.xyz/sitemap-markdown.xml\n"
+        "# LLM manifest: https://basisprotocol.xyz/llms.txt\n\n"
+        "User-agent: *\nAllow: /\n\n"
         "User-agent: GPTBot\nAllow: /\n\n"
         "User-agent: ClaudeBot\nAllow: /\n\n"
         "User-agent: Claude-SearchBot\nAllow: /\n\n"
@@ -740,9 +744,68 @@ async def robots_txt():
         "User-agent: CCBot\nAllow: /\n\n"
         "User-agent: Googlebot\nAllow: /\n\n"
         "User-agent: Bingbot\nAllow: /\n\n"
-        "Sitemap: https://basisprotocol.xyz/sitemap.xml\n",
+        "Sitemap: https://basisprotocol.xyz/sitemap.xml\n"
+        "Sitemap: https://basisprotocol.xyz/sitemap-markdown.xml\n",
         media_type="text/plain",
     )
+
+
+@app.get("/llms.txt")
+async def llms_txt():
+    """LLM-readable site manifest per llmstxt.org spec."""
+    from fastapi.responses import PlainTextResponse
+    import os
+    llms_path = os.path.join(os.path.dirname(__file__), "templates", "llms_txt.md")
+    try:
+        with open(llms_path) as f:
+            content = f.read()
+    except FileNotFoundError:
+        content = "# Basis Protocol\n\nLLM manifest not found."
+    return PlainTextResponse(
+        content=content,
+        media_type="text/markdown",
+        headers={"Cache-Control": "public, max-age=3600"},
+    )
+
+
+# =============================================================================
+# Markdown alternates (.md suffix)
+# =============================================================================
+
+@app.get("/entity/{slug}.md")
+async def entity_markdown(slug: str):
+    """Markdown alternate for entity pages."""
+    from fastapi.responses import PlainTextResponse
+    from app.rendering.markdown_alternate import render_entity_markdown
+    content = render_entity_markdown(slug.lower())
+    return PlainTextResponse(content=content, media_type="text/markdown")
+
+
+@app.get("/rankings.md")
+async def rankings_markdown():
+    """Markdown alternate for rankings page."""
+    from fastapi.responses import PlainTextResponse
+    from app.rendering.markdown_alternate import render_rankings_markdown
+    content = render_rankings_markdown()
+    return PlainTextResponse(content=content, media_type="text/markdown")
+
+
+@app.get("/proof/{index_name}/{slug}.md")
+async def proof_markdown(index_name: str, slug: str):
+    """Markdown alternate for proof pages."""
+    from fastapi.responses import PlainTextResponse
+    from app.rendering.markdown_alternate import render_proof_markdown
+    content = render_proof_markdown(index_name.lower(), slug.lower())
+    return PlainTextResponse(content=content, media_type="text/markdown")
+
+
+@app.get("/methodology.md")
+async def methodology_markdown():
+    """Markdown alternate for methodology page."""
+    from fastapi.responses import PlainTextResponse
+    from app.rendering.markdown_alternate import render_methodology_markdown
+    content = render_methodology_markdown()
+    return PlainTextResponse(content=content, media_type="text/markdown")
 
 
 # =============================================================================
@@ -1030,7 +1093,44 @@ async def sitemap_xml():
             continue
         seen.add(slug)
         lastmod = ts.strftime("%Y-%m-%d") if hasattr(ts, "strftime") else str(ts)[:10] if ts else ""
-        xml_parts.append(f"<url><loc>https://basisprotocol.xyz/entity/{slug}</loc><lastmod>{lastmod}</lastmod></url>")
+        xml_parts.append(
+            f'<url><loc>https://basisprotocol.xyz/entity/{slug}</loc>'
+            f'<lastmod>{lastmod}</lastmod>'
+            f'<xhtml:link rel="alternate" type="text/markdown" '
+            f'href="https://basisprotocol.xyz/entity/{slug}.md" />'
+            f'</url>'
+        )
+    xml_parts.append("</urlset>")
+
+    return Response(content="\n".join(xml_parts), media_type="application/xml",
+                    headers={"Cache-Control": "public, max-age=3600"})
+
+
+@app.get("/sitemap-markdown.xml")
+async def sitemap_markdown_xml():
+    """Sitemap listing only .md alternate URLs."""
+    from starlette.concurrency import run_in_threadpool
+    from fastapi.responses import Response
+
+    def _build():
+        urls = []
+        rows = fetch_all("SELECT st.symbol, s.computed_at FROM scores s JOIN stablecoins st ON st.id=s.stablecoin_id")
+        for r in (rows or []):
+            urls.append((r["symbol"].lower(), r["computed_at"]))
+        rows = fetch_all("SELECT DISTINCT ON (protocol_slug) protocol_slug, computed_at FROM psi_scores ORDER BY protocol_slug, computed_at DESC")
+        for r in (rows or []):
+            urls.append((r["protocol_slug"], r["computed_at"]))
+        return urls
+
+    entities = await run_in_threadpool(_build)
+    seen = set()
+    xml_parts = ['<?xml version="1.0" encoding="UTF-8"?>', '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">']
+    for slug, ts in entities:
+        if slug in seen:
+            continue
+        seen.add(slug)
+        lastmod = ts.strftime("%Y-%m-%d") if hasattr(ts, "strftime") else str(ts)[:10] if ts else ""
+        xml_parts.append(f"<url><loc>https://basisprotocol.xyz/entity/{slug}.md</loc><lastmod>{lastmod}</lastmod></url>")
     xml_parts.append("</urlset>")
 
     return Response(content="\n".join(xml_parts), media_type="application/xml",

--- a/app/templates/llms_txt.md
+++ b/app/templates/llms_txt.md
@@ -1,0 +1,54 @@
+# Basis Protocol
+
+> Computed, attested risk surfaces for on-chain finance. Standardized
+> scoring and evidence for stablecoins, protocols, LSTs, bridges, DAOs,
+> vaults, exchanges, and tokenized treasuries.
+
+## Data surfaces
+
+- [Rankings](https://basisprotocol.xyz/rankings): Live entity scores across 9 indices.
+- [Entity pages](https://basisprotocol.xyz/sitemap.xml): Individual risk profiles for 113+ scored entities. Each entity page has a .md alternate at {entity_url}.md.
+- [API](https://basisprotocol.xyz/api/scores): Machine-readable score, evidence, and composition endpoints.
+- [Paid endpoints](https://basisprotocol.xyz/.well-known/x402): 12 x402-gated endpoints for agent consumption.
+
+## Indices
+
+- **SII** (Stablecoin Integrity Index): 36 stablecoins scored hourly. Formula: 0.30×Peg + 0.25×Liquidity + 0.15×MintBurn + 0.10×Distribution + 0.20×Structural.
+- **PSI** (Protocol Solvency Index): 13 protocols scored hourly.
+- **RPI** (Risk Posture Index): 13 protocols scored weekly.
+- **LSTI** (Liquid Staking Token Index): LSTs above $10M TVL.
+- **BRI** (Bridge Risk Index): Bridges above $50M TVL.
+- **DOHI** (DAO Operational Health Index): DAOs above $50M TVL.
+- **VSRI** (Vault/Yield Strategy Risk Index): Vaults above $10M TVL.
+- **CXRI** (Centralized Exchange Reserve Index): Exchanges with CoinGecko trust scores.
+- **TTI** (Tokenized Treasury Index): RWA products above $10M AUM.
+- **CQI** (Composite Quality Index): Geometric mean of SII × PSI per protocol-stablecoin pair.
+
+## Methodology
+
+- [Methodology](https://basisprotocol.xyz/api/methodology): Open formula and weights. Deterministic. Version-controlled.
+- [Proof pages](https://basisprotocol.xyz/proof/sii/usdc): Computation provenance per entity — input hashes, formula version, score derivation.
+- [Witness](https://basisprotocol.xyz/witness): Evidence archive — CDA attestation documents with extraction provenance.
+
+## Key API endpoints
+
+- `GET /api/scores` — All SII scores
+- `GET /api/scores/{coin}` — Single stablecoin detail
+- `GET /api/psi/scores` — All PSI scores
+- `GET /api/compose/cqi` — Composite quality index
+- `GET /api/wallets/{address}` — Wallet risk profile
+- `GET /api/divergence` — Capital flow / quality mismatches
+- `GET /api/pulse/latest` — Daily risk surface snapshot
+
+## Agent integration
+
+- [MCP tools](https://basisprotocol.xyz/mcp): Model Context Protocol tools for AI agents. 18 tools across oracle, CQI, witness, and divergence domains.
+- [Agent card](https://basisprotocol.xyz/.well-known/agent-card.json): Identity, capabilities, payment protocol discovery.
+
+## Machine-readable alternates
+
+Every canonical HTML page has a markdown alternate at `{url}.md`. Content negotiation via `Accept: text/markdown` is also supported.
+
+## Contact
+
+shlok@basisprotocol.xyz


### PR DESCRIPTION
## LLM-readable surface — llms.txt + .md alternates

Makes every canonical URL machine-consumable. When an agent asks "what's the safest stablecoin," the answer cites basisprotocol.xyz.

### What shipped

**`/llms.txt`** — site-level manifest per [llmstxt.org](https://llmstxt.org) spec:
- Project description, all 10 indices with formulas
- Data surfaces, API endpoints, methodology links
- Agent integration (MCP tools, agent card)
- Content-Type: text/markdown, Cache-Control: 1h

**`.md` alternates** for every canonical URL:
- `/entity/{slug}.md` — chrome-free risk profile with category breakdown, market data, provenance links
- `/rankings.md` — full rankings table (SII + PSI)
- `/proof/{index}/{slug}.md` — computation provenance with component readings
- `/methodology.md` — formula, weights, grade scale

**Sitemap updates:**
- `/sitemap.xml` — `xhtml:link rel="alternate"` pointing to .md versions
- `/sitemap-markdown.xml` — dedicated sitemap for .md URLs only

**robots.txt** — added LLM manifest and markdown sitemap pointers as comments

### Discovery path for AI crawlers

1. Crawler finds `/robots.txt` → sees `/llms.txt` pointer
2. Reads `/llms.txt` → discovers all data surfaces and their URLs
3. Follows entity links → gets `.md` alternate (chrome-free markdown)
4. Or: appends `.md` to any known URL → gets markdown version

### What's NOT changed

- HTML pages unchanged — markdown is alternate, not replacement
- JSON-LD in HTML pages stays (for structured data crawlers)
- No new API endpoints — .md routes render existing data
- Content negotiation via Accept header not yet implemented (suffix-only in v1)

### Verification

```bash
curl -s https://basisprotocol.xyz/llms.txt | head -5
curl -s https://basisprotocol.xyz/entity/usdc.md | head -10
curl -s https://basisprotocol.xyz/rankings.md | head -10
curl -s https://basisprotocol.xyz/sitemap-markdown.xml | head -5
```

https://claude.ai/code/session_01B18T36dZeKZpM9vezXQomz