### PR TITLE
feat(sii): route scoring through aggregation registry (v1.1.0 wiring)

### DIFF
--- a/app/composition.py
+++ b/app/composition.py
@@ -64,6 +64,14 @@ def compute_cqi(asset_symbol, protocol_slug):
     """
     Compute Collateral Quality Index for an asset-in-protocol pair.
     Fetches SII and PSI scores from the database on demand.
+
+    Note: SII inputs now reflect coverage_weighted aggregation as of the
+    SII v1.1.0 wiring PR (see docs/methodology/sii_wiring_acceptance.md).
+    CQI pairs computed before that PR landed were correct against the
+    pre-wiring SII basis but require re-attestation if a consumer wants
+    them to reflect the new SII output. Tracked as
+    basis-hub#cqi-rqs-reattestation — deliberately deferred so CQI's own
+    methodology doesn't shift in the same commit as SII's wiring.
     """
     # Get SII score from scores table joined to stablecoins
     sii_row = fetch_one("""
@@ -122,6 +130,14 @@ def compute_cqi(asset_symbol, protocol_slug):
 def compute_rqs(holdings: list[dict], coverage_threshold: float = 0.0) -> dict:
     """
     Compute Reserve Quality Score from a list of stablecoin holdings.
+
+    Note: the per-holding SII lookups inside this path pull from the `scores`
+    table, which as of the SII v1.1.0 wiring PR reflects coverage_weighted
+    aggregation. Historical RQS values computed before that PR landed are
+    still correct against their timestamped inputs; consumers who want RQS
+    recomputed under the new SII basis need the re-attestation pipeline
+    tracked by basis-hub#cqi-rqs-reattestation. See
+    docs/methodology/sii_wiring_acceptance.md.
 
     Each holding dict must have:
       - symbol: stablecoin ticker (e.g. "USDC")

--- a/app/index_definitions/sii_v1.py
+++ b/app/index_definitions/sii_v1.py
@@ -2,17 +2,28 @@
 SII v1.1.0 — Stablecoin Integrity Index expressed as an index definition.
 
 This mirrors the canonical weights and component normalizations in app/scoring.py
-but expressed in the generic index definition format so SII and PSI share a schema.
+but expresses them in the generic index definition format so SII dispatches
+through the same aggregation registry as every other index.
 
-v1.1.0 — aggregation migrated from legacy SII v1.0.0 renormalization to
-coverage_weighted with min_coverage=0.0. Weights, categories, and
-components are unchanged. The production scoring path in app/scoring.py
-(calculate_sii + calculate_structural_composite) is NOT yet re-routed
-through the aggregation registry; that wiring is the follow-up tracked
-by the TODO in app/scoring.py::calculate_sii. This declaration change
-lets the analyzer and any downstream consumer that reads the definition
-see the target formula. See docs/methodology/aggregation_impact_analysis.md
-and docs/methodology/sii_changelog.md.
+v1.1.0 — aggregation migrated from the three-level legacy SII path
+(components → legacy categories → structural subcategories → v1 categories →
+overall) to the two-level registry model (components → v1 categories →
+overall) with formula `coverage_weighted` and `min_coverage=0.0`.
+
+The legacy three-level path is preserved in `app/scoring.py::calculate_sii` and
+`calculate_structural_composite` and remains callable as the reference
+implementation for `legacy_sii_v1` in `app.composition.AGGREGATION_FORMULAS`
+so historical scores stay reproducible. `STRUCTURAL_SUBWEIGHTS` and
+`DB_TO_STRUCTURAL_MAPPING` are now **legacy-only** — they do not participate
+in the current-scoring overall. The per-subcategory structural scores
+(reserves/contract/oracle/governance/network) continue to be stored on the
+`scores` table as derived informational outputs; they no longer drive the
+overall SII score.
+
+See:
+  - docs/methodology/aggregation_impact_analysis.md
+  - docs/methodology/sii_changelog.md
+  - docs/methodology/sii_wiring_acceptance.md
 """
 
 from app.scoring import SII_V1_WEIGHTS, STRUCTURAL_SUBWEIGHTS, COMPONENT_NORMALIZATIONS
@@ -32,13 +43,52 @@ def _fn_to_name(fn) -> str:
     return _FN_NAME_MAP.get(fn.__name__, fn.__name__)
 
 
+# Canonical legacy→v1 category mapping for SII components. `COMPONENT_NORMALIZATIONS`
+# in `app/scoring.py` tags components with the 8-way legacy category vocabulary
+# (peg_stability, liquidity, flows, market_activity, holder_distribution,
+# smart_contract, governance, transparency, regulatory, network, reserves,
+# oracle). `SII_V1_DEFINITION["categories"]` uses the 5-way v1 vocabulary
+# (peg_stability, liquidity_depth, mint_burn_dynamics, holder_distribution,
+# structural_risk_composite). For the registry's flat two-level aggregation to
+# activate every v1 category, each component's `category` in the definition
+# must be the v1 name. This table is the single source of truth for that
+# mapping; it mirrors `LEGACY_TO_V1_MAPPING` in `app/scoring.py` used by the
+# legacy three-level path. Keeping them in sync is a correctness invariant
+# enforced by `tests/test_sii_wiring.py::test_legacy_and_v1_mappings_agree`.
+SII_LEGACY_TO_V1_CATEGORY = {
+    "peg_stability":      "peg_stability",
+    "liquidity":          "liquidity_depth",
+    "market_activity":    "mint_burn_dynamics",
+    "flows":              "mint_burn_dynamics",
+    "holder_distribution":"holder_distribution",
+    "smart_contract":     "structural_risk_composite",
+    "governance":         "structural_risk_composite",
+    "transparency":       "structural_risk_composite",
+    "regulatory":         "structural_risk_composite",
+    "network":            "structural_risk_composite",
+    "reserves":           "structural_risk_composite",
+    "oracle":             "structural_risk_composite",
+}
+
+
 def _build_components():
-    """Convert COMPONENT_NORMALIZATIONS to generic index definition format."""
+    """Convert COMPONENT_NORMALIZATIONS to generic index definition format.
+
+    Each component's `category` is remapped from its legacy name (the value
+    stored in COMPONENT_NORMALIZATIONS) to its v1 name via
+    SII_LEGACY_TO_V1_CATEGORY so the category labels match the 5 v1 categories
+    declared in `SII_V1_DEFINITION["categories"]`. Legacy names that have no
+    entry in the mapping fall through unchanged — fail visibly so a new
+    legacy category added to COMPONENT_NORMALIZATIONS without a mapping
+    surfaces as a missing category, not a silently dropped component.
+    """
     components = {}
     for comp_id, spec in COMPONENT_NORMALIZATIONS.items():
+        legacy_cat = spec["category"]
         components[comp_id] = {
             "name": comp_id.replace("_", " ").title(),
-            "category": spec["category"],
+            "category": SII_LEGACY_TO_V1_CATEGORY.get(legacy_cat, legacy_cat),
+            "legacy_category": legacy_cat,
             "weight": spec["weight"],
             "normalization": {
                 "function": _fn_to_name(spec["fn"]),
@@ -63,6 +113,13 @@ SII_V1_DEFINITION = {
         cat_id: {"name": cat_id.replace("_", " ").title(), "weight": weight}
         for cat_id, weight in SII_V1_WEIGHTS.items()
     },
+    # Legacy-only. Preserved on the definition for downstream readers
+    # (methodology page, report renderers) that surfaced the structural
+    # subcategory breakdown before v1.1.0. The weights here no longer
+    # participate in overall SII computation; they're retained as the
+    # reference for `legacy_sii_v1` and for the informational sub-scores
+    # persisted to the `scores` table (reserves_score, contract_score,
+    # oracle_score, governance_score, network_score).
     "structural_subcategories": {
         sub_id: {"name": sub_id.replace("_", " ").title(), "weight": weight}
         for sub_id, weight in STRUCTURAL_SUBWEIGHTS.items()

--- a/app/scoring.py
+++ b/app/scoring.py
@@ -12,23 +12,27 @@ All normalization functions preserved exactly from the original codebase.
 
 Aggregation-registry note
 -------------------------
-SII predates the generic scoring engine (`app.scoring_engine.score_entity`)
-and its named-formula aggregation registry (`app.composition.aggregate`).
-The weighted-sum renormalization in `calculate_sii` and
-`calculate_structural_composite` is the SII-v1.0.0 equivalent of
-`aggregate_legacy_renormalize`, but with subtly different rounding —
-intermediate categories are not rounded here, whereas
-`aggregate_legacy_renormalize` rounds to 2 decimals per category.
+SII production scoring dispatches through `app.composition.aggregate`
+(SII v1.1.0 wiring). `app.worker.compute_sii_from_components` builds the
+`component_scores` and `raw_values` dicts and calls `aggregate()` with
+`SII_V1_DEFINITION`, which declares `coverage_weighted` with
+`min_coverage=0.0`. Overall and category scores come from that dispatch.
 
-The `legacy_sii_v1` formula in `app.composition.AGGREGATION_FORMULAS`
-reserves SII's slot and preserves this rounding semantics. Wiring SII's
-call sites to dispatch through that formula is deferred to a follow-up PR
-so this infrastructure PR carries zero risk of shifting stored SII values.
+The functions in this module — `calculate_sii`,
+`calculate_structural_composite`, `aggregate_legacy_to_v1` — are the
+reference implementation of the pre-wiring **three-level** SII path
+(components → legacy categories simple-averaged → structural subcategories
+simple-averaged → `STRUCTURAL_SUBWEIGHTS`-weighted composite → v1
+categories via `SII_V1_WEIGHTS` → overall). They remain callable so the
+`legacy_sii_v1` formula in `app.composition.AGGREGATION_FORMULAS` has a
+reference for historical reproducibility, and so the structural
+subcategory scores (reserves_score / contract_score / oracle_score /
+governance_score / network_score) can be produced alongside the dispatch
+path's overall as derived informational outputs on the `scores` table.
 
-Until that follow-up lands, `calculate_sii` and
-`calculate_structural_composite` remain the canonical SII overall
-computation paths. Callers are `app.worker.compute_sii_for_coin` (line 190)
-and `app.data_layer.component_replay` (line 127).
+`STRUCTURAL_SUBWEIGHTS` and `DB_TO_STRUCTURAL_MAPPING` are legacy-only —
+they do not participate in current SII overall computation. See
+docs/methodology/sii_changelog.md and docs/methodology/sii_wiring_acceptance.md.
 """
 
 import math
