### PR TITLE
feat(pipeline-10): pre-stress reading tag + triptych endpoint

### DIFF
--- a/app/collectors/oracle_behavior.py
+++ b/app/collectors/oracle_behavior.py
@@ -20,7 +20,7 @@ from datetime import datetime, timezone
 
 import httpx
 
-from app.database import fetch_all, fetch_one, execute
+from app.database import fetch_all, fetch_one, execute, get_cursor
 
 logger = logging.getLogger(__name__)
 
@@ -48,6 +48,10 @@ SYMBOL_TO_COINGECKO = {
 DEVIATION_STRESS_THRESHOLD = 0.5   # percent (fallback)
 LATENCY_STRESS_THRESHOLD = 3600    # seconds (fallback — 1 hour)
 HEARTBEAT_BUFFER = 1.1             # 10% buffer past heartbeat before flagging
+
+# Pre-stress context window: readings in this window before a newly-opened
+# event get tagged so the triptych endpoint can render before / during / after.
+PRE_STRESS_WINDOW_HOURS = 72
 
 # Fallback public RPCs
 FALLBACK_RPCS = {
@@ -278,6 +282,53 @@ async def _fetch_cex_prices(client: httpx.AsyncClient, symbols: list[str]) -> di
 # Stress event handling
 # ---------------------------------------------------------------------------
 
+def tag_pre_stress_readings(
+    event_id: int,
+    oracle_address: str,
+    chain: str,
+    asset_symbol: str,
+    event_start,
+    window_hours: int = PRE_STRESS_WINDOW_HOURS,
+) -> int:
+    """Retroactively tag the preceding `window_hours` of readings for a
+    newly-opened stress event. Writes the tagged count back onto the event
+    row so the triptych endpoint can verify completeness without a scan.
+
+    Never raises — tagging failure must not block the stress event from
+    opening. Returns the number of readings tagged, or 0 on any error.
+    Idempotent via `pre_stress_event_id IS NULL` guard (no re-tagging on
+    subsequent updates to the same event).
+    """
+    try:
+        with get_cursor() as cur:
+            cur.execute(
+                """UPDATE oracle_price_readings
+                   SET pre_stress_event_id = %s
+                   WHERE oracle_address = %s
+                     AND chain = %s
+                     AND asset_symbol = %s
+                     AND recorded_at >= %s - (%s || ' hours')::INTERVAL
+                     AND recorded_at < %s
+                     AND pre_stress_event_id IS NULL""",
+                (event_id, oracle_address, chain, asset_symbol,
+                 event_start, str(window_hours), event_start),
+            )
+            tagged = cur.rowcount or 0
+            cur.execute(
+                "UPDATE oracle_stress_events SET pre_stress_readings_tagged = %s WHERE id = %s",
+                (tagged, event_id),
+            )
+        logger.info(
+            f"Pre-stress tagging: event {event_id} ({oracle_address[:10]}.. "
+            f"{asset_symbol}/{chain}) — tagged {tagged} readings in prior "
+            f"{window_hours}h"
+        )
+        return tagged
+    except Exception as e:
+        logger.warning(f"Pre-stress tagging failed for event {event_id}: {e}")
+        return 0
+
+
 def _handle_stress_event(oracle: dict, reading: dict, deviation_pct: float, latency: int):
     """Handle oracle stress event: create or update."""
     oracle_addr = oracle["oracle_address"]
@@ -364,13 +415,15 @@ def _handle_stress_event(oracle: dict, reading: dict, deviation_pct: float, late
         content_data = f"{oracle_addr}{chain}{event_type}{now.isoformat()}"
         content_hash = "0x" + hashlib.sha256(content_data.encode()).hexdigest()
 
-        execute(
+        new_event = fetch_one(
             """INSERT INTO oracle_stress_events
                 (oracle_address, oracle_name, asset_symbol, chain,
                  event_type, event_start, max_deviation_pct, max_latency_seconds,
                  reading_count, concurrent_sii_score, concurrent_psi_scores,
-                 affected_protocols, content_hash, attested_at)
-               VALUES (%s, %s, %s, %s, %s, NOW(), %s, %s, 1, %s, %s, %s, %s, NOW())""",
+                 affected_protocols, content_hash, attested_at,
+                 pre_stress_window_hours)
+               VALUES (%s, %s, %s, %s, %s, NOW(), %s, %s, 1, %s, %s, %s, %s, NOW(), %s)
+               RETURNING id, event_start""",
             (
                 oracle_addr, oracle.get("oracle_name"), asset, chain,
                 event_type, abs_dev, latency,
@@ -378,8 +431,19 @@ def _handle_stress_event(oracle: dict, reading: dict, deviation_pct: float, late
                 json.dumps(concurrent_psi) if concurrent_psi else None,
                 json.dumps(affected) if affected else None,
                 content_hash,
+                PRE_STRESS_WINDOW_HOURS,
             ),
         )
+
+        if new_event and new_event.get("id"):
+            tag_pre_stress_readings(
+                event_id=new_event["id"],
+                oracle_address=oracle_addr,
+                chain=chain,
+                asset_symbol=asset,
+                event_start=new_event["event_start"],
+                window_hours=PRE_STRESS_WINDOW_HOURS,
+            )
 
         try:
             from app.state_attestation import attest_state

--- a/app/server.py
+++ b/app/server.py
@@ -9080,6 +9080,15 @@ async def oracle_reading_history(
     return {"readings": [dict(r) for r in (rows or [])], "count": len(rows or [])}
 
 
+def _with_triptych_url(row: dict) -> dict:
+    """Attach triptych_url to a stress-event row so consumers have a
+    one-hop link to the before/during/after artifact."""
+    d = dict(row)
+    if d.get("id") is not None:
+        d["triptych_url"] = f"/api/oracle/stress-events/{d['id']}/triptych"
+    return d
+
+
 @app.get("/api/oracle/stress-events")
 async def oracle_stress_events_list(
     asset_symbol: Optional[str] = None,
@@ -9107,7 +9116,7 @@ async def oracle_stress_events_list(
             ORDER BY event_start DESC""",
         tuple(params),
     )
-    return {"events": [dict(r) for r in (rows or [])], "count": len(rows or [])}
+    return {"events": [_with_triptych_url(r) for r in (rows or [])], "count": len(rows or [])}
 
 
 @app.get("/api/oracle/stress-events/active")
@@ -9118,7 +9127,81 @@ async def oracle_stress_events_active():
            WHERE event_end IS NULL
            ORDER BY event_start DESC"""
     )
-    return {"events": [dict(r) for r in (rows or [])], "count": len(rows or [])}
+    return {"events": [_with_triptych_url(r) for r in (rows or [])], "count": len(rows or [])}
+
+
+@app.get("/api/oracle/stress-events/{event_id}/triptych")
+async def oracle_stress_event_triptych(event_id: int):
+    """Before / during / after readings for a single stress event.
+
+    - pre_stress: readings tagged with this event_id by the pre-stress
+      tagger at event-open time (up to pre_stress_window_hours of context).
+    - during: readings flagged is_stress_event between event_start and
+      event_end (or NOW() if still open).
+    - post_stress: readings in the 72 hours after event_end. Empty if the
+      event is still open.
+    """
+    event = fetch_one(
+        "SELECT * FROM oracle_stress_events WHERE id = %s",
+        (event_id,),
+    )
+    if not event:
+        raise HTTPException(status_code=404, detail="Stress event not found")
+
+    reading_cols = (
+        "id, recorded_at AS reading_timestamp, oracle_price, cex_price, "
+        "deviation_pct, latency_seconds, is_stress_event"
+    )
+
+    pre_rows = fetch_all(
+        f"""SELECT {reading_cols}
+            FROM oracle_price_readings
+            WHERE pre_stress_event_id = %s
+            ORDER BY recorded_at ASC""",
+        (event_id,),
+    ) or []
+
+    during_rows = fetch_all(
+        f"""SELECT {reading_cols}
+            FROM oracle_price_readings
+            WHERE is_stress_event = TRUE
+              AND oracle_address = %s
+              AND chain = %s
+              AND asset_symbol = %s
+              AND recorded_at >= %s
+              AND recorded_at <= COALESCE(%s, NOW())
+            ORDER BY recorded_at ASC""",
+        (event["oracle_address"], event["chain"], event["asset_symbol"],
+         event["event_start"], event.get("event_end")),
+    ) or []
+
+    if event.get("event_end"):
+        post_rows = fetch_all(
+            f"""SELECT {reading_cols}
+                FROM oracle_price_readings
+                WHERE oracle_address = %s
+                  AND chain = %s
+                  AND asset_symbol = %s
+                  AND recorded_at > %s
+                  AND recorded_at <= %s + INTERVAL '72 hours'
+                ORDER BY recorded_at ASC""",
+            (event["oracle_address"], event["chain"], event["asset_symbol"],
+             event["event_end"], event["event_end"]),
+        ) or []
+    else:
+        post_rows = []
+
+    return {
+        "event": _with_triptych_url(event),
+        "pre_stress": [dict(r) for r in pre_rows],
+        "during": [dict(r) for r in during_rows],
+        "post_stress": [dict(r) for r in post_rows],
+        "counts": {
+            "pre_stress": len(pre_rows),
+            "during": len(during_rows),
+            "post_stress": len(post_rows),
+        },
+    }
 
 
 @app.get("/api/oracle/{asset_symbol}/deviation-history")

--- a/migrations/075_oracle_pre_stress_tagging.sql
+++ b/migrations/075_oracle_pre_stress_tagging.sql
@@ -1,0 +1,20 @@
+-- Migration 075: Pre-stress reading tagging for Pipeline 10 (Oracle Behavioral Record)
+--
+-- Adds retroactive tagging of the 72 hours of oracle_price_readings that
+-- preceded a stress event. Lets the triptych endpoint render
+-- before / during / after context without scanning the whole readings table.
+--
+-- No backfill. Rows written before this migration stay untagged; only
+-- stress events opened after deploy get pre-stress context.
+
+ALTER TABLE oracle_price_readings
+    ADD COLUMN IF NOT EXISTS pre_stress_event_id BIGINT NULL
+        REFERENCES oracle_stress_events(id);
+
+CREATE INDEX IF NOT EXISTS idx_oracle_readings_pre_stress
+    ON oracle_price_readings(pre_stress_event_id)
+    WHERE pre_stress_event_id IS NOT NULL;
+
+ALTER TABLE oracle_stress_events
+    ADD COLUMN IF NOT EXISTS pre_stress_window_hours INTEGER NULL DEFAULT 72,
+    ADD COLUMN IF NOT EXISTS pre_stress_readings_tagged INTEGER NULL;

--- a/tests/test_oracle_behavior.py
+++ b/tests/test_oracle_behavior.py
@@ -1,0 +1,273 @@
+"""
+Isolated tests for Pipeline 10 (Oracle Behavioral Record) pre-stress tagging.
+
+Mocks the database layer with an in-memory simulation so the test runs
+without a real Postgres. The function under test is
+`tag_pre_stress_readings`, which retroactively tags readings in the 72
+hours preceding a newly-opened stress event.
+
+Tests:
+1. 100 hourly readings + stress event at now → exactly 72 readings tagged
+   (the first 72 hours of prior data), 28 untagged (older than window)
+2. Tagging is idempotent — a second call against the same event does not
+   double-tag (pre_stress_event_id IS NULL guard)
+3. A reading that belongs to a different oracle address is not tagged
+4. The event row's pre_stress_readings_tagged counter is updated
+5. Tagging failure does not raise (never blocks stress event open)
+"""
+import os
+import sys
+import types
+from datetime import datetime, timedelta, timezone
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+# Stub heavy optional deps so the module under test imports cleanly without
+# the prod runtime environment. We only exercise pure-Python logic here.
+if "httpx" not in sys.modules:
+    _httpx = types.ModuleType("httpx")
+
+    class _AsyncClient:  # minimal surface used by oracle_behavior top-level imports
+        def __init__(self, *a, **k):
+            pass
+
+    _httpx.AsyncClient = _AsyncClient
+    sys.modules["httpx"] = _httpx
+
+if "app.database" not in sys.modules:
+    _dbmod = types.ModuleType("app.database")
+    _dbmod.fetch_all = lambda *a, **k: []
+    _dbmod.fetch_one = lambda *a, **k: None
+    _dbmod.execute = lambda *a, **k: None
+
+    from contextlib import contextmanager
+
+    @contextmanager
+    def _noop_cursor(dict_cursor=False):
+        raise RuntimeError("get_cursor must be patched by the test")
+        yield  # unreachable
+
+    _dbmod.get_cursor = _noop_cursor
+    sys.modules["app.database"] = _dbmod
+
+
+# ---------------------------------------------------------------------------
+# In-memory database simulation
+# ---------------------------------------------------------------------------
+
+class FakeCursor:
+    """Minimal psycopg2-like cursor that operates on in-memory tables."""
+
+    def __init__(self, db):
+        self.db = db
+        self.rowcount = 0
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        pass
+
+    def execute(self, sql, params=None):
+        sql_stripped = " ".join(sql.split()).upper()
+        if sql_stripped.startswith("UPDATE ORACLE_PRICE_READINGS"):
+            event_id, oracle_addr, chain, asset, event_start, window_hours_str, event_start_2 = params
+            window_hours = int(window_hours_str)
+            window_start = event_start - timedelta(hours=window_hours)
+            tagged = 0
+            for r in self.db["readings"]:
+                if (r["oracle_address"] == oracle_addr
+                        and r["chain"] == chain
+                        and r["asset_symbol"] == asset
+                        and r["recorded_at"] >= window_start
+                        and r["recorded_at"] < event_start
+                        and r["pre_stress_event_id"] is None):
+                    r["pre_stress_event_id"] = event_id
+                    tagged += 1
+            self.rowcount = tagged
+        elif sql_stripped.startswith("UPDATE ORACLE_STRESS_EVENTS"):
+            tagged, event_id = params
+            for e in self.db["events"]:
+                if e["id"] == event_id:
+                    e["pre_stress_readings_tagged"] = tagged
+            self.rowcount = 1
+
+
+class FakeDB:
+    def __init__(self):
+        self.readings = []
+        self.events = []
+
+    def cursor(self):
+        return FakeCursor({"readings": self.readings, "events": self.events})
+
+
+def _make_readings(oracle_addr, chain, asset, now, count, step_hours=1):
+    """Generate `count` hourly readings ending just before `now`."""
+    readings = []
+    for i in range(count):
+        readings.append({
+            "id": i + 1,
+            "oracle_address": oracle_addr,
+            "chain": chain,
+            "asset_symbol": asset,
+            "recorded_at": now - timedelta(hours=(i + 1) * step_hours),
+            "pre_stress_event_id": None,
+        })
+    return readings
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+def _get_tagger():
+    """Import tag_pre_stress_readings after patching its DB helpers."""
+    from app.collectors import oracle_behavior
+    return oracle_behavior.tag_pre_stress_readings
+
+
+def _run_tag(db, **kwargs):
+    """Invoke tag_pre_stress_readings with get_cursor patched to use our fake db."""
+    from contextlib import contextmanager
+
+    @contextmanager
+    def fake_get_cursor(dict_cursor=False):
+        yield db.cursor()
+
+    with patch("app.collectors.oracle_behavior.get_cursor", fake_get_cursor):
+        return _get_tagger()(**kwargs)
+
+
+def test_exactly_72_of_100_readings_tagged():
+    """The user's acceptance test:
+    100 hourly readings, stress event at now, window = 72h →
+    the 72 most recent readings (within the window) are tagged;
+    the 28 older ones are not.
+    """
+    oracle_addr = "0x" + "a" * 40
+    chain = "ethereum"
+    asset = "ETH"
+    now = datetime(2026, 4, 20, 12, 0, 0, tzinfo=timezone.utc)
+
+    db = FakeDB()
+    db.readings = _make_readings(oracle_addr, chain, asset, now, count=100)
+    db.events.append({
+        "id": 42,
+        "oracle_address": oracle_addr,
+        "chain": chain,
+        "asset_symbol": asset,
+        "event_start": now,
+        "event_end": None,
+        "pre_stress_readings_tagged": None,
+    })
+
+    tagged_count = _run_tag(
+        db,
+        event_id=42,
+        oracle_address=oracle_addr,
+        chain=chain,
+        asset_symbol=asset,
+        event_start=now,
+        window_hours=72,
+    )
+
+    assert tagged_count == 72, f"expected 72 tagged, got {tagged_count}"
+
+    tagged = [r for r in db.readings if r["pre_stress_event_id"] == 42]
+    untagged = [r for r in db.readings if r["pre_stress_event_id"] is None]
+
+    assert len(tagged) == 72
+    assert len(untagged) == 28
+
+    # The 72 tagged readings are the 72 most-recent (closest to event_start).
+    tagged_hours_ago = sorted(
+        round((now - r["recorded_at"]).total_seconds() / 3600) for r in tagged
+    )
+    assert tagged_hours_ago[0] == 1   # oldest tagged = 1h before now
+    assert tagged_hours_ago[-1] == 72  # newest tagged = 72h before now
+
+    # The 28 untagged are older than 72h
+    untagged_hours_ago = sorted(
+        round((now - r["recorded_at"]).total_seconds() / 3600) for r in untagged
+    )
+    assert untagged_hours_ago[0] == 73
+    assert untagged_hours_ago[-1] == 100
+
+    # Counter was written back onto the event row
+    assert db.events[0]["pre_stress_readings_tagged"] == 72
+
+
+def test_idempotent_no_double_tag():
+    """Second call against the same event tags zero additional rows."""
+    oracle_addr = "0x" + "b" * 40
+    now = datetime(2026, 4, 20, 12, 0, 0, tzinfo=timezone.utc)
+
+    db = FakeDB()
+    db.readings = _make_readings(oracle_addr, "ethereum", "USDC", now, count=80)
+    db.events.append({
+        "id": 7, "oracle_address": oracle_addr, "chain": "ethereum",
+        "asset_symbol": "USDC", "event_start": now, "event_end": None,
+        "pre_stress_readings_tagged": None,
+    })
+
+    first = _run_tag(db, event_id=7, oracle_address=oracle_addr, chain="ethereum",
+                     asset_symbol="USDC", event_start=now, window_hours=72)
+    second = _run_tag(db, event_id=7, oracle_address=oracle_addr, chain="ethereum",
+                      asset_symbol="USDC", event_start=now, window_hours=72)
+
+    assert first == 72
+    assert second == 0, "re-tagging should be a no-op"
+
+
+def test_other_oracle_not_tagged():
+    """Readings from a different oracle address are not tagged."""
+    now = datetime(2026, 4, 20, 12, 0, 0, tzinfo=timezone.utc)
+    target = "0x" + "c" * 40
+    other = "0x" + "d" * 40
+
+    db = FakeDB()
+    db.readings = _make_readings(target, "ethereum", "ETH", now, count=50)
+    db.readings += _make_readings(other, "ethereum", "ETH", now, count=50)
+    db.events.append({
+        "id": 99, "oracle_address": target, "chain": "ethereum",
+        "asset_symbol": "ETH", "event_start": now, "event_end": None,
+        "pre_stress_readings_tagged": None,
+    })
+
+    tagged = _run_tag(db, event_id=99, oracle_address=target, chain="ethereum",
+                      asset_symbol="ETH", event_start=now, window_hours=72)
+
+    assert tagged == 50, "all 50 target readings within window should tag"
+    for r in db.readings:
+        if r["oracle_address"] == other:
+            assert r["pre_stress_event_id"] is None
+
+
+def test_tagging_never_raises_on_db_error():
+    """A DB exception inside tagging is swallowed, returning 0.
+    This guarantees stress-event opens never fail because of the tag step."""
+    from contextlib import contextmanager
+
+    @contextmanager
+    def broken_cursor(dict_cursor=False):
+        raise RuntimeError("simulated DB outage")
+        yield  # unreachable
+
+    with patch("app.collectors.oracle_behavior.get_cursor", broken_cursor):
+        from app.collectors.oracle_behavior import tag_pre_stress_readings
+        result = tag_pre_stress_readings(
+            event_id=1, oracle_address="0x" + "e" * 40,
+            chain="ethereum", asset_symbol="USDC",
+            event_start=datetime.now(timezone.utc),
+        )
+    assert result == 0, "tagger must swallow DB errors and return 0"
+
+
+if __name__ == "__main__":
+    test_exactly_72_of_100_readings_tagged()
+    test_idempotent_no_double_tag()
+    test_other_oracle_not_tagged()
+    test_tagging_never_raises_on_db_error()
+    print("ALL TESTS PASS")

--- a/tests/test_oracle_behavior.py
+++ b/tests/test_oracle_behavior.py
@@ -245,6 +245,28 @@ def test_other_oracle_not_tagged():
             assert r["pre_stress_event_id"] is None
 
 
+def test_tags_all_available_when_fewer_than_72_prior_readings():
+    """Edge case: only 40 prior readings exist. The tagger should tag
+    all 40 without erroring, not try to reach 72 that aren't there."""
+    oracle_addr = "0x" + "f" * 40
+    now = datetime(2026, 4, 20, 12, 0, 0, tzinfo=timezone.utc)
+
+    db = FakeDB()
+    db.readings = _make_readings(oracle_addr, "ethereum", "DAI", now, count=40)
+    db.events.append({
+        "id": 11, "oracle_address": oracle_addr, "chain": "ethereum",
+        "asset_symbol": "DAI", "event_start": now, "event_end": None,
+        "pre_stress_readings_tagged": None,
+    })
+
+    tagged = _run_tag(db, event_id=11, oracle_address=oracle_addr, chain="ethereum",
+                      asset_symbol="DAI", event_start=now, window_hours=72)
+
+    assert tagged == 40, f"expected 40 tagged (all available), got {tagged}"
+    assert all(r["pre_stress_event_id"] == 11 for r in db.readings)
+    assert db.events[0]["pre_stress_readings_tagged"] == 40
+
+
 def test_tagging_never_raises_on_db_error():
     """A DB exception inside tagging is swallowed, returning 0.
     This guarantees stress-event opens never fail because of the tag step."""
@@ -269,5 +291,6 @@ if __name__ == "__main__":
     test_exactly_72_of_100_readings_tagged()
     test_idempotent_no_double_tag()
     test_other_oracle_not_tagged()
+    test_tags_all_available_when_fewer_than_72_prior_readings()
     test_tagging_never_raises_on_db_error()
     print("ALL TESTS PASS")


### PR DESCRIPTION
## Summary
When a stress event opens, retroactively tag the preceding 72 hours of `oracle_price_readings` for that `(oracle_address, chain, asset_symbol)` so every event has before/during/after context. The 72 hours leading up to a depeg is exactly where the earliest signal lives — without this tag it is indistinguishable from normal noise.

## Changes

**Migration 075 — no backfill**
- `oracle_price_readings.pre_stress_event_id` (nullable FK → `oracle_stress_events.id`) + partial index
- `oracle_stress_events.pre_stress_window_hours` default 72 (nullable so pre-migration rows stay untouched)
- `oracle_stress_events.pre_stress_readings_tagged` — auditable counter so `triptych_url` completeness is verifiable without scanning `oracle_price_readings`

**`app/collectors/oracle_behavior.py`**
- INSERT at `_handle_stress_event` switched to `fetch_one(... RETURNING id, event_start)` so the new event id is captured in one round trip
- New `tag_pre_stress_readings()` helper runs the `UPDATE` against the 72h window, writes `rowcount` back onto the event row, logs at INFO
- Tagging hooks onto the **new-open path only**. Updates to existing open events don't re-tag. The `pre_stress_event_id IS NULL` guard makes it idempotent even if called twice by mistake.
- Wrapped in try/except — tagging failure never blocks the stress event from opening. Verified by the error-swallow test.

**`app/server.py`**
- `GET /api/oracle/stress-events/{event_id}/triptych` — returns `pre_stress` / `during` / `post_stress` arrays plus a `counts` summary and the event row itself. 404 if event not found. `post_stress` is empty while the event is still open. Columns: `reading_timestamp` (aliased from `recorded_at`), `oracle_price`, `cex_price`, `deviation_pct`, `latency_seconds`, `is_stress_event`.
- `triptych_url` injected into existing `/api/oracle/stress-events` and `/api/oracle/stress-events/active` via a shared `_with_triptych_url()` helper.

**`tests/test_oracle_behavior.py`**
- 4 tests, mock-based like `test_contract_upgrades.py`. No real DB required.
- `test_exactly_72_of_100_readings_tagged` — the user-specified acceptance case
- `test_idempotent_no_double_tag`
- `test_other_oracle_not_tagged`
- `test_tagging_never_raises_on_db_error`

## What didn't change
- Stress thresholds, lifecycle logic, and the unreplicability guarantee are untouched. The tag is purely additive.
- Reuses the existing `oracle_stress_events` attestation domain. No new attestation domain.
- Pipeline 10 behavior on events opened before 075 deploys: `pre_stress_event_id` stays NULL for their prior readings, `pre_stress_readings_tagged` stays NULL. The triptych endpoint returns empty `pre_stress` for those events, which is the expected behavior.

## Test plan
- [ ] Run migration 075 against the dev database
- [ ] Confirm an active stress event (or wait for one / synthesize one in staging) gets `pre_stress_readings_tagged` populated within the tagging window
- [ ] `GET /api/oracle/stress-events/active` — confirm each row now carries `triptych_url`
- [ ] `GET /api/oracle/stress-events/{id}/triptych` — confirm 3 arrays + counts; verify `pre_stress` array length matches `pre_stress_readings_tagged` on the event row
- [ ] Verify PSI + SII pipelines still produce scores (this PR is read-only against those domains, but worth a spot-check)
- [ ] `python tests/test_oracle_behavior.py` — all 4 pass

## Sequencing note
This is Task 1 of a three-PR sequence (10 → 8 → 22, migrations 075 → 076 → 077). Ships first because it has no external dependencies and no schema ambiguity. Pipeline 8 comment capture and Pipeline 22 pool composition capture follow once this is merged and verified in production.

https://claude.ai/code/session_01XqvVdfS5yCKZjGWRDKcwSA