### PR TITLE
feat(disputes): schema, API, ops dashboard for score dispute lifecycle

### DIFF
--- a/app/disputes.py
+++ b/app/disputes.py
@@ -1,0 +1,176 @@
+"""
+Disputes — Score Dispute Lifecycle
+====================================
+Manages the submission, counter-evidence, and resolution lifecycle
+for disputes against scored entities. Each lifecycle step produces
+a content-hashed transition for on-chain anchoring.
+"""
+
+import hashlib
+import json
+import logging
+from datetime import datetime, timezone
+from decimal import Decimal
+
+from app.database import fetch_all, fetch_one, execute, get_cursor
+
+logger = logging.getLogger(__name__)
+
+
+def _serialize(obj):
+    """JSON serializer for objects not serializable by default."""
+    if isinstance(obj, Decimal):
+        return float(obj)
+    if isinstance(obj, datetime):
+        return obj.isoformat()
+    if hasattr(obj, "isoformat"):
+        return obj.isoformat()
+    return str(obj)
+
+
+def _compute_transition_hash(dispute_id: str, transition_index: int, payload: dict) -> str:
+    """SHA-256 of canonical JSON of {dispute_id, transition_index, payload}."""
+    canonical = json.dumps({
+        "dispute_id": str(dispute_id),
+        "transition_index": transition_index,
+        "payload": payload,
+    }, sort_keys=True, separators=(",", ":"), default=_serialize)
+    return hashlib.sha256(canonical.encode()).hexdigest()
+
+
+def compute_on_chain_entity_id(transition: dict) -> str:
+    """Compute deterministic bytes32 entityId for on-chain anchoring.
+
+    Uses keccak256 (with sha256 fallback) of canonical
+    {dispute_id, transition_index, transition_kind}.
+    Returns 0x-prefixed hex string.
+    """
+    canonical = json.dumps({
+        "dispute_id": str(transition.get("dispute_id", "")),
+        "transition_index": transition.get("transition_index", 0),
+        "transition_kind": transition.get("transition_kind", ""),
+    }, sort_keys=True, separators=(",", ":"))
+    try:
+        import sha3
+        h = sha3.keccak_256(canonical.encode()).hexdigest()
+    except ImportError:
+        h = hashlib.sha256(canonical.encode()).hexdigest()
+    return "0x" + h
+
+
+def submit_dispute(entity_slug: str, submitter_identifier: str, submitter_type: str,
+                   submission_text: str, submission_evidence_url: str = None,
+                   disputed_score_content_hash: str = None) -> str:
+    """Submit a new dispute. Creates the dispute row and transition_index=0 submission transition.
+
+    Returns dispute_id (UUID string).
+    """
+    with get_cursor() as cur:
+        # Insert dispute
+        cur.execute(
+            """INSERT INTO disputes
+               (entity_slug, disputed_score_content_hash, submitter_identifier,
+                submitter_type, submission_text, submission_evidence_url, status, created_at)
+               VALUES (%s, %s, %s, %s, %s, %s, 'submitted', NOW())
+               RETURNING dispute_id""",
+            (entity_slug, disputed_score_content_hash, submitter_identifier,
+             submitter_type, submission_text, submission_evidence_url),
+        )
+        row = cur.fetchone()
+        dispute_id = str(row[0]) if isinstance(row, tuple) else str(row["dispute_id"])
+
+        # Build submission transition payload
+        payload = {
+            "entity_slug": entity_slug,
+            "submitter_identifier": submitter_identifier,
+            "submitter_type": submitter_type,
+            "submission_text": submission_text,
+            "submission_evidence_url": submission_evidence_url,
+            "disputed_score_content_hash": disputed_score_content_hash,
+        }
+        content_hash = _compute_transition_hash(dispute_id, 0, payload)
+
+        cur.execute(
+            """INSERT INTO dispute_transitions
+               (dispute_id, transition_index, transition_kind, transition_payload,
+                content_hash, created_at)
+               VALUES (%s::uuid, 0, 'submission', %s, %s, NOW())""",
+            (dispute_id, json.dumps(payload, default=_serialize), content_hash),
+        )
+
+    logger.info(f"Dispute submitted: {dispute_id} for entity {entity_slug}")
+    return dispute_id
+
+
+def issue_counter_evidence(dispute_id: str, payload_dict: dict, author: str) -> str:
+    """Add counter-evidence transition (transition_index=1).
+
+    Updates dispute status to 'counter_evidence_issued'.
+    Returns transition_id (UUID string).
+    """
+    payload = {
+        **payload_dict,
+        "author": author,
+    }
+    content_hash = _compute_transition_hash(dispute_id, 1, payload)
+
+    with get_cursor() as cur:
+        cur.execute(
+            """INSERT INTO dispute_transitions
+               (dispute_id, transition_index, transition_kind, transition_payload,
+                content_hash, created_at)
+               VALUES (%s::uuid, 1, 'counter_evidence', %s, %s, NOW())
+               RETURNING transition_id""",
+            (dispute_id, json.dumps(payload, default=_serialize), content_hash),
+        )
+        row = cur.fetchone()
+        transition_id = str(row[0]) if isinstance(row, tuple) else str(row["transition_id"])
+
+        cur.execute(
+            """UPDATE disputes SET status = 'counter_evidence_issued'
+               WHERE dispute_id = %s::uuid""",
+            (dispute_id,),
+        )
+
+    logger.info(f"Counter-evidence issued for dispute {dispute_id}")
+    return transition_id
+
+
+def resolve_dispute(dispute_id: str, resolution_category: str,
+                    resolution_narrative: str, author: str) -> str:
+    """Add resolution transition (transition_index=2).
+
+    Updates dispute: status='resolved', resolved_at=NOW(), resolution fields.
+    Returns transition_id (UUID string).
+    """
+    payload = {
+        "resolution_category": resolution_category,
+        "resolution_narrative": resolution_narrative,
+        "author": author,
+    }
+    content_hash = _compute_transition_hash(dispute_id, 2, payload)
+
+    with get_cursor() as cur:
+        cur.execute(
+            """INSERT INTO dispute_transitions
+               (dispute_id, transition_index, transition_kind, transition_payload,
+                content_hash, created_at)
+               VALUES (%s::uuid, 2, 'resolution', %s, %s, NOW())
+               RETURNING transition_id""",
+            (dispute_id, json.dumps(payload, default=_serialize), content_hash),
+        )
+        row = cur.fetchone()
+        transition_id = str(row[0]) if isinstance(row, tuple) else str(row["transition_id"])
+
+        cur.execute(
+            """UPDATE disputes
+               SET status = 'resolved',
+                   resolved_at = NOW(),
+                   resolution_category = %s,
+                   resolution_narrative = %s
+               WHERE dispute_id = %s::uuid""",
+            (resolution_category, resolution_narrative, dispute_id),
+        )
+
+    logger.info(f"Dispute resolved: {dispute_id} — {resolution_category}")
+    return transition_id