@@ -148,20 +152,25 @@ def score_to_grade(score: float) -> str:
 
 def calculate_structural_composite(subscores: Dict[str, Optional[float]]) -> Optional[float]:
     """
-    Calculate Structural Risk Composite from its 5 subcategories.
+    Calculate Structural Risk Composite from its 5 subcategories (legacy path).
 
     Formula:
       Structural = 0.30×Reserves + 0.20×SmartContract + 0.15×Oracle + 0.20×Governance + 0.15×Network
 
     Returns None if no subcategory data is available.
 
-    TODO(aggregation-migration): route through
-      app.composition.aggregate(definition, component_scores,
-                                 raw_values=..., params={})
-    with formula=legacy_sii_v1 once a synthetic structural-composite
-    definition is wired into the dispatch path. Preserved verbatim here to
-    avoid shifting stored SII values during the aggregation-infrastructure
-    PR. See the module docstring for context.
+    Legacy-only as of SII v1.1.0 wiring. This function produces the
+    structural_risk_composite value that the **three-level** pre-wiring
+    SII path used as an input to `calculate_sii`. Current SII scoring
+    dispatches through `app.composition.aggregate` with the
+    `coverage_weighted` formula, which aggregates structural components
+    directly by their per-component `COMPONENT_NORMALIZATIONS` weights
+    — `STRUCTURAL_SUBWEIGHTS` no longer participates in overall
+    computation. This function is retained (a) as the reference
+    implementation backing `legacy_sii_v1` in the aggregation registry
+    so historical scores remain reproducible, and (b) to produce the 5
+    derived structural sub-scores persisted to the `scores` table as
+    informational outputs. See the module docstring.
     """
     total = 0.0
     weight_used = 0.0
@@ -184,21 +193,23 @@ def calculate_structural_composite(subscores: Dict[str, Optional[float]]) -> Opt
 
 def calculate_sii(category_scores: Dict[str, Optional[float]]) -> Optional[float]:
     """
-    Calculate SII using the canonical v1.0.0 formula.
+    Calculate SII using the legacy v1.0.0 three-level formula.
 
     Formula:
       SII = 0.30×Peg + 0.25×Liquidity + 0.15×MintBurn + 0.10×Distribution + 0.20×Structural
 
     Args:
-        category_scores: Dict with scores (0-100) for each canonical category.
+        category_scores: Dict with scores (0-100) for each canonical v1 category.
 
     Returns:
         SII score (0-100), or None if no data available.
 
-    TODO(aggregation-migration): route through app.composition.aggregate with
-    formula=legacy_sii_v1 once a synthetic SII-level definition is wired in.
-    Preserved verbatim here to avoid rounding-induced SII drift during the
-    aggregation-infrastructure PR. See module docstring.
+    Legacy-only as of SII v1.1.0 wiring. Current SII scoring dispatches
+    through `app.composition.aggregate` with the `coverage_weighted`
+    formula in `app.worker.compute_sii_from_components`. This function
+    remains the reference implementation backing the `legacy_sii_v1`
+    formula in the aggregation registry so historical scores stay
+    reproducible. See module docstring and docs/methodology/sii_wiring_acceptance.md.
     """
     total = 0.0
     weight_used = 0.0

--- a/app/server.py
+++ b/app/server.py
@@ -83,6 +83,21 @@ class _ResponseCache:
 _cache = _ResponseCache()
 
 
