### PR TITLE
fix(keeper): normalize addresses at ingest, guard on-chain fetch, capture stacks

### DIFF
--- a/keeper/converter.ts
+++ b/keeper/converter.ts
@@ -44,11 +44,11 @@ export const TOKEN_ADDRESSES: Record<string, string> = {
   dai:   "0x6b175474e89094c44da98b954eedeac495271d0f",
   frax:  "0x853d955acef822db058eb8505911ed77f175b99e",
   pyusd: "0x6c3ea9036406852006290770bedfcaba0e23a0e8",
-  fdusd: "0xc5f0f7b66764F6ec8C8Dff7BA683102295E16409",
-  tusd:  "0x0000000000085d4780B73119b644AE5ecd22b376",
-  usdd:  "0x0C10bF8FcB7Bf5412187A595ab97a3609160b5c6",
-  usde:  "0x4c9EDD5852cd905f086C759E8383e09bff1E68B3",
-  usd1:  "0x8d0D000Ee44948FC98c9B98A4FA4921476f08B0d",
+  fdusd: "0xc5f0f7b66764f6ec8c8dff7ba683102295e16409",
+  tusd:  "0x0000000000085d4780b73119b644ae5ecd22b376",
+  usdd:  "0x0c10bf8fcb7bf5412187a595ab97a3609160b5c6",
+  usde:  "0x4c9edd5852cd905f086c759e8383e09bff1e68b3",
+  usd1:  "0x8d0d000ee44948fc98c9b98a4fa4921476f08b0d",
 };
 
 export function tokenIdToAddress(id: string): string | undefined {

--- a/keeper/index.ts
+++ b/keeper/index.ts
@@ -119,7 +119,7 @@ function buildTokenAddressMap(apiScores: ApiScore[]): Record<string, string> {
 
   for (const s of apiScores) {
     if (s.token_contract) {
-      dynamic[s.id.toLowerCase()] = s.token_contract;
+      dynamic[s.id.toLowerCase()] = s.token_contract.toLowerCase();
     } else {
       missingCount++;
     }
@@ -173,10 +173,17 @@ async function runCycle(
   }
 
   // 2. Diff on-chain state for both chains in parallel
-  const [onChainBase, onChainArb] = await Promise.all([
+  const [onChainBaseResult, onChainArbResult] = await Promise.allSettled([
     fetchOnChainScores(providerBase, config.chains.base.oracleAddress),
     fetchOnChainScores(providerArb, config.chains.arbitrum.oracleAddress),
   ]);
+
+  const onChainBase = onChainBaseResult.status === "fulfilled"
+    ? onChainBaseResult.value
+    : (() => { logger.error("Failed to fetch on-chain scores from Base", { error: onChainBaseResult.reason?.stack ?? String(onChainBaseResult.reason) }); return new Map<string, import("./differ.js").OnChainScore>(); })();
+  const onChainArb = onChainArbResult.status === "fulfilled"
+    ? onChainArbResult.value
+    : (() => { logger.error("Failed to fetch on-chain scores from Arbitrum", { error: onChainArbResult.reason?.stack ?? String(onChainArbResult.reason) }); return new Map<string, import("./differ.js").OnChainScore>(); })();
 
   const updatesBase = computeUpdates(
     apiScores,
@@ -508,7 +515,7 @@ async function main(): Promise<void> {
       await runCycle(config, walletBase, walletArb, providerBase, providerArb);
     } catch (err) {
       const msg = `Unhandled error in keeper cycle`;
-      const errStr = err instanceof Error ? err.message : String(err);
+      const errStr = err instanceof Error ? (err.stack ?? err.message) : String(err);
       logger.error(msg, { error: errStr });
       cycleErrors.push(errStr);
       await sendAlert(msg, err);
@@ -527,7 +534,7 @@ async function main(): Promise<void> {
 }
 
 main().catch(async (err) => {
-  logger.error("Fatal keeper error", { error: err instanceof Error ? err.message : String(err) });
+  logger.error("Fatal keeper error", { error: err instanceof Error ? (err.stack ?? err.message) : String(err) });
   await sendAlert("Keeper crashed — fatal error", err);
   process.exit(1);
 });


### PR DESCRIPTION
## Summary
- **Normalize addresses**: Lowercase all 5 mixed-case entries in `TOKEN_ADDRESSES` (fdusd, tusd, usdd, usde, usd1) and lowercase API `token_contract` at ingest in `buildTokenAddressMap` so dynamic map matches on-chain keys
- **Guard on-chain fetch**: Switch `fetchOnChainScores` from `Promise.all` to `Promise.allSettled` so one chain's RPC failure doesn't kill the entire cycle — failed chain gets an empty map instead
- **Capture stacks**: Cycle-level and fatal catch blocks now log `err.stack` instead of `err.message`, preserving call site for post-mortem

## Test plan
- [ ] Verify keeper starts and completes a dry-run cycle (`npx tsx keeper/index.ts --dry-run`)
- [ ] Confirm mixed-case token addresses (fdusd, usd1, etc.) match on-chain lookups
- [ ] Simulate one chain RPC timeout — cycle should complete for the other chain
- [ ] Trigger a cycle error and confirm stack trace appears in logs

https://claude.ai/code/session_011bTVc5haorCZgtCtxzJmtq