--- a/app/ops/routes.py
+++ b/app/ops/routes.py
@@ -3440,6 +3440,190 @@ async def track_record_on_chain_status(request: Request):
         return JSONResponse({"error": str(e)}, status_code=500)
 
 
+# =============================================================================
+# Disputes
+# =============================================================================
+
+@router.post("/disputes")
+async def submit_dispute(request: Request):
+    _check_admin_key(request)
+    try:
+        body = await request.json()
+        required = ["entity_slug", "submitter_identifier", "submitter_type", "submission_text"]
+        for field in required:
+            if not body.get(field):
+                return JSONResponse({"error": f"{field} required"}, status_code=400)
+        if body["submitter_type"] not in ("issuer", "third_party", "regulator", "anonymous"):
+            return JSONResponse({"error": "submitter_type must be one of: issuer, third_party, regulator, anonymous"}, status_code=400)
+
+        from app.disputes import submit_dispute as _submit
+        dispute_id = _submit(
+            entity_slug=body["entity_slug"],
+            submitter_identifier=body["submitter_identifier"],
+            submitter_type=body["submitter_type"],
+            submission_text=body["submission_text"],
+            submission_evidence_url=body.get("submission_evidence_url"),
+            disputed_score_content_hash=body.get("disputed_score_content_hash"),
+        )
+        return {"status": "ok", "dispute_id": dispute_id}
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"Dispute submission failed: {e}")
+        return JSONResponse({"error": str(e), "traceback": _traceback_mod.format_exc()}, status_code=500)
+
+
+@router.post("/disputes/{dispute_id}/counter-evidence")
+async def dispute_counter_evidence(dispute_id: str, request: Request):
+    _check_admin_key(request)
+    try:
+        body = await request.json()
+        if not body.get("payload"):
+            return JSONResponse({"error": "payload required"}, status_code=400)
+        if not body.get("author"):
+            return JSONResponse({"error": "author required"}, status_code=400)
+
+        from app.disputes import issue_counter_evidence
+        transition_id = issue_counter_evidence(
+            dispute_id=dispute_id,
+            payload_dict=body["payload"],
+            author=body["author"],
+        )
+        return {"status": "ok", "transition_id": transition_id}
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"Counter-evidence failed: {e}")
+        return JSONResponse({"error": str(e), "traceback": _traceback_mod.format_exc()}, status_code=500)
+
+
+@router.post("/disputes/{dispute_id}/resolve")
+async def dispute_resolve(dispute_id: str, request: Request):
+    _check_admin_key(request)
+    try:
+        body = await request.json()
+        if not body.get("resolution_category"):
+            return JSONResponse({"error": "resolution_category required"}, status_code=400)
+        if body["resolution_category"] not in ("accepted", "partially_accepted", "rejected"):
+            return JSONResponse({"error": "resolution_category must be one of: accepted, partially_accepted, rejected"}, status_code=400)
+        if not body.get("resolution_narrative"):
+            return JSONResponse({"error": "resolution_narrative required"}, status_code=400)
+        if not body.get("author"):
+            return JSONResponse({"error": "author required"}, status_code=400)
+
+        from app.disputes import resolve_dispute
+        transition_id = resolve_dispute(
+            dispute_id=dispute_id,
+            resolution_category=body["resolution_category"],
+            resolution_narrative=body["resolution_narrative"],
+            author=body["author"],
+        )
+        return {"status": "ok", "transition_id": transition_id}
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"Dispute resolution failed: {e}")
+        return JSONResponse({"error": str(e), "traceback": _traceback_mod.format_exc()}, status_code=500)
+
+
+@router.get("/disputes")
+async def list_disputes(request: Request, status: Optional[str] = None):
+    _check_admin_key(request)
+    try:
+        if status:
+            rows = fetch_all(
+                "SELECT * FROM disputes WHERE status = %s ORDER BY created_at DESC",
+                (status,),
+            )
+        else:
+            rows = fetch_all("SELECT * FROM disputes ORDER BY created_at DESC")
+        return {"disputes": [dict(r) for r in rows] if rows else []}
+    except Exception as e:
+        return JSONResponse({"error": str(e)}, status_code=500)
+
+
+@router.get("/disputes/pending-on-chain")
+async def disputes_pending_on_chain(request: Request, chain: str = "base"):
+    _check_admin_key(request)
+    if chain not in ("base", "arbitrum"):
+        return JSONResponse({"error": "chain must be 'base' or 'arbitrum'"}, status_code=400)
+
+    col = f"committed_on_chain_{chain}"
+    try:
+        from app.disputes import compute_on_chain_entity_id
+        rows = fetch_all(
+            f"SELECT * FROM dispute_transitions WHERE {col} = FALSE ORDER BY created_at"
+        )
+        results = []
+        for r in (rows or []):
+            entry = dict(r)
+            entry["entity_id_bytes32"] = compute_on_chain_entity_id(entry)
+            if isinstance(entry.get("transition_payload"), str):
+                entry["transition_payload"] = json.loads(entry["transition_payload"])
+            results.append(entry)
+        return results
+    except Exception as e:
+        return JSONResponse({"error": str(e)}, status_code=500)
+
+
+@router.get("/disputes/{dispute_id}")
+async def get_dispute(dispute_id: str, request: Request):
+    _check_admin_key(request)
+    try:
+        dispute = fetch_one(
+            "SELECT * FROM disputes WHERE dispute_id = %s::uuid", (dispute_id,)
+        )
+        if not dispute:
+            return JSONResponse({"error": "dispute not found"}, status_code=404)
+
+        transitions = fetch_all(
+            "SELECT * FROM dispute_transitions WHERE dispute_id = %s::uuid ORDER BY transition_index",
+            (dispute_id,),
+        )
+        result = dict(dispute)
+        result["transitions"] = [dict(t) for t in transitions] if transitions else []
+        for t in result["transitions"]:
+            if isinstance(t.get("transition_payload"), str):
+                t["transition_payload"] = json.loads(t["transition_payload"])
+        return result
+    except Exception as e:
+        return JSONResponse({"error": str(e)}, status_code=500)
+
+
+@router.post("/disputes/transitions/{transition_id}/committed/{chain}")
+async def dispute_transition_mark_committed(transition_id: str, chain: str, request: Request):
+    _check_admin_key(request)
+    if chain not in ("base", "arbitrum"):
+        return JSONResponse({"error": "chain must be 'base' or 'arbitrum'"}, status_code=400)
+
+    body = await request.json()
+    tx_hash = body.get("tx_hash")
+    if not tx_hash:
+        return JSONResponse({"error": "tx_hash required"}, status_code=400)
+
+    col_flag = f"committed_on_chain_{chain}"
+    col_hash = f"on_chain_tx_hash_{chain}"
+    try:
+        existing = fetch_one(
+            "SELECT transition_id FROM dispute_transitions WHERE transition_id = %s::uuid",
+            (transition_id,),
+        )
+        if not existing:
+            return JSONResponse({"error": "transition not found"}, status_code=404)
+
+        execute(
+            f"""UPDATE dispute_transitions
+                SET {col_flag} = TRUE,
+                    {col_hash} = %s,
+                    committed_at = COALESCE(committed_at, NOW())
+                WHERE transition_id = %s::uuid""",
+            (tx_hash, transition_id),
+        )
+        return {"status": "ok", "transition_id": transition_id, "chain": chain, "tx_hash": tx_hash}
+    except Exception as e:
+        return JSONResponse({"error": str(e)}, status_code=500)
+
+
 def register_ops_routes(app):
     """Register the ops router with the main FastAPI app."""
     app.include_router(router)

