### PR TITLE
feat(api): add confidence tier code as grade field for on-chain publi…

### DIFF
--- a/app/confidence_tier_codes.py
+++ b/app/confidence_tier_codes.py
@@ -1,0 +1,32 @@
+"""
+Confidence Tier Codes
+======================
+Maps confidence_tag strings to two-character codes for on-chain
+publishing via the bytes2 grade slot on the BasisOracle contract.
+
+These are NOT credit ratings. They represent the methodological
+confidence level at which the underlying score was computed.
+"""
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+CONFIDENCE_TIER_CODES_VERSION = "v1"
+
+CONFIDENCE_TIER_CODES: dict[str, str] = {
+    None: "HI",
+    "STANDARD": "ST",
+    "LIMITED DATA": "LD",
+}
+
+_FALLBACK_CODE = "XX"
+
+
+def tag_to_code(confidence_tag: str | None) -> str:
+    """Return two-character tier code for a confidence_tag value."""
+    code = CONFIDENCE_TIER_CODES.get(confidence_tag)
+    if code is None and confidence_tag not in CONFIDENCE_TIER_CODES:
+        logger.warning(f"Unknown confidence_tag '{confidence_tag}' — using fallback code '{_FALLBACK_CODE}'")
+        return _FALLBACK_CODE
+    return code

--- a/app/server.py
+++ b/app/server.py
@@ -1414,8 +1414,9 @@ async def get_scores(response: Response, methodology_version: Optional[str] = Qu
         JOIN stablecoins st ON st.id = s.stablecoin_id
         ORDER BY s.overall_score DESC
     """)
-    
+
     from app.scoring_engine import compute_confidence_tag
+    from app.confidence_tier_codes import tag_to_code as _tag_to_code
     SII_COMPONENTS_TOTAL = len(COMPONENT_NORMALIZATIONS)
 
     results = []
@@ -1466,6 +1467,7 @@ async def get_scores(response: Response, methodology_version: Optional[str] = Qu
             "issuer": row["issuer"],
             "token_contract": row.get("token_contract"),
             "score": float(row["overall_score"]),
+            "grade": _tag_to_code(conf_tag),
             "confidence": conf_level,
             "confidence_tag": conf_tag,
             "missing_categories": missing,
@@ -4589,6 +4591,7 @@ async def psi_scores():
     """)
     from app.index_definitions.psi_v01 import PSI_V01_DEFINITION
     from app.scoring_engine import compute_confidence_tag
+    from app.confidence_tier_codes import tag_to_code as _psi_tag_to_code
     psi_cats_total = len(PSI_V01_DEFINITION["categories"])
     psi_comps_total_def = len(PSI_V01_DEFINITION["components"])
 
@@ -4636,6 +4639,7 @@ async def psi_scores():
             "protocol_slug": slug,
             "protocol_name": row["protocol_name"],
             "score": float(row["overall_score"]) if row.get("overall_score") else None,
+            "grade": _psi_tag_to_code(psi_conf["tag"]),
             "confidence": psi_conf["confidence"],
             "confidence_tag": psi_conf["tag"],
             "missing_categories": psi_conf.get("missing_categories") or psi_missing,

--- a/docs/confidence_tier_code_field.md
+++ b/docs/confidence_tier_code_field.md
@@ -1,0 +1,33 @@
+# Confidence Tier Code Field
+
+## What the `grade` field carries
+
+The `grade` field in `/api/scores` and `/api/psi/scores` carries a **confidence tier code**, not a credit rating.
+
+This is **not** an NRSRO rating, a CRA rating, or any assessment of creditworthiness. It is a two-character code representing the methodological confidence level at which the underlying score was computed.
+
+## Mapping table
+
+| confidence_tag | Code | Meaning |
+|---|---|---|
+| *(null/high)* | `HI` | High confidence — ≥80% component coverage |
+| `STANDARD` | `ST` | Standard confidence — ≥60% component coverage |
+| `LIMITED DATA` | `LD` | Limited data — <60% component coverage |
+| *(unknown)* | `XX` | Fallback for unrecognized tags |
+
+Version: `confidence_tier_codes_v1`
+
+## On-chain storage
+
+The `bytes2 grade` slot on the BasisOracle contract (BasisSIIOracle.sol) is a legacy schema field name. As of this commit, the semantic meaning is "confidence tier code."
+
+The keeper's `gradeToBytes2()` function packs any two ASCII characters into bytes2. The field is encoding-agnostic — it simply stores two bytes. The interpretation of those bytes changed from letter grades to confidence tier codes.
+
+Examples:
+- `"HI"` → `0x4849` (H=0x48, I=0x49)
+- `"ST"` → `0x5354` (S=0x53, T=0x54)
+- `"LD"` → `0x4c44` (L=0x4c, D=0x44)
+
+## Future methodology hash
+
+The confidence tier code mapping will be registered as `confidence_tier_codes_v1` in the methodology_hashes registry (PR 4) and anchored on-chain via `publishReportHash` with lens `0x00000300`.

--- a/keeper/converter.ts
+++ b/keeper/converter.ts
@@ -59,20 +59,15 @@ export function tokenIdToAddress(id: string): string | undefined {
 // Grade→bytes2 lookup table (for reference/validation)
 // ============================================================
 
-export const GRADE_BYTES2: Record<string, string> = {
-  "A+": "0x412b",
-  "A":  "0x4100",
-  "A-": "0x412d",
-  "B+": "0x422b",
-  "B":  "0x4200",
-  "B-": "0x422d",
-  "C+": "0x432b",
-  "C":  "0x4300",
-  "C-": "0x432d",
-  "D":  "0x4400",
-  "F":  "0x4600",
+// Confidence tier codes — the bytes2 "grade" slot now carries a
+// methodological confidence tier, not a credit rating.
+export const CONFIDENCE_TIER_BYTES2: Record<string, string> = {
+  "HI": "0x4849",  // High confidence (>=80% coverage)
+  "ST": "0x5354",  // Standard confidence (>=60% coverage)
+  "LD": "0x4c44",  // Limited Data (<60% coverage)
+  "XX": "0x5858",  // Unknown / fallback
 };
 
-export function validateGrade(grade: string): boolean {
-  return grade in GRADE_BYTES2;
+export function validateTierCode(code: string): boolean {
+  return code in CONFIDENCE_TIER_BYTES2;
 }


### PR DESCRIPTION
…shing

The bytes2 grade slot on the oracle is repurposed from letter grades (removed for NRSRO/CRA compliance in 86fb5ee) to confidence tier codes:
  HI (high, >=80% coverage), ST (standard, >=60%), LD (limited, <60%).

/api/scores and /api/psi/scores now include a `grade` field derived from confidence_tag via tag_to_code(). The keeper's gradeToBytes2() packs any two ASCII chars into bytes2, so no keeper code changes needed.

keeper/converter.ts: GRADE_BYTES2 lookup table replaced with CONFIDENCE_TIER_BYTES2, validateGrade renamed to validateTierCode. Neither was called in production code — purely for reference.

https://claude.ai/code/session_011bTVc5haorCZgtCtxzJmtq