+def _parse_jsonb(v):
+    """Safely decode a JSONB column value. psycopg2 usually returns dicts/
+    lists directly for JSONB, but some code paths stringify; accept both
+    and return None on parse failure."""
+    if v is None:
+        return None
+    if isinstance(v, str):
+        import json as _j
+        try:
+            return _j.loads(v)
+        except Exception:
+            return None
+    return v
+
+
 app = FastAPI(
     title="Basis Protocol API",
     description="Standardized risk surfaces for on-chain finance",
@@ -1354,6 +1369,10 @@ async def get_scores(response: Response, methodology_version: Optional[str] = Qu
 
         comp_count = comp_populated
 
+        # Aggregation envelope (columns from migration 084; populated by the
+        # SII v1.1.0 wiring). Historical rows return None.
+        eff_weights = _parse_jsonb(row.get("effective_category_weights"))
+        agg_params = _parse_jsonb(row.get("aggregation_params"))
         results.append({
             "id": row["stablecoin_id"],
             "name": row["name"],
@@ -1388,6 +1407,12 @@ async def get_scores(response: Response, methodology_version: Optional[str] = Qu
             },
             "component_count": comp_count,
             "formula_version": row.get("formula_version"),
+            "aggregation_method": row.get("aggregation_method"),
+            "aggregation_params": agg_params,
+            "aggregation_formula_version": row.get("aggregation_formula_version"),
+            "effective_category_weights": eff_weights,
+            "coverage": float(row["coverage"]) if row.get("coverage") is not None else None,
+            "withheld": bool(row.get("withheld")) if row.get("withheld") is not None else False,
             "computed_at": row["computed_at"].isoformat() if row.get("computed_at") else None,
         })
     
@@ -1539,6 +1564,12 @@ async def get_score_detail(coin: str, methodology_version: Optional[str] = Query
         "formula_version": row.get("formula_version"),
         "methodology_version": FORMULA_VERSION,
         "methodology_version_pinned": pinned,
+        "aggregation_method": row.get("aggregation_method"),
+        "aggregation_params": _parse_jsonb(row.get("aggregation_params")),
+        "aggregation_formula_version": row.get("aggregation_formula_version"),
+        "effective_category_weights": _parse_jsonb(row.get("effective_category_weights")),
+        "coverage": float(row["coverage"]) if row.get("coverage") is not None else None,
+        "withheld": bool(row.get("withheld")) if row.get("withheld") is not None else False,
         "daily_change": float(row["daily_change"]) if row.get("daily_change") else None,
         "weekly_change": float(row["weekly_change"]) if row.get("weekly_change") else None,
         "computed_at": row["computed_at"].isoformat() if row.get("computed_at") else None,
@@ -1916,6 +1947,7 @@ async def get_all_indices():
             "description": idx["description"],
             "entity_type": idx["entity_type"],
             "formula": formula,
+            "aggregation": idx.get("aggregation"),
             "categories": categories,
             "total_components": len(idx.get("components", {})),
             "structural_subcategories": idx.get("structural_subcategories"),

--- a/app/worker.py
+++ b/app/worker.py
@@ -170,86 +170,130 @@ async def collect_all_components(
 
 def compute_sii_from_components(components: list[dict]) -> dict:
     """
-    Given a flat list of component readings, compute the SII score.
-    Returns dict with overall score, category scores, structural breakdown.
+    Given a flat list of component readings, compute the SII score via the
+    aggregation registry.
+
+    As of SII v1.1.0, overall and category scores are produced by
+    ``app.composition.aggregate(SII_V1_DEFINITION, component_scores,
+    raw_values)`` — the same dispatch path every other index uses. The
+    formula declared on the definition (``coverage_weighted`` with
+    ``min_coverage=0.0``) governs how categories combine.
+
+    The structural subcategory breakdown (reserves/contract/oracle/
+    governance/network) is preserved as **derived informational** output,
+    computed from per-legacy-category averages via ``DB_TO_STRUCTURAL_MAPPING``.
+    These sub-scores continue to populate their dedicated columns on the
+    ``scores`` table but no longer drive the overall. The legacy
+    three-level path (``calculate_sii`` + ``calculate_structural_composite``
+    + ``aggregate_legacy_to_v1``) remains callable as the reference
+    implementation for ``legacy_sii_v1`` in the formula registry so
+    historical scores stay reproducible.
+
+    See docs/methodology/sii_changelog.md and
+    docs/methodology/sii_wiring_acceptance.md.
     """
-    # Group by category → average normalized scores
-    category_scores: dict[str, list[float]] = {}
-    for comp in components:
-        cat = comp.get("category", "unknown")
-        score = comp.get("normalized_score")
-        if score is not None:
-            category_scores.setdefault(cat, []).append(score)
-    
-    cat_avgs = {cat: sum(s) / len(s) for cat, s in category_scores.items()}
-    
-    # Map legacy categories to v1.0.0 structure
-    v1_scores = aggregate_legacy_to_v1(cat_avgs)
-    
-    # Calculate final SII
-    overall = calculate_sii(v1_scores)
+    import json as _json
+    from app.composition import aggregate
+    from app.index_definitions.sii_v1 import SII_V1_DEFINITION
+    from app.scoring import (
+        COMPONENT_NORMALIZATIONS,
+        DB_TO_STRUCTURAL_MAPPING,
+    )
+    from app.scoring_engine import compute_confidence_tag
+
+    # Build the (component_scores, raw_values) dicts keyed by component_id.
+    # Only components declared in the definition participate; collector-only
+    # ids (e.g., Solana-chain-specific variants) are ignored to match the
+    # analyzer's Section B behavior.
+    component_scores: dict[str, float] = {}
+    raw_values: dict[str, float] = {}
+    for c in components:
+        cid = c.get("component_id")
+        if cid is None or cid not in SII_V1_DEFINITION["components"]:
+            continue
+        rv = c.get("raw_value")
+        if rv is not None:
+            raw_values[cid] = rv
+        ns = c.get("normalized_score")
+        if ns is not None:
+            component_scores[cid] = float(ns)
+
+    agg = aggregate(SII_V1_DEFINITION, component_scores, raw_values)
+
+    overall = agg.get("overall_score")
     if overall is None:
         overall = 0.0
-    
-    # Extract structural subscores for storage
-    from app.scoring import DB_TO_STRUCTURAL_MAPPING, STRUCTURAL_SUBWEIGHTS
-    structural_buckets: dict[str, list[float]] = {}
-    for legacy_cat, sub in DB_TO_STRUCTURAL_MAPPING.items():
-        if legacy_cat in cat_avgs:
-            structural_buckets.setdefault(sub, []).append(cat_avgs[legacy_cat])
-    structural_subs = {
-        sub: sum(s) / len(s)
-        for sub, s in structural_buckets.items()
-    }
-    
     rounded_overall = round(overall, 2)
 
-    # V7.3 confidence tag fields — derived from actual populated components
-    # against the SII v1 component definition. components_total is the total
-    # number of components in COMPONENT_NORMALIZATIONS (56 as of v1.0.0).
-    # components_populated counts only components whose normalized_score is
-    # not None and whose component_id is part of the v1 definition.
-    from app.scoring import COMPONENT_NORMALIZATIONS
-    from app.scoring_engine import compute_confidence_tag
-    sii_comp_total = len(COMPONENT_NORMALIZATIONS)
-    sii_comp_populated = sum(
-        1 for c in components
-        if c.get("component_id") in COMPONENT_NORMALIZATIONS
-        and c.get("normalized_score") is not None
-    )
-    sii_coverage = round(sii_comp_populated / max(sii_comp_total, 1), 4)
+    cat_scores = agg.get("category_scores") or {}
 
-    # Missing categories (V1 names): any weighted v1 category whose aggregate
-    # score is None/zero because no component produced a normalized value.
-    _v1_missing = [
-        cat for cat, val in v1_scores.items()
-        if val is None or val == 0
-    ]
+    # Per-legacy-category averages — used only for the informational structural
+    # sub-scores (reserves_score, contract_score, oracle_score,
+    # governance_score, network_score). These columns are preserved on the
+    # scores table for methodology-page display and do not drive overall as of
+    # SII v1.1.0.
+    legacy_bucket: dict[str, list[float]] = {}
+    for c in components:
+        legacy_cat = c.get("category", "unknown")
+        ns = c.get("normalized_score")
+        if ns is None:
+            continue
+        legacy_bucket.setdefault(legacy_cat, []).append(float(ns))
+    legacy_avgs = {k: sum(v) / len(v) for k, v in legacy_bucket.items()}
+    structural_buckets: dict[str, list[float]] = {}
+    for legacy_cat, sub in DB_TO_STRUCTURAL_MAPPING.items():
+        if legacy_cat in legacy_avgs:
+            structural_buckets.setdefault(sub, []).append(legacy_avgs[legacy_cat])
+    structural_subs = {
+        sub: sum(s) / len(s) for sub, s in structural_buckets.items()
+    }
+
+    # V7.3 confidence tag fields — derived from actual populated components
+    # against the SII v1 component definition. Mirrors the behavior the
+    # pre-wiring path produced.
+    sii_comp_total = len(COMPONENT_NORMALIZATIONS)
+    sii_comp_populated = len(component_scores)
+    sii_coverage = round(sii_comp_populated / max(sii_comp_total, 1), 4)
+    _v1_missing = sorted(
+        set(SII_V1_DEFINITION["categories"].keys()) - set(cat_scores.keys())
+    )
     _conf = compute_confidence_tag(
         5 - len(_v1_missing), 5, sii_coverage, _v1_missing,
     )
 
+    # Aggregation envelope — six fields persisted on the scores table per
+    # migration 084, now populated on every cycle.
+    aggregation_params = (SII_V1_DEFINITION.get("aggregation") or {}).get("params", {})
+
     return {
         "overall_score": rounded_overall,
         "grade": score_to_grade(rounded_overall),
-        "peg_score": round(v1_scores.get("peg_stability") or 0, 2),
-        "liquidity_score": round(v1_scores.get("liquidity_depth") or 0, 2),
-        "mint_burn_score": round(v1_scores.get("mint_burn_dynamics") or 0, 2),
-        "distribution_score": round(v1_scores.get("holder_distribution") or 0, 2),
-        "structural_score": round(v1_scores.get("structural_risk_composite") or 0, 2),
+        "peg_score": round(cat_scores.get("peg_stability") or 0, 2),
+        "liquidity_score": round(cat_scores.get("liquidity_depth") or 0, 2),
+        "mint_burn_score": round(cat_scores.get("mint_burn_dynamics") or 0, 2),
+        "distribution_score": round(cat_scores.get("holder_distribution") or 0, 2),
+        "structural_score": round(cat_scores.get("structural_risk_composite") or 0, 2),
         "reserves_score": round(structural_subs.get("reserves_collateral") or 0, 2),
         "contract_score": round(structural_subs.get("smart_contract_risk") or 0, 2),
         "oracle_score": round(structural_subs.get("oracle_integrity") or 0, 2),
         "governance_score": round(structural_subs.get("governance_operations") or 0, 2),
         "network_score": round(structural_subs.get("network_chain_risk") or 0, 2),
         "component_count": len(components),
-        "formula_version": FORMULA_VERSION,
+        "formula_version": SII_V1_DEFINITION["version"],
         "components_populated": sii_comp_populated,
         "components_total": sii_comp_total,
         "component_coverage": sii_coverage,
         "missing_categories": _v1_missing,
         "confidence": _conf["confidence"],
         "confidence_tag": _conf["tag"],
+        # Aggregation envelope — persisted by store_score into the columns
+        # added by migration 084.
+        "aggregation_method": agg.get("method"),
+        "aggregation_params": aggregation_params,
+        "aggregation_formula_version": agg.get("formula_version"),
+        "effective_category_weights": agg.get("effective_category_weights") or {},
+        "coverage": agg.get("coverage"),
+        "withheld": bool(agg.get("withheld")),
     }
 
 
@@ -307,6 +351,8 @@ def store_score(stablecoin_id: str, score_data: dict, price_ctx: dict):
     
     import json as _json
     missing_cats = score_data.get("missing_categories") or []
+    eff_weights = score_data.get("effective_category_weights") or {}
+    agg_params = score_data.get("aggregation_params") or {}
 
     with get_cursor() as cur:
         cur.execute("""
@@ -319,6 +365,8 @@ def store_score(stablecoin_id: str, score_data: dict, price_ctx: dict):
                 daily_change, weekly_change,
                 confidence, confidence_tag, component_coverage,
                 components_populated, components_total, missing_categories,
+                aggregation_method, aggregation_params, aggregation_formula_version,
+                effective_category_weights, coverage, withheld,
                 computed_at, updated_at
             ) VALUES (
                 %s, %s, %s,
@@ -327,6 +375,8 @@ def store_score(stablecoin_id: str, score_data: dict, price_ctx: dict):
                 %s, %s, %s,
                 %s, %s, %s,
                 %s, %s,
+                %s, %s, %s,
+                %s, %s, %s,
                 %s, %s, %s,
                 %s, %s, %s,
                 NOW(), NOW()
@@ -358,6 +408,12 @@ def store_score(stablecoin_id: str, score_data: dict, price_ctx: dict):
                 components_populated = EXCLUDED.components_populated,
                 components_total = EXCLUDED.components_total,
                 missing_categories = EXCLUDED.missing_categories,
+                aggregation_method = EXCLUDED.aggregation_method,
+                aggregation_params = EXCLUDED.aggregation_params,
+                aggregation_formula_version = EXCLUDED.aggregation_formula_version,
+                effective_category_weights = EXCLUDED.effective_category_weights,
+                coverage = EXCLUDED.coverage,
+                withheld = EXCLUDED.withheld,
                 computed_at = NOW(),
                 updated_at = NOW()
         """, (
@@ -380,6 +436,12 @@ def store_score(stablecoin_id: str, score_data: dict, price_ctx: dict):
             score_data.get("components_populated"),
             score_data.get("components_total"),
             _json.dumps(missing_cats),
+            score_data.get("aggregation_method"),
+            _json.dumps(agg_params),
+            score_data.get("aggregation_formula_version"),
+            _json.dumps(eff_weights),
+            score_data.get("coverage"),
+            bool(score_data.get("withheld")),
         ))
 
 

--- a/docs/methodology/sii_changelog.md
+++ b/docs/methodology/sii_changelog.md
@@ -1,13 +1,55 @@
 # SII Methodology Changelog
 
-## v1.1.0 — 2026-04-21
+## v1.1.0 — 2026-04-21 (wiring landed)
+
+**Status as of the wiring PR on `claude/sii-dispatch-wiring`:** production SII
+scoring is now routed through `app.composition.aggregate()` with the
+declared formula (`coverage_weighted`, `min_coverage=0.0`). The declaration
+and dispatch match.
+
+Methodology clarification: SII flattened from three-level aggregation
+(components → legacy categories → structural subcategories → v1 categories →
+overall) to two-level (components → v1 categories → overall). Structural
+subcategory weights (`STRUCTURAL_SUBWEIGHTS`) and the legacy→v1 category
+remap (`DB_TO_STRUCTURAL_MAPPING` / `LEGACY_TO_V1_MAPPING`) are preserved
+for historical reproducibility under the `legacy_sii_v1` formula slot but
+no longer participate in current scoring. New SII scores use the v1
+category structure directly with component-level weights from
+`COMPONENT_NORMALIZATIONS`. Expected movement: USDC 93.36 → 94.60 per
+Section B of `docs/methodology/aggregation_impact_analysis.md`; full
+Section B table frozen in `docs/methodology/sii_wiring_acceptance.md`.
+
+The 5 structural subcategory scores (reserves_score, contract_score,
+oracle_score, governance_score, network_score) continue to be computed
+from the legacy per-category averages and persisted to the `scores` table
+as derived informational outputs. They no longer drive the overall.
+
+Code changes:
+- `app/index_definitions/sii_v1.py` — `SII_LEGACY_TO_V1_CATEGORY` added;
+  `_build_components` now remaps component categories to v1 names.
+- `app/worker.py::compute_sii_from_components` — dispatches via
+  `aggregate(SII_V1_DEFINITION, component_scores, raw_values)`; structural
+  sub-scores preserved as informational.
+- `app/worker.py::store_score` — persists the six aggregation envelope
+  fields (columns already added by migration 084).
+- `app/server.py` — `/api/scores`, `/api/scores/{coin}`, and `/api/indices`
+  emit aggregation fields.
+- `scripts/analyze_aggregation_impact.py` — analyzer's local SII category
+  remap removed; imports from the shared definition.
+- `tests/test_sii_wiring.py` — four tests locking dispatch, divergence,
+  category-activation, and legacy-path divergence.
+
+No new migration. Migration 084 already added the aggregation envelope
+columns to the `scores` table.
+
+## v1.1.0 — 2026-04-21 (declaration only)
 
 **Aggregation migration:** `legacy_renormalize` → `coverage_weighted` with `min_coverage=0.0`.
 
 - Declared via `SII_V1_DEFINITION.aggregation` in `app/index_definitions/sii_v1.py`.
 - Weights, categories, and components unchanged.
 - Justification: `docs/methodology/aggregation_impact_analysis.md` (Section B — SII). Under coverage-weighted, categories contribute to the overall in proportion to their populated-weight fraction, so partially-populated categories are no longer silently over-weighted relative to fully-populated peers. Net shift for the USDC anchor is +~1 point (93.36 → ~94.60 per Section B of the report).
-- **Production scoring path wiring deferred.** `app/scoring.py::calculate_sii` and `app/worker.py::compute_sii_from_components` do not yet dispatch through `app.composition.aggregate`; the TODO in `app/scoring.py::calculate_sii` tracks that follow-up. This release carries the declaration change only; stored SII scores will not shift until the wiring PR lands.
+- **Production scoring path wiring deferred.** `app/scoring.py::calculate_sii` and `app/worker.py::compute_sii_from_components` did not yet dispatch through `app.composition.aggregate` at the time of this entry; that wiring landed in the subsequent entry above.
 
 ## v1.0.0 — 2025-12-28
 

--- a/docs/methodology/sii_wiring_acceptance.md
+++ b/docs/methodology/sii_wiring_acceptance.md
@@ -1,0 +1,139 @@
+# SII v1.1.0 Wiring — Acceptance Runbook
+
+**Frozen-as-of:** commit `26101b7` (SII v1.1.0 declaration)
+**Applies to:** the first post-deploy scoring cycle after the wiring PR lands
+**Tolerance rule:** ±0.10 per entity. Exceedances are discrepancy reports,
+not rollback triggers. The first post-deploy cycle's values are the new
+ground truth; the table below is a prediction from yesterday's readings.
+
+## Methodology clarification
+
+Before this PR, SII computed overall via a three-level aggregation
+(components → legacy categories simple-averaged → structural subcategories
+simple-averaged → `STRUCTURAL_SUBWEIGHTS`-weighted composite → `SII_V1_WEIGHTS`-weighted
+overall). The declaration on `SII_V1_DEFINITION` (v1.1.0, `coverage_weighted`
+with `min_coverage=0.0`) did not take effect.
+
+After this PR, SII computes overall via the registry's flat two-level
+`aggregate()` path — components → v1 categories → overall, with
+per-component weights from `COMPONENT_NORMALIZATIONS` applied inside each
+v1 category, and `coverage_weighted` effective category weights driving the
+overall sum. Structural subcategory scores (reserves_score / contract_score /
+oracle_score / governance_score / network_score) are preserved on the
+`scores` table as derived informational outputs; they no longer drive the
+overall. The three-level path is preserved verbatim as the reference
+implementation for the `legacy_sii_v1` formula slot so historical scores
+remain reproducible.
+
+`STRUCTURAL_SUBWEIGHTS` and `DB_TO_STRUCTURAL_MAPPING` are now legacy-only.
+
+## Expected values — Section B, column cw@0.0
+
+Frozen from `docs/methodology/aggregation_impact_analysis.md` §B as of
+commit `26101b7`. 36 entities.
+
+| entity | legacy | expected (cw@0.0) | delta |
+|---|---|---|---|
+| USDC | 93.36 | 94.60 | +1.24 |
+| USDT | 89.44 | 90.44 | +1.00 |
+| DAI | 84.52 | 85.77 | +1.25 |
+| USD1 | 83.68 | 86.80 | +3.12 |
+| USDS | 81.83 | 86.00 | +4.17 |
+| PYUSD | 79.37 | 81.92 | +2.55 |
+| RLUSD | 75.39 | 82.47 | +7.08 |
+| crvUSD | 75.03 | 77.02 | +1.99 |
+| GHO | 74.60 | 79.69 | +5.09 |
+| FDUSD | 74.01 | 76.25 | +2.24 |
+| USDe | 73.22 | 73.20 | -0.02 |
+| TUSD | 72.85 | 75.89 | +3.04 |
+| USDD | 71.52 | 75.45 | +3.93 |
+| USDP | 70.44 | 79.01 | +8.57 |
+| FRAX | 65.84 | 67.12 | +1.28 |
+| MUSD | 64.77 | 74.87 | +10.10 |
+| USDTB | 63.14 | 69.05 | +5.91 |
+| DOLA | 63.11 | 69.06 | +5.95 |
+| MIM | 60.33 | 68.36 | +8.03 |
+| GUSD | 58.34 | 67.11 | +8.77 |
+| OUSD | 56.99 | 64.01 | +7.02 |
+| LUSD | 56.28 | 60.09 | +3.81 |
+| EURC | 55.84 | 54.63 | -1.21 |
+| SUSDS | 54.78 | 53.66 | -1.12 |
+| SUSDE | 52.93 | 49.53 | -3.40 |
+| EURI | 46.98 | 48.23 | +1.25 |
+| STKGHO | 45.99 | 48.88 | +2.89 |
+| STEAKUSDC | 42.52 | 40.76 | -1.76 |
+| EURE | 42.33 | 43.54 | +1.21 |
+| BUSD0 | 42.11 | 41.63 | -0.48 |
+| sUSD | 38.09 | 36.49 | -1.60 |
+| SDOLA | 37.71 | 38.23 | +0.52 |
+| FRAX (variant) | 37.02 | 34.05 | -2.97 |
+| RAI | 35.58 | 32.87 | -2.71 |
+| USDD (BTTC bridge) | 35.20 | 33.68 | -1.52 |
+| EURS | 33.09 | 24.92 | -8.17 |
+
+Source: `docs/methodology/aggregation_impact_analysis.md` §B (regenerated
+from production component_readings on 2026-04-21 via
+`python scripts/analyze_aggregation_impact.py`). These are predictions,
+not targets.
+
+## Post-deploy verification
+
+Run once against the first scoring cycle that writes v1.1.0 rows.
+
+### Pull current SII overalls
+
+```sql
+-- Latest overall_score per stablecoin, with the aggregation envelope
+-- v1.1.0 writes. aggregation_method='coverage_weighted' is the signal that
+-- the wiring is live; rows written pre-wiring will show NULL.
+SELECT
+    st.symbol,
+    s.overall_score,
+    s.aggregation_method,
+    s.aggregation_formula_version,
+    s.coverage,
+    s.withheld,
+    s.computed_at
+FROM scores s
+JOIN stablecoins st ON st.id = s.stablecoin_id
+ORDER BY s.overall_score DESC;
+```
+
+### Compare to this table
+
+For each entity in the table above, compute `|new_overall - expected| ≤ 0.10`.
+
+- **Pass:** all entities within ±0.10 of the expected value, and every row has
+  `aggregation_method = 'coverage_weighted'` with `coverage` and
+  `effective_category_weights` populated.
+- **Discrepancy report (not rollback):** any entity outside ±0.10. Record
+  the entity, the expected value, and the actual value. Likely causes:
+  - Component readings drifted between report generation and first post-deploy
+    cycle (prices/volumes/etc. update hourly — expected drift for some entities).
+  - A new component landed in `COMPONENT_NORMALIZATIONS` between commits
+    `26101b7` and the wiring PR — re-run the analyzer and refresh this table.
+  - Collector produced a new value for a component that was missing at
+    report time — legitimate new signal, not a regression.
+- **Rollback trigger:** `aggregation_method IS NULL` on any v1.1.0-cycle row,
+  or `overall_score` systematically regresses toward pre-wiring values for
+  all entities. That indicates the dispatch isn't active.
+
+### Spot-check the canonical anchor
+
+```sql
+SELECT overall_score, aggregation_method, coverage, withheld
+FROM scores WHERE stablecoin_id = 'usdc';
+-- Expect: overall_score ≈ 94.60, aggregation_method = 'coverage_weighted',
+-- coverage ~ 0.62, withheld = false.
+```
+
+## Follow-ups not in this PR
+
+- CQI/RQS re-attestation: SII inputs now reflect coverage_weighted aggregation.
+  Any CQI pair or RQS snapshot computed before this PR lands is still
+  correct under its own timestamp, but downstream re-attestation will be
+  needed when CQI/RQS consumers want to reflect the new SII basis.
+  Tracked as `basis-hub#cqi-rqs-reattestation`.
+- Backfilling historical `scores` rows with aggregation envelope fields:
+  NOT to be done. V9.9 preserves historical scores at their original
+  formula name and methodology version. Pre-wiring rows stay NULL.

--- a/scripts/analyze_aggregation_impact.py
+++ b/scripts/analyze_aggregation_impact.py
@@ -211,47 +211,11 @@ def analyze_psi_rpi(index_id: str, query: str, module_path: str, symbol: str) ->
     return out
 
 
-# Legacy category names declared on SII components (inherited from
-# COMPONENT_NORMALIZATIONS) → SII v1 category names declared on
-# SII_V1_DEFINITION["categories"]. Canonical source: app/scoring_engine.py's
-# is_sii_category_complete_legacy(). Duplicated here so the analyzer is
-# self-contained and the aggregation-registry replay activates all five v1
-# categories. Without this remap, only peg_stability and holder_distribution
-# would contribute (those are the two cat names that happen to overlap
-# between the legacy and v1 vocabularies), and every formula would score
-# SII entities on 40% of the definition, producing results uncomparable
-# across formulas.
-_SII_LEGACY_TO_V1_CATEGORY = {
-    "peg_stability": "peg_stability",
-    "liquidity": "liquidity_depth",
-    "market_activity": "mint_burn_dynamics",
-    "flows": "mint_burn_dynamics",
-    "holder_distribution": "holder_distribution",
-    "smart_contract": "structural_risk_composite",
-    "governance": "structural_risk_composite",
-    "transparency": "structural_risk_composite",
-    "regulatory": "structural_risk_composite",
-    "network": "structural_risk_composite",
-    "reserves": "structural_risk_composite",
-    "oracle": "structural_risk_composite",
-}
-
-
-def _sii_definition_with_v1_categories(definition: dict) -> dict:
-    """Return a shallow-cloned SII definition whose components' `category`
-    field uses v1 category names (matching `definition["categories"]` keys).
-
-    Non-destructive: never mutates the shared SII_V1_DEFINITION object.
-    """
-    new_components = {}
-    for cid, cdef in definition["components"].items():
-        new_cdef = dict(cdef)
-        legacy_cat = cdef.get("category")
-        new_cdef["category"] = _SII_LEGACY_TO_V1_CATEGORY.get(legacy_cat, legacy_cat)
-        new_components[cid] = new_cdef
-    out = dict(definition)
-    out["components"] = new_components
-    return out
+# Legacy→v1 SII category mapping lives on the definition as of SII v1.1.0.
+# Imported here for diagnostic/documentation purposes only; the analyzer's
+# replay reads `SII_V1_DEFINITION["components"][cid]["category"]` directly
+# (which is already the v1 name) and needs no local remapping.
+from app.index_definitions.sii_v1 import SII_LEGACY_TO_V1_CATEGORY as _SII_LEGACY_TO_V1_CATEGORY  # noqa: F401
 
 
 def analyze_sii() -> list[dict]:
@@ -268,22 +232,15 @@ def analyze_sii() -> list[dict]:
     by this replay, which matches production SII scoring behavior — the
     definition is the canonical component universe.
 
-    Note on category semantics: SII_V1_DEFINITION declares 5 v1 categories
-    (peg_stability, liquidity_depth, mint_burn_dynamics, holder_distribution,
-    structural_risk_composite) but its components inherit the 8-way legacy
-    category vocabulary from COMPONENT_NORMALIZATIONS. This analyzer applies
-    the canonical legacy→v1 remapping (see _SII_LEGACY_TO_V1_CATEGORY) to a
-    local copy of the definition so that every v1 category receives its
-    fair share of components during aggregation. Production's SII scorer in
-    app/worker.py::compute_sii_from_components applies the equivalent
-    mapping via aggregate_legacy_to_v1 / DB_TO_STRUCTURAL_MAPPING. Follow-up
-    ticket `sii-component-gap` covers full reconciliation between the
-    collector's 80 component_ids, the scorer's 56 declared components, and
-    the ~37 that overlap end-to-end.
+    Category semantics as of SII v1.1.0: the legacy→v1 category remap lives
+    inside `app/index_definitions/sii_v1.py::_build_components` so
+    `SII_V1_DEFINITION` presents v1 category labels on its components. No
+    local wrapping is required here; aggregate() activates all five v1
+    categories directly. Follow-up ticket `sii-component-gap` covers full
+    reconciliation between the collector's 80 component_ids, the scorer's 56
+    declared components, and the ~37 that overlap end-to-end.
     """
     from app.index_definitions.sii_v1 import SII_V1_DEFINITION
-
-    sii_definition = _sii_definition_with_v1_categories(SII_V1_DEFINITION)
 
     entities = _fetch_all(INDEX_SOURCES[0][3])
 
@@ -305,7 +262,7 @@ def analyze_sii() -> list[dict]:
             if r.get("normalized_score") is not None
         }
         rescored = rescore_entity_under_formulas(
-            sii_definition, component_scores, raw_values
+            SII_V1_DEFINITION, component_scores, raw_values
         )
         out.append({
             "index": "sii",

--- a/tests/test_sii_wiring.py
+++ b/tests/test_sii_wiring.py
@@ -1,0 +1,276 @@
+"""
+SII v1.1.0 wiring tests.
+
+Four tests locking the methodology clarification shipped in this PR:
+
+  a) Dispatch — aggregate() is invoked and the result carries the declared
+     formula name and params.
+  b) Divergence — legacy_renormalize vs coverage_weighted on a partially-
+     populated synthetic SII fixture produce different overalls. If they
+     agree, the formula migration is cosmetic.
+  c) Category-activation — all 5 v1 categories land in category_scores
+     when every component has a reading. Confirms the legacy→v1 remap
+     inside app/index_definitions/sii_v1.py::_build_components works.
+  d) Legacy reproducibility — the registry's `legacy_renormalize` formula
+     is NOT byte-for-byte identical to the pre-wiring SII path
+     (calculate_sii + aggregate_legacy_to_v1 + calculate_structural_composite)
+     because the old path averaged components within legacy categories
+     (ignoring COMPONENT_NORMALIZATIONS weights) whereas the registry
+     formulas apply those weights. This test captures the delta with a
+     ±0.05 tolerance so regressions surface loudly. See the PR description
+     and docs/methodology/sii_changelog.md for the methodology rationale.
+
+Plus an invariant check that the SII_LEGACY_TO_V1_CATEGORY mapping in the
+definition agrees with LEGACY_TO_V1_MAPPING in app/scoring.py. Divergence
+there would produce a silent category-assignment drift.
+"""
+from __future__ import annotations
+
+import pytest
+
+from app.composition import AGGREGATION_FORMULA_VERSION, aggregate
+from app.index_definitions.sii_v1 import (
+    SII_LEGACY_TO_V1_CATEGORY,
+    SII_V1_DEFINITION,
+)
+from app.scoring import (
+    COMPONENT_NORMALIZATIONS,
+    LEGACY_TO_V1_MAPPING,
+    SII_V1_WEIGHTS,
+    aggregate_legacy_to_v1,
+    calculate_sii,
+)
+
+
+# ---------------------------------------------------------------------------
+# Synthetic fixture
+# ---------------------------------------------------------------------------
+# Real component_ids chosen to land in each legacy category (so the v1 remap
+# activates every v1 category). Scores are deliberately heterogeneous so the
+# coverage-weighted vs legacy-renormalize paths diverge.
+#
+# (component_id, legacy_category, normalized_score)
+_FIXTURE = [
+    # peg_stability (v1: peg_stability)
+    ("peg_current_deviation", "peg_stability", 95.0),
+    ("peg_7d_stddev",         "peg_stability", 90.0),
+    # liquidity (v1: liquidity_depth)
+    ("market_cap",            "liquidity",     85.0),
+    ("volume_24h",            "liquidity",     80.0),
+    # flows (v1: mint_burn_dynamics)
+    ("daily_mint_volume",     "flows",         75.0),
+    ("daily_burn_volume",     "flows",         70.0),
+    # holder_distribution (v1: holder_distribution)
+    ("top_10_concentration",  "holder_distribution", 65.0),
+    ("unique_holders",        "holder_distribution", 60.0),
+    # structural_risk_composite (5 legacy subcats):
+    ("reserve_to_supply_ratio", "transparency",    90.0),  # transparency → structural
+    ("contract_verified",     "smart_contract",   55.0),  # smart_contract → structural
+    ("chain_count",           "network",          70.0),  # network → structural
+    ("dao_timelock_hours",    "governance",       40.0),  # governance → structural
+]
+
+
+def _verify_fixture_exists():
+    """Sanity: every fixture id must be in COMPONENT_NORMALIZATIONS and must
+    carry the declared legacy category."""
+    for comp_id, legacy_cat, _ in _FIXTURE:
+        assert comp_id in COMPONENT_NORMALIZATIONS, f"unknown component {comp_id}"
+        assert COMPONENT_NORMALIZATIONS[comp_id]["category"] == legacy_cat, (
+            f"{comp_id} is in {COMPONENT_NORMALIZATIONS[comp_id]['category']}, "
+            f"test fixture expects {legacy_cat}"
+        )
+
+
+def _fixture_component_scores():
+    return {cid: score for cid, _, score in _FIXTURE}
+
+
+def _fixture_raw_values():
+    # Aggregation formulas consume component_scores; raw_values flow through
+    # for downstream consumers. Supply 1.0 placeholders so no formula path
+    # short-circuits on missing raw data.
+    return {cid: 1.0 for cid, _, _ in _FIXTURE}
+
+
+# ---------------------------------------------------------------------------
+# Invariant: the two legacy→v1 mappings must agree
+# ---------------------------------------------------------------------------
+
+
+def test_legacy_and_v1_mappings_agree():
+    """app/index_definitions/sii_v1.SII_LEGACY_TO_V1_CATEGORY mirrors
+    app/scoring.LEGACY_TO_V1_MAPPING. Divergence would produce silent
+    category-assignment drift between the legacy SII path and the registry
+    path."""
+    _verify_fixture_exists()
+    # Every legacy cat referenced by COMPONENT_NORMALIZATIONS must map the
+    # same v1 name through both tables.
+    legacy_cats_in_use = {
+        spec["category"] for spec in COMPONENT_NORMALIZATIONS.values()
+    }
+    for legacy_cat in legacy_cats_in_use:
+        assert legacy_cat in SII_LEGACY_TO_V1_CATEGORY, (
+            f"{legacy_cat} missing from SII_LEGACY_TO_V1_CATEGORY"
+        )
+        assert legacy_cat in LEGACY_TO_V1_MAPPING, (
+            f"{legacy_cat} missing from scoring.LEGACY_TO_V1_MAPPING"
+        )
+        assert SII_LEGACY_TO_V1_CATEGORY[legacy_cat] == LEGACY_TO_V1_MAPPING[legacy_cat], (
+            f"legacy_cat={legacy_cat}: definition says "
+            f"{SII_LEGACY_TO_V1_CATEGORY[legacy_cat]}, scoring says "
+            f"{LEGACY_TO_V1_MAPPING[legacy_cat]}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Test a — Dispatch
+# ---------------------------------------------------------------------------
+
+
+def test_dispatch_emits_declared_formula_and_params():
+    """aggregate() on SII_V1_DEFINITION returns the declared formula name
+    and params on the result dict, confirming the declaration → dispatch
+    plumbing is live."""
+    cs = _fixture_component_scores()
+    rv = _fixture_raw_values()
+    result = aggregate(SII_V1_DEFINITION, cs, rv)
+    assert result["method"] == "coverage_weighted"
+    # params are declared on the definition and must land on the result.
+    declared = SII_V1_DEFINITION["aggregation"]["params"]
+    assert declared == {"min_coverage": 0.0}
+    # formula_version is the registry's version string — stable across the PR.
+    assert result["formula_version"] == AGGREGATION_FORMULA_VERSION
+    # The aggregation envelope fields every downstream consumer depends on.
+    for field in (
+        "overall_score", "category_scores", "effective_category_weights",
+        "coverage", "withheld", "method", "formula_version",
+    ):
+        assert field in result, f"aggregate() result missing {field}"
+    assert result["withheld"] is False  # min_coverage=0.0 never withholds
+    assert result["overall_score"] is not None
+
+
+# ---------------------------------------------------------------------------
+# Test b — Divergence
+# ---------------------------------------------------------------------------
+
+
+def test_legacy_renormalize_and_coverage_weighted_produce_different_overalls():
+    """On a partially-populated fixture, legacy_renormalize and
+    coverage_weighted must produce numerically different overalls. If they
+    agree, the declared migration is cosmetic — coverage_weighted's
+    effective-weight reweighting would have no effect and the report's
+    Section B deltas wouldn't materialize."""
+    cs = _fixture_component_scores()
+    rv = _fixture_raw_values()
+
+    legacy_def = dict(SII_V1_DEFINITION)
+    legacy_def["aggregation"] = {"formula": "legacy_renormalize", "params": {}}
+    legacy_result = aggregate(legacy_def, cs, rv)
+
+    cw_def = dict(SII_V1_DEFINITION)
+    cw_def["aggregation"] = {"formula": "coverage_weighted", "params": {"min_coverage": 0.0}}
+    cw_result = aggregate(cw_def, cs, rv)
+
+    legacy_overall = legacy_result["overall_score"]
+    cw_overall = cw_result["overall_score"]
+    assert legacy_overall is not None
+    assert cw_overall is not None
+    assert abs(legacy_overall - cw_overall) > 0.01, (
+        f"legacy_renormalize={legacy_overall} vs coverage_weighted={cw_overall}; "
+        f"formulas produced identical overalls — partial-category reweighting "
+        f"has no effect on this fixture"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test c — Category activation
+# ---------------------------------------------------------------------------
+
+
+def test_all_five_v1_categories_activate_when_fully_populated():
+    """When every component in SII_V1_DEFINITION has a reading, all 5 v1
+    categories populate in category_scores. Confirms the legacy→v1 remap
+    inside _build_components works — without the remap, only peg_stability
+    and holder_distribution would land (the two names that happen to
+    overlap between the legacy and v1 vocabularies)."""
+    cs = {cid: 80.0 for cid in SII_V1_DEFINITION["components"]}
+    rv = {cid: 1.0 for cid in SII_V1_DEFINITION["components"]}
+    result = aggregate(SII_V1_DEFINITION, cs, rv)
+    expected_v1_cats = {
+        "peg_stability", "liquidity_depth", "mint_burn_dynamics",
+        "holder_distribution", "structural_risk_composite",
+    }
+    got_cats = set(result["category_scores"].keys())
+    assert got_cats == expected_v1_cats, (
+        f"expected {expected_v1_cats}, got {got_cats}"
+    )
+    # With all components at 80, the overall must be exactly 80.
+    assert result["overall_score"] == 80.0
+
+
+# ---------------------------------------------------------------------------
+# Test d — Legacy reproducibility characterization
+# ---------------------------------------------------------------------------
+
+
+def test_registry_legacy_renormalize_differs_from_production_legacy_path():
+    """The registry's legacy_renormalize is NOT byte-for-byte identical to
+    the pre-wiring SII path (calculate_sii + aggregate_legacy_to_v1 +
+    calculate_structural_composite) because the old path averaged
+    components within legacy categories ignoring COMPONENT_NORMALIZATIONS
+    weights, whereas the registry applies those weights. This is a
+    characterization test — it locks the specific delta for the synthetic
+    fixture so any regression surfaces loudly.
+
+    This divergence is the methodology clarification stated in the SII
+    v1.1.0 wiring PR: new scores use v1 categories directly with
+    component-level weights; structural subcategory weights and the legacy
+    three-level aggregation remain accessible only via the `legacy_sii_v1`
+    formula slot for historical reproducibility.
+    """
+    cs = _fixture_component_scores()
+    rv = _fixture_raw_values()
+
+    # Path A: pre-wiring SII path — legacy-category simple averages + SII_V1_WEIGHTS
+    legacy_cat_sums: dict[str, list[float]] = {}
+    for comp_id, legacy_cat, score in _FIXTURE:
+        legacy_cat_sums.setdefault(legacy_cat, []).append(score)
+    legacy_avgs = {cat: sum(v) / len(v) for cat, v in legacy_cat_sums.items()}
+    v1_scores = aggregate_legacy_to_v1(legacy_avgs)
+    pre_wiring_overall = calculate_sii(v1_scores)
+
+    # Path B: registry legacy_renormalize on SII_V1_DEFINITION
+    legacy_def = dict(SII_V1_DEFINITION)
+    legacy_def["aggregation"] = {"formula": "legacy_renormalize", "params": {}}
+    registry_result = aggregate(legacy_def, cs, rv)
+    registry_overall = registry_result["overall_score"]
+
+    assert pre_wiring_overall is not None
+    assert registry_overall is not None
+
+    # Document the observed delta so a future refactor that accidentally
+    # realigns the paths trips this test. If the paths ever converge, this
+    # test should be updated alongside a deliberate methodology note.
+    #
+    # Observed on this fixture (12 components; 2 per v1 category except
+    # structural which gets 4 across 4 legacy subcategories):
+    #   pre-wiring (legacy-avg → aggregate_legacy_to_v1 → calculate_sii): 79.02
+    #   registry legacy_renormalize (per-component weights inside v1 cats):  78.75
+    #   delta = -0.27
+    # The registry value is lower because structural's 4 populated legacy
+    # subcategories average to a higher value under simple-average (55+70+40+90
+    # → 63.75) than under the per-component-weight reweighting across the full
+    # structural_risk_composite v1 category. Exact delta depends on
+    # COMPONENT_NORMALIZATIONS weights; lock with a ±0.05 tolerance so a future
+    # weights change that shifts it surfaces here.
+    delta = registry_overall - pre_wiring_overall
+    expected_delta = -0.27
+    assert abs(delta - expected_delta) < 0.05, (
+        f"pre_wiring={pre_wiring_overall}, registry={registry_overall}, "
+        f"delta={delta:+.2f}, expected {expected_delta:+.2f}±0.05. "
+        f"If the legacy path or COMPONENT_NORMALIZATIONS weights changed "
+        f"intentionally, recalibrate this test and add a note to "
+        f"docs/methodology/sii_changelog.md."
+    )


### PR DESCRIPTION
## Summary

SII v1.1.0 declared `aggregation: coverage_weighted, min_coverage=0.0` in commit `26101b7` but the production path in `app/worker.py::compute_sii_from_components` continued to call `app/scoring.py::calculate_sii` + `calculate_structural_composite`. This PR closes the declaration/behavior gap.

## Methodology clarification

This PR flattens SII from three-level aggregation (components → legacy categories → structural subcategories → v1 categories → overall) to two-level (components → v1 categories → overall). Structural subcategory weights and the legacy→v1 category remap are preserved only for historical reproducibility under the `legacy_sii_v1` formula. New SII scores use the v1 category structure directly with component-level weights from `COMPONENT_NORMALIZATIONS`.

**Expected movement: USDC 93.36 → 94.60** per Section B of `docs/methodology/aggregation_impact_analysis.md`. Full 36-entity expected-value table frozen in `docs/methodology/sii_wiring_acceptance.md`.

## What changed

- `app/index_definitions/sii_v1.py` — `SII_LEGACY_TO_V1_CATEGORY` added (moved from analyzer's local copy); `_build_components` remaps component categories to v1 names.
- `app/worker.py::compute_sii_from_components` — dispatches via `aggregate(SII_V1_DEFINITION, ...)`. Structural sub-scores preserved as informational outputs.
- `app/worker.py::store_score` — persists the six aggregation envelope fields (columns added by migration 084).
- `app/server.py` — `/api/scores`, `/api/scores/{coin}`, `/api/indices` emit aggregation fields.
- `app/composition.py` — comments on `compute_cqi`/`compute_rqs` flag `basis-hub#cqi-rqs-reattestation`.
- `app/scoring.py` — docstrings mark `calculate_sii`, `calculate_structural_composite`, `STRUCTURAL_SUBWEIGHTS`, `DB_TO_STRUCTURAL_MAPPING` as legacy-only reference backing `legacy_sii_v1`. Code unchanged.
- `scripts/analyze_aggregation_impact.py` — local SII category remap removed; imports shared mapping.

No new migration. No weights/categories/components/normalization changed. No change to `is_category_complete` or the promotion gate. Historical score rows preserve their original `overall_score` and `formula_version` per V9.9.

## Expected before → after (spot checks from Section B cw@0.0)

| Entity | Before (legacy) | After (cw@0.0) |
|---|---|---|
| USDC | 93.36 | 94.60 |
| USDT | 89.44 | 90.44 |
| DAI | 84.52 | 85.77 |
| PYUSD | 79.37 | 81.92 |
| FRAX | 65.84 | 67.12 |

Full table: `docs/methodology/sii_wiring_acceptance.md`. ±0.10 tolerance on first post-deploy cycle; exceedances are discrepancy reports, not rollback triggers.

## Tests

`tests/test_sii_wiring.py` — 5 tests, all passing:
- `test_legacy_and_v1_mappings_agree` — invariant that `SII_LEGACY_TO_V1_CATEGORY` mirrors `LEGACY_TO_V1_MAPPING` in `app/scoring.py`.
- `test_dispatch_emits_declared_formula_and_params` — confirms `aggregate()` result carries `method='coverage_weighted'` + declared params + full envelope.
- `test_legacy_renormalize_and_coverage_weighted_produce_different_overalls` — formulas diverge numerically on partial-coverage fixture.
- `test_all_five_v1_categories_activate_when_fully_populated` — legacy→v1 remap works inside `_build_components`.
- `test_registry_legacy_renormalize_differs_from_production_legacy_path` — characterization test: locks the −0.27 ±0.05 delta between registry `legacy_renormalize` and the pre-wiring three-level SII path.

55/55 non-env tests pass. `e2e_test.py` + `test_contract_upgrades.py` require live server/DB (ConnectionError in sandbox, unrelated).

## Acceptance runbook

`docs/methodology/sii_wiring_acceptance.md` ships with:
- Frozen 36-entity expected-values table, tagged to commit `26101b7`.
- psql one-liner to pull first post-deploy overalls + aggregation envelope.
- Rollback trigger: `aggregation_method IS NULL` on v1.1.0-cycle rows, or systematic regression toward pre-wiring values.

## Follow-ups not in this PR

- **CQI/RQS re-attestation**: `basis-hub#cqi-rqs-reattestation`. Comments added near `compute_cqi` and `compute_rqs`.
- **V9.9 append**: `docs/basis_protocol_v9_9_constitution_amendment.md` is not in the repo; append-only status note pending the file being added.

References: commit `26101b7` (declaration), `docs/methodology/aggregation_impact_analysis.md` (Section B), `docs/methodology/sii_wiring_acceptance.md` (frozen targets).

https://claude.ai/code/session_012Kdm7QyJLDSmGyrjiXueqx