--- a/app/server.py
+++ b/app/server.py
@@ -1096,6 +1096,90 @@ async def entity_page(slug: str, request: Request):
     })
 
 
+@app.get("/disputes")
+async def disputes_ssr_page():
+    """Server-rendered HTML page listing public disputes."""
+    from starlette.concurrency import run_in_threadpool
+    from fastapi.responses import HTMLResponse
+
+    def _load_disputes():
+        return fetch_all(
+            "SELECT * FROM disputes WHERE status != 'submitted' ORDER BY created_at DESC LIMIT 100"
+        )
+
+    try:
+        rows = await run_in_threadpool(_load_disputes)
+    except Exception:
+        rows = []
+
+    dispute_rows_html = ""
+    for r in (rows or []):
+        d = dict(r)
+        status_color = {
+            "under_review": "#f39c12",
+            "counter_evidence_issued": "#3498db",
+            "resolved": "#27ae60",
+            "withdrawn": "#95a5a6",
+        }.get(d.get("status", ""), "#999")
+        resolution = ""
+        if d.get("resolution_category"):
+            resolution = f' <span style="font-size:10px;color:#666">({d["resolution_category"]})</span>'
+        created = str(d.get("created_at", ""))[:10]
+        dispute_rows_html += f"""<tr>
+<td><a href="/api/disputes/{d['dispute_id']}" style="color:#0a0a0a;font-family:'IBM Plex Mono',monospace;font-size:11px">{str(d['dispute_id'])[:8]}...</a></td>
+<td style="font-weight:600">{d.get('entity_slug', '')}</td>
+<td>{d.get('submitter_type', '')}</td>
+<td><span style="color:{status_color};font-weight:600">{d.get('status', '')}</span>{resolution}</td>
+<td style="color:#666">{created}</td>
+</tr>"""
+
+    if not dispute_rows_html:
+        dispute_rows_html = '<tr><td colspan="5" style="text-align:center;color:#999;padding:24px">No public disputes yet.</td></tr>'
+
+    html = f"""<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Score Disputes | Basis Protocol</title>
+<meta name="description" content="Public record of score disputes submitted against Basis Protocol indices.">
+<link rel="canonical" href="https://basisprotocol.xyz/disputes">
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;600;700&family=IBM+Plex+Sans:wght@400;600;700&display=swap" rel="stylesheet">
+<style>
+body {{ margin:0; background:#f5f2ec; color:#0a0a0a; font-family:'IBM Plex Sans',system-ui,sans-serif; }}
+.page-wrap {{ max-width:900px; margin:0 auto; padding:24px 16px; }}
+h1 {{ font-size:28px; font-weight:400; letter-spacing:-0.3px; margin:0 0 8px; }}
+.meta {{ font-family:'IBM Plex Mono',monospace; font-size:11px; color:#6a6a6a; }}
+table {{ width:100%; border-collapse:collapse; margin-top:20px; }}
+th {{ text-align:left; font-family:'IBM Plex Mono',monospace; font-size:10px; font-weight:600;
+     color:#6a6a6a; text-transform:uppercase; letter-spacing:0.5px; padding:8px 6px;
+     border-bottom:2px solid #c8c4bc; }}
+td {{ padding:8px 6px; font-size:12px; border-bottom:1px solid #e0ddd6; }}
+a {{ color:#0a0a0a; }}
+.footer {{ margin-top:32px; padding-top:12px; border-top:1px solid #c8c4bc;
+           font-family:'IBM Plex Mono',monospace; font-size:10px; color:#9a9a9a;
+           display:flex; justify-content:space-between; }}
+</style>
+</head>
+<body>
+<div class="page-wrap">
+<p class="meta"><a href="/">Basis Protocol</a> &rsaquo; Disputes</p>
+<h1>Score Disputes</h1>
+<p class="meta">Public record of disputes submitted against scored entities. Disputes become visible once they move to review.</p>
+<table>
+<thead><tr><th>ID</th><th>Entity</th><th>Submitter</th><th>Status</th><th>Submitted</th></tr></thead>
+<tbody>{dispute_rows_html}</tbody>
+</table>
+<p class="meta" style="margin-top:16px">Data also available via <a href="/api/disputes">API</a>.</p>
+<div class="footer"><span>Basis Protocol</span><span>basisprotocol.xyz</span></div>
+</div>
+</body>
+</html>"""
+
+    return HTMLResponse(content=html, headers={"Cache-Control": "public, max-age=120"})
+
+
 @app.get("/sitemap.xml")
 async def sitemap_xml():
     """Dynamic sitemap listing all entity pages."""
@@ -4347,6 +4431,60 @@ async def verify_assessment(assessment_id: str):
             "recomputed_inputs_hash": recomputed_hash,
         },
     }
+
+
+# =============================================================================
+# Disputes — Public API
+# =============================================================================
+
+@app.get("/api/disputes")
+async def public_list_disputes(status: Optional[str] = None):
+    """Public dispute listing. Only shows disputes that have moved past 'submitted' status."""
+    try:
+        if status:
+            if status == "submitted":
+                return {"disputes": []}
+            rows = fetch_all(
+                "SELECT * FROM disputes WHERE status = %s AND status != 'submitted' ORDER BY created_at DESC",
+                (status,),
+            )
+        else:
+            rows = fetch_all(
+                "SELECT * FROM disputes WHERE status != 'submitted' ORDER BY created_at DESC"
+            )
+        return {"disputes": [dict(r) for r in rows] if rows else []}
+    except Exception as e:
+        return JSONResponse(status_code=500, content={"error": str(e)})
+
+
+@app.get("/api/disputes/{dispute_id}")
+async def public_get_dispute(dispute_id: str):
+    """Public single-dispute view. Only visible if status != 'submitted'."""
+    try:
+        dispute = fetch_one(
+            "SELECT * FROM disputes WHERE dispute_id = %s::uuid AND status != 'submitted'",
+            (dispute_id,),
+        )
+        if not dispute:
+            raise HTTPException(status_code=404, detail="Dispute not found or not yet public")
+
+        transitions = fetch_all(
+            "SELECT * FROM dispute_transitions WHERE dispute_id = %s::uuid ORDER BY transition_index",
+            (dispute_id,),
+        )
+        result = dict(dispute)
+        result["transitions"] = []
+        for t in (transitions or []):
+            td = dict(t)
+            if isinstance(td.get("transition_payload"), str):
+                import json as _json
+                td["transition_payload"] = _json.loads(td["transition_payload"])
+            result["transitions"].append(td)
+        return result
+    except HTTPException:
+        raise
+    except Exception as e:
+        return JSONResponse(status_code=500, content={"error": str(e)})
 
 
 # =============================================================================

--- a/frontend/src/pages/OpsDashboard.jsx
+++ b/frontend/src/pages/OpsDashboard.jsx
@@ -3217,6 +3217,97 @@ function TrackRecordPanel() {
 }
 
 
+function DisputesPanel() {
+  const [disputes, setDisputes] = useState([]);
+  const [loading, setLoading] = useState(false);
+  const [flash, showFlash] = useFlash();
+
+  const load = async () => {
+    setLoading(true);
+    try {
+      const res = await opsFetch("/api/ops/disputes");
+      setDisputes(res.disputes || []);
+    } catch (e) {
+      showFlash(e.message, false);
+    }
+    setLoading(false);
+  };
+
+  useEffect(() => { load(); }, []);
+
+  const statusColor = (s) => ({
+    submitted: "#3498db",
+    under_review: "#f39c12",
+    counter_evidence_issued: "#8e44ad",
+    resolved: "#27ae60",
+    withdrawn: "#95a5a6",
+  }[s] || "#999");
+
+  const countByStatus = {};
+  disputes.forEach(d => { countByStatus[d.status] = (countByStatus[d.status] || 0) + 1; });
+
+  return (
+    <Section title="DISPUTES" actions={
+      <button onClick={load} disabled={loading} style={{ fontSize: 9, fontFamily: T.mono, padding: "2px 6px", border: `1px solid ${T.paper}44`, background: "transparent", color: T.paper, cursor: "pointer", opacity: loading ? 0.5 : 1 }}>
+        {loading ? "Loading..." : "Refresh"}
+      </button>
+    }>
+      <Flash flash={flash} />
+      <div style={{ padding: "0 10px" }}>
+        {!disputes.length && !loading && <div style={{ color: T.inkFaint, fontSize: 12 }}>No disputes filed yet.</div>}
+
+        {disputes.length > 0 && (
+          <>
+            {/* Status counts */}
+            <div style={{ display: "flex", gap: 16, flexWrap: "wrap", marginBottom: 12, padding: "8px 0", borderBottom: `1px solid ${T.ruleLight}` }}>
+              <div>
+                <Lbl>Total</Lbl>
+                <div style={{ fontSize: 18, fontFamily: T.mono, fontWeight: 700, color: T.ink }}>{disputes.length}</div>
+              </div>
+              {Object.entries(countByStatus).map(([s, c]) => (
+                <div key={s}>
+                  <Lbl>{s.replace(/_/g, " ")}</Lbl>
+                  <div style={{ fontSize: 14, fontFamily: T.mono, color: statusColor(s) }}>{c}</div>
+                </div>
+              ))}
+            </div>
+
+            {/* Disputes table */}
+            <div style={{ overflowX: "auto" }}>
+              <table style={{ width: "100%", borderCollapse: "collapse", fontSize: 11, fontFamily: T.mono }}>
+                <thead>
+                  <tr style={{ borderBottom: `2px solid ${T.ruleMid}` }}>
+                    <th style={{ textAlign: "left", padding: "4px 6px", fontSize: 10, color: T.inkLight }}>Entity</th>
+                    <th style={{ textAlign: "left", padding: "4px 6px", fontSize: 10, color: T.inkLight }}>Submitter</th>
+                    <th style={{ textAlign: "left", padding: "4px 6px", fontSize: 10, color: T.inkLight }}>Status</th>
+                    <th style={{ textAlign: "left", padding: "4px 6px", fontSize: 10, color: T.inkLight }}>Created</th>
+                    <th style={{ textAlign: "left", padding: "4px 6px", fontSize: 10, color: T.inkLight }}>On-chain</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {disputes.map(d => (
+                    <tr key={d.dispute_id} style={{ borderBottom: `1px solid ${T.ruleLight}` }}>
+                      <td style={{ padding: "4px 6px", fontWeight: 600 }}>{d.entity_slug}</td>
+                      <td style={{ padding: "4px 6px", color: T.inkMid }}>{d.submitter_type}</td>
+                      <td style={{ padding: "4px 6px" }}>
+                        <span style={{ color: statusColor(d.status), fontWeight: 600 }}>{d.status.replace(/_/g, " ")}</span>
+                        {d.resolution_category && <span style={{ color: T.inkFaint, marginLeft: 4 }}>({d.resolution_category})</span>}
+                      </td>
+                      <td style={{ padding: "4px 6px", color: T.inkFaint }}>{(d.created_at || "").substring(0, 10)}</td>
+                      <td style={{ padding: "4px 6px", color: T.inkFaint }}>{d.status === "resolved" ? "pending" : "-"}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </>
+        )}
+      </div>
+    </Section>
+  );
+}
+
+
 function ABMPanel() {
   const [campaigns, setCampaigns] = useState([]);
   const [config, setConfig] = useState(null);
@@ -4490,6 +4581,7 @@ export default function OpsDashboard() {
                 <BacktestPanel />
                 <ABMPanel />
                 <TrackRecordPanel />
+                <DisputesPanel />
               </div>
             )}
             {tab === "playground" && (

--- a/migrations/088_disputes_infrastructure.sql
+++ b/migrations/088_disputes_infrastructure.sql
@@ -1,0 +1,54 @@
+-- Migration 088: Disputes infrastructure
+-- Score dispute lifecycle: submission, counter-evidence, resolution
+-- On-chain anchoring columns for dispute transitions
+
+CREATE TABLE IF NOT EXISTS disputes (
+    dispute_id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    entity_slug TEXT NOT NULL,
+    disputed_score_content_hash TEXT,
+    submitter_identifier TEXT NOT NULL,
+    submitter_type TEXT NOT NULL CHECK (submitter_type IN ('issuer', 'third_party', 'regulator', 'anonymous')),
+    submission_text TEXT NOT NULL,
+    submission_evidence_url TEXT,
+    status TEXT NOT NULL DEFAULT 'submitted' CHECK (status IN ('submitted', 'under_review', 'counter_evidence_issued', 'resolved', 'withdrawn')),
+    created_at TIMESTAMPTZ DEFAULT NOW(),
+    resolved_at TIMESTAMPTZ,
+    resolution_category TEXT CHECK (resolution_category IN ('accepted', 'partially_accepted', 'rejected')),
+    resolution_narrative TEXT
+);
+
+CREATE TABLE IF NOT EXISTS dispute_transitions (
+    transition_id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    dispute_id UUID NOT NULL REFERENCES disputes(dispute_id) ON DELETE CASCADE,
+    transition_index INTEGER NOT NULL,
+    transition_kind TEXT NOT NULL CHECK (transition_kind IN ('submission', 'counter_evidence', 'resolution')),
+    transition_payload JSONB NOT NULL,
+    content_hash TEXT NOT NULL UNIQUE,
+    created_at TIMESTAMPTZ DEFAULT NOW(),
+    committed_on_chain_base BOOLEAN DEFAULT FALSE,
+    committed_on_chain_arbitrum BOOLEAN DEFAULT FALSE,
+    on_chain_tx_hash_base TEXT,
+    on_chain_tx_hash_arbitrum TEXT,
+    committed_at TIMESTAMPTZ,
+    UNIQUE(dispute_id, transition_index)
+);
+
+CREATE INDEX IF NOT EXISTS idx_disputes_entity_created
+    ON disputes(entity_slug, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_disputes_status_open
+    ON disputes(status)
+    WHERE status != 'resolved';
+
+CREATE INDEX IF NOT EXISTS idx_dispute_transitions_dispute_idx
+    ON dispute_transitions(dispute_id, transition_index);
+
+CREATE INDEX IF NOT EXISTS idx_dispute_transitions_pending_base
+    ON dispute_transitions(committed_on_chain_base)
+    WHERE committed_on_chain_base = FALSE;
+
+CREATE INDEX IF NOT EXISTS idx_dispute_transitions_pending_arb
+    ON dispute_transitions(committed_on_chain_arbitrum)
+    WHERE committed_on_chain_arbitrum = FALSE;
+
+INSERT INTO migrations (name) VALUES ('088_disputes_infrastructure') ON CONFLICT DO NOTHING;


### PR DESCRIPTION
## Summary
- **Migration 088**: `disputes` + `dispute_transitions` tables with full lifecycle (submitted → under_review → counter_evidence_issued → resolved/withdrawn), on-chain anchoring columns per transition, 5 partial indexes
- **`app/disputes.py`**: `submit_dispute`, `issue_counter_evidence`, `resolve_dispute` — each creates a transition with deterministic content_hash. `compute_on_chain_entity_id` for keeper anchoring via lens `0x00000200`.
- **7 admin endpoints** in ops/routes.py: CRUD for disputes + counter-evidence + resolution + pending-on-chain polling + committed marking
- **2 public endpoints** in server.py: list/detail for disputes with status != 'submitted' (submitted stay private until acknowledged)
- **SSR page** at `/disputes` — server-rendered HTML listing public disputes
- **Ops dashboard** — `DisputesPanel` with status counts and entry table

## Test plan
- [ ] Migration 088 applies cleanly
- [ ] POST /api/ops/disputes creates dispute + submission transition with content_hash
- [ ] POST .../counter-evidence adds transition_index=1, updates status
- [ ] POST .../resolve adds transition_index=2, sets resolved_at
- [ ] GET /api/disputes (public) excludes status='submitted'
- [ ] GET /api/ops/disputes/pending-on-chain returns uncommitted transitions
- [ ] Ops dashboard DisputesPanel renders

https://claude.ai/code/session_011bTVc5haorCZgtCtxzJmtq