### PR TITLE
feat(mempool): Alchemy pending-tx WebSocket watcher + reconciliation

### DIFF
--- a/app/data_layer/mempool_watcher.py
+++ b/app/data_layer/mempool_watcher.py
@@ -1,0 +1,661 @@
+"""
+Mempool observation capture via Alchemy's alchemy_pendingTransactions
+WebSocket subscription with server-side address filtering.
+
+Phase 1 scope: Ethereum mainnet only. No new vendor — uses the existing
+ALCHEMY_API_KEY on free tier. A single long-lived WebSocket connection
+subscribes with a watchlist of up to 100 addresses; each event writes a
+row to `mempool_observations`. A reconciliation loop every 60s calls
+eth_getTransactionByHash (via app.utils.rpc_provider.call) to stamp
+confirmed_block / confirmed_at / confirmation_latency_ms on observations,
+and marks tx dropped after 10 min of no confirmation.
+
+Cost control: Alchemy free tier has a ~1M compute-unit daily budget.
+This module tracks hourly CU consumption via `api_usage_hourly` (the
+existing `api_tracker` snapshot) and:
+  - logs [mempool_watcher] WARN when hourly CU > 50K (≈1.2M/day sustained)
+  - pauses the subscription for 1 hour if 24h rolling CU > 800K (80% of budget)
+  - emits a state_attestation with domain='mempool_capture_status' on
+    pause/resume so operators have an audit trail of gaps
+
+Deferred to Phase 2:
+  - Dwellir WebSocket as verification source
+  - Base / Arbitrum mempool capture
+  - Solana mempool (different architecture)
+
+The watcher runs as a background task launched from app/worker.py main().
+It is idempotent across restarts (tx_hash is UNIQUE on the table) and
+safe to kill at any point.
+"""
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+import logging
+import os
+import time
+from datetime import datetime, timezone
+from typing import Any, Iterable
+
+from app.database import execute, fetch_all, fetch_one, get_cursor
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+MAX_WATCHLIST_ADDRESSES = 100
+RECONCILIATION_INTERVAL_SEC = 60
+DROPPED_THRESHOLD_SEC = 10 * 60      # 10 minutes
+WS_PING_INTERVAL_SEC = 30
+WS_PING_TIMEOUT_SEC = 10
+WS_RECONNECT_BASE_DELAY_SEC = 2
+WS_RECONNECT_MAX_DELAY_SEC = 120
+
+# Alchemy CU budget thresholds (free tier ~1M/day).
+CU_HOURLY_WARN_THRESHOLD = 50_000
+CU_DAILY_PAUSE_THRESHOLD = 800_000
+PAUSE_DURATION_SEC = 3600
+
+_ALCHEMY_WS_CHAIN_MAP = {
+    "ethereum": "eth-mainnet",
+    "base":     "base-mainnet",
+    "arbitrum": "arb-mainnet",
+}
+
+
+# ---------------------------------------------------------------------------
+# Watchlist builder
+# ---------------------------------------------------------------------------
+
+def build_watchlist(chain: str = "ethereum", limit: int = MAX_WATCHLIST_ADDRESSES) -> list[str]:
+    """Assemble the address watchlist from available tables.
+
+    Sources (in priority order):
+      1. stablecoins.contract — mainnet token contracts. Always on
+         ethereum mainnet in current schema (no `chain` column); included
+         only when chain='ethereum'.
+      2. protocol_pool_wallets.pool_contract_address — distinct protocol
+         pool contracts, ranked by balance sum across receipt-token holders.
+
+    Returns lowercased 0x-prefixed addresses, deduplicated, capped at
+    `limit`. Logs a warning if the combined source count exceeds the cap —
+    caller should see that in Railway.
+    """
+    addresses: list[str] = []
+    seen: set[str] = set()
+
+    def _add(addr: str | None) -> None:
+        if not addr or not isinstance(addr, str):
+            return
+        a = addr.lower().strip()
+        if not a.startswith("0x") or len(a) != 42:
+            return
+        if a in seen:
+            return
+        seen.add(a)
+        addresses.append(a)
+
+    if chain == "ethereum":
+        try:
+            rows = fetch_all(
+                "SELECT contract FROM stablecoins "
+                "WHERE contract IS NOT NULL AND scoring_enabled = TRUE"
+            ) or []
+            for r in rows:
+                _add(r.get("contract"))
+        except Exception as e:
+            logger.warning(f"[mempool_watcher] stablecoins watchlist skipped: {e}")
+
+    try:
+        rows = fetch_all(
+            """
+            SELECT LOWER(pool_contract_address) AS addr, SUM(COALESCE(balance, 0)) AS bal
+            FROM protocol_pool_wallets
+            WHERE chain = %s AND pool_contract_address IS NOT NULL
+            GROUP BY LOWER(pool_contract_address)
+            ORDER BY bal DESC
+            LIMIT %s
+            """,
+            (chain, max(limit * 2, 50)),
+        ) or []
+        for r in rows:
+            _add(r.get("addr"))
+            if len(addresses) >= limit:
+                break
+    except Exception as e:
+        logger.warning(f"[mempool_watcher] protocol_pool_wallets watchlist skipped: {e}")
+
+    original_count = len(addresses)
+    if original_count > limit:
+        logger.warning(
+            f"[mempool_watcher] watchlist truncated from {original_count} to {limit} "
+            f"(MAX_WATCHLIST_ADDRESSES). Raise the cap in code when Alchemy free tier "
+            f"demonstrates it can handle more."
+        )
+        addresses = addresses[:limit]
+
+    return addresses
+
+
+# ---------------------------------------------------------------------------
+# Cost control
+# ---------------------------------------------------------------------------
+
+def _current_hour_cu(provider: str = "alchemy") -> int:
+    """Approximate CU consumption for the current hour, derived from
+    api_usage_hourly's total_calls. We don't have per-call CU accounting
+    (Alchemy doesn't return it in responses), so this is a call-count
+    proxy: mempool subscription + polling calls are roughly 1:1 with CU
+    on free tier for eth_getTransactionByHash. The WebSocket
+    subscription itself is a flat CU cost and not counted per-event, so
+    this proxy is conservative."""
+    try:
+        row = fetch_one(
+            """
+            SELECT COALESCE(SUM(total_calls), 0) AS total
+            FROM api_usage_hourly
+            WHERE provider = %s AND hour = date_trunc('hour', NOW())
+            """,
+            (provider,),
+        )
+        return int(row["total"]) if row else 0
+    except Exception:
+        return 0
+
+
+def _rolling_24h_cu(provider: str = "alchemy") -> int:
+    try:
+        row = fetch_one(
+            """
+            SELECT COALESCE(SUM(total_calls), 0) AS total
+            FROM api_usage_hourly
+            WHERE provider = %s AND hour > NOW() - INTERVAL '24 hours'
+            """,
+            (provider,),
+        )
+        return int(row["total"]) if row else 0
+    except Exception:
+        return 0
+
+
+def _attest_capture_status(status: str, note: str, gap_seconds: int | None = None) -> None:
+    """Record a pause/resume event to state_attestations so operators can
+    see capture gaps. domain='mempool_capture_status'. Non-fatal."""
+    try:
+        payload = json.dumps({
+            "status": status,
+            "note": note,
+            "gap_seconds": gap_seconds,
+            "recorded_at": datetime.now(timezone.utc).isoformat(),
+        }, sort_keys=True)
+        content_hash = hashlib.sha256(payload.encode()).hexdigest()
+        execute(
+            """
+            INSERT INTO state_attestations
+                (domain, entity_id, batch_hash, record_count, methodology_version, cycle_timestamp)
+            VALUES (%s, %s, %s, %s, %s, NOW())
+            """,
+            ("mempool_capture_status", status, content_hash, 1, "mempool-v0.1.0"),
+        )
+    except Exception as e:
+        logger.debug(f"[mempool_watcher] capture-status attestation skipped: {e}")
+
+
+# ---------------------------------------------------------------------------
+# Observation writer
+# ---------------------------------------------------------------------------
+
+def _insert_observation(tx: dict) -> bool:
+    """Write one mempool observation row. Returns True on insert, False on
+    ON CONFLICT (tx_hash already seen — subscription sometimes delivers
+    dupes) or on error."""
+    try:
+        tx_hash = tx.get("hash")
+        if not tx_hash:
+            return False
+
+        from_addr = (tx.get("from") or "").lower() or None
+        to_addr = (tx.get("to") or "").lower() or None
+
+        def _hex_to_int(v):
+            if v is None:
+                return None
+            if isinstance(v, int):
+                return v
+            try:
+                return int(v, 16) if isinstance(v, str) and v.startswith("0x") else int(v)
+            except Exception:
+                return None
+
+        value_wei = _hex_to_int(tx.get("value"))
+        gas_price_wei = _hex_to_int(tx.get("gasPrice") or tx.get("maxFeePerGas"))
+        nonce = _hex_to_int(tx.get("nonce"))
+
+        input_data = tx.get("input") or "0x"
+        input_truncated = input_data[:1026]  # "0x" + 512 bytes (=1024 hex chars)
+        selector = input_data[:10] if len(input_data) >= 10 else None
+
+        seen_at_ms = int(time.time() * 1000)
+
+        execute(
+            """
+            INSERT INTO mempool_observations
+                (tx_hash, from_address, to_address, value_wei, gas_price_wei,
+                 nonce, input_data_truncated, function_selector, source,
+                 seen_at, seen_at_ms)
+            VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, NOW(), %s)
+            ON CONFLICT (tx_hash) DO NOTHING
+            """,
+            (
+                tx_hash, from_addr, to_addr, value_wei, gas_price_wei,
+                nonce, input_truncated, selector, "alchemy",
+                seen_at_ms,
+            ),
+        )
+        return True
+    except Exception as e:
+        logger.debug(f"[mempool_watcher] insert failed: {type(e).__name__}: {e}")
+        return False
+
+
+def _attest_observation(tx_hash: str, seen_at_ms: int) -> None:
+    """Single-row state attestation for the incoming observation.
+
+    Per the spec: content_hash = SHA-256 of tx_hash + seen_at_ms + source.
+    The attestation domain is `mempool_observations`. Writes are non-fatal —
+    a failure here never drops the captured data, only the audit trail.
+    """
+    try:
+        content = f"{tx_hash}|{seen_at_ms}|alchemy"
+        content_hash = hashlib.sha256(content.encode()).hexdigest()
+        execute(
+            """
+            INSERT INTO state_attestations
+                (domain, entity_id, batch_hash, record_count, methodology_version, cycle_timestamp)
+            VALUES (%s, %s, %s, %s, %s, NOW())
+            """,
+            ("mempool_observations", tx_hash, content_hash, 1, "mempool-v0.1.0"),
+        )
+    except Exception:
+        pass
+
+
+# ---------------------------------------------------------------------------
+# WebSocket subscription
+# ---------------------------------------------------------------------------
+
+def _alchemy_ws_url(chain: str) -> str | None:
+    key = os.environ.get("ALCHEMY_API_KEY", "")
+    subdomain = _ALCHEMY_WS_CHAIN_MAP.get(chain)
+    if not (key and subdomain):
+        return None
+    return f"wss://{subdomain}.g.alchemy.com/v2/{key}"
+
+
+async def _subscribe_and_consume(ws, watchlist: list[str]) -> int:
+    """Send the alchemy_pendingTransactions subscribe request, then consume
+    events. Returns event count on disconnect (for logging). Caller owns
+    retry/reconnect."""
+    sub_id = 1
+    subscribe_msg = {
+        "jsonrpc": "2.0",
+        "id": sub_id,
+        "method": "eth_subscribe",
+        "params": [
+            "alchemy_pendingTransactions",
+            {"toAddress": watchlist, "hashesOnly": False},
+        ],
+    }
+    await ws.send(json.dumps(subscribe_msg))
+
+    # Wait for subscription confirmation. Alchemy responds with a result
+    # field containing the subscription id.
+    subscription_id: str | None = None
+    async for raw in ws:
+        try:
+            msg = json.loads(raw)
+        except Exception:
+            continue
+        if msg.get("id") == sub_id:
+            subscription_id = msg.get("result")
+            logger.error(
+                f"[mempool_watcher] SUBSCRIBED chain=ethereum "
+                f"addresses={len(watchlist)} subscription_id={subscription_id}"
+            )
+            break
+        if "error" in msg:
+            raise RuntimeError(f"subscribe error: {msg['error']}")
+
+    if not subscription_id:
+        raise RuntimeError("subscription id not received")
+
+    event_count = 0
+    async for raw in ws:
+        try:
+            msg = json.loads(raw)
+        except Exception:
+            continue
+        # Alchemy notification shape:
+        # {"jsonrpc":"2.0","method":"eth_subscription",
+        #  "params":{"subscription":"<id>", "result":{...tx...}}}
+        if msg.get("method") == "eth_subscription":
+            params = msg.get("params") or {}
+            tx = params.get("result") or {}
+            if tx and _insert_observation(tx):
+                event_count += 1
+                _attest_observation(tx.get("hash", ""), int(time.time() * 1000))
+
+    return event_count
+
+
+async def run_watcher(chain: str = "ethereum") -> None:
+    """Long-lived WebSocket watcher. Never returns under normal operation —
+    caller schedules this as a background task. Reconnects on any error
+    with exponential backoff. Self-pauses on Alchemy CU budget exhaustion.
+
+    Run exactly one instance per chain per worker. Multiple instances
+    would duplicate subscriptions (Alchemy charges CU per subscription)
+    and bloat mempool_observations via benign UNIQUE-on-tx_hash conflicts.
+    """
+    try:
+        import websockets
+    except ImportError:
+        logger.error(
+            "[mempool_watcher] websockets library not installed — skipping. "
+            "Add `websockets>=12.0` to requirements.txt and redeploy."
+        )
+        return
+
+    url = _alchemy_ws_url(chain)
+    if not url:
+        logger.error(
+            f"[mempool_watcher] ALCHEMY_API_KEY or chain subdomain unresolvable "
+            f"for chain={chain} — watcher disabled"
+        )
+        return
+
+    reconnect_delay = WS_RECONNECT_BASE_DELAY_SEC
+    paused_until: float = 0.0
+
+    while True:
+        # Cost-control gate.
+        now = time.time()
+        if now < paused_until:
+            wait = paused_until - now
+            await asyncio.sleep(min(wait, 60))
+            continue
+
+        rolling_24h = _rolling_24h_cu("alchemy")
+        if rolling_24h > CU_DAILY_PAUSE_THRESHOLD:
+            paused_until = now + PAUSE_DURATION_SEC
+            logger.error(
+                f"[mempool_watcher] PAUSE alchemy 24h CU={rolling_24h:,} > "
+                f"{CU_DAILY_PAUSE_THRESHOLD:,} budget threshold — "
+                f"pausing subscription for {PAUSE_DURATION_SEC}s"
+            )
+            _attest_capture_status(
+                "paused",
+                f"alchemy_24h_cu={rolling_24h} exceeds {CU_DAILY_PAUSE_THRESHOLD} threshold",
+                gap_seconds=PAUSE_DURATION_SEC,
+            )
+            continue
+
+        hourly_cu = _current_hour_cu("alchemy")
+        if hourly_cu > CU_HOURLY_WARN_THRESHOLD:
+            logger.error(
+                f"[mempool_watcher] WARN alchemy hourly CU={hourly_cu:,} > "
+                f"{CU_HOURLY_WARN_THRESHOLD:,} — sustained rate would exceed daily budget"
+            )
+
+        watchlist = build_watchlist(chain=chain, limit=MAX_WATCHLIST_ADDRESSES)
+        if not watchlist:
+            logger.error(
+                "[mempool_watcher] watchlist is empty — no stablecoins or pool "
+                "contracts available; retrying in 300s"
+            )
+            await asyncio.sleep(300)
+            continue
+
+        connect_started = time.time()
+        try:
+            async with websockets.connect(
+                url,
+                ping_interval=WS_PING_INTERVAL_SEC,
+                ping_timeout=WS_PING_TIMEOUT_SEC,
+                max_size=2**23,  # 8 MB frame cap
+                close_timeout=5,
+            ) as ws:
+                reconnect_delay = WS_RECONNECT_BASE_DELAY_SEC  # reset on successful connect
+                events = await _subscribe_and_consume(ws, watchlist)
+                logger.warning(
+                    f"[mempool_watcher] connection closed after {events:,} events"
+                )
+                _attest_capture_status(
+                    "resumed",
+                    f"connection lifetime={int(time.time() - connect_started)}s events={events}",
+                )
+        except asyncio.CancelledError:
+            logger.error("[mempool_watcher] cancelled; shutting down cleanly")
+            raise
+        except Exception as e:
+            elapsed = int(time.time() - connect_started)
+            logger.error(
+                f"[mempool_watcher] connection error after {elapsed}s: "
+                f"{type(e).__name__}: {e}"
+            )
+
+        await asyncio.sleep(reconnect_delay)
+        reconnect_delay = min(reconnect_delay * 2, WS_RECONNECT_MAX_DELAY_SEC)
+
+
+# ---------------------------------------------------------------------------
+# Reconciliation loop
+# ---------------------------------------------------------------------------
+
+async def reconcile_once() -> dict:
+    """Check every unconfirmed tx older than 60s exactly once. Update
+    confirmed_block / confirmed_at / confirmation_latency_ms for txs the
+    chain has sealed; mark dropped=TRUE for txs that have been in the pool
+    longer than DROPPED_THRESHOLD_SEC with no confirmation.
+
+    Returns counts for diagnostic logging.
+    """
+    from app.utils.rpc_provider import call as rpc_call, RPCError
+
+    counts = {"checked": 0, "confirmed": 0, "dropped": 0, "errors": 0}
+
+    try:
+        rows = fetch_all(
+            """
+            SELECT id, tx_hash, seen_at, seen_at_ms
+            FROM mempool_observations
+            WHERE confirmed_block IS NULL
+              AND dropped = FALSE
+              AND seen_at < NOW() - INTERVAL '60 seconds'
+            ORDER BY seen_at
+            LIMIT 500
+            """
+        ) or []
+    except Exception as e:
+        logger.warning(f"[mempool_watcher] reconcile query failed: {e}")
+        return counts
+
+    now_ms = int(time.time() * 1000)
+    drop_cutoff_ms = now_ms - (DROPPED_THRESHOLD_SEC * 1000)
+
+    for r in rows:
+        counts["checked"] += 1
+        tx_hash = r["tx_hash"]
+        try:
+            tx = await rpc_call(
+                "eth_getTransactionByHash", [tx_hash], chain="ethereum", timeout=8.0,
+            )
+        except RPCError as e:
+            counts["errors"] += 1
+            logger.debug(f"[mempool_watcher] reconcile RPC fail {tx_hash[:12]}: {e}")
+            continue
+        except Exception as e:
+            counts["errors"] += 1
+            logger.debug(
+                f"[mempool_watcher] reconcile exc {tx_hash[:12]}: "
+                f"{type(e).__name__}: {e}"
+            )
+            continue
+
+        if tx and tx.get("blockNumber"):
+            # Confirmed — stamp block + latency.
+            try:
+                block_num = int(tx["blockNumber"], 16)
+            except Exception:
+                counts["errors"] += 1
+                continue
+            latency_ms = max(0, now_ms - int(r["seen_at_ms"]))
+            try:
+                execute(
+                    """
+                    UPDATE mempool_observations
+                    SET confirmed_block = %s,
+                        confirmed_at = NOW(),
+                        confirmation_latency_ms = %s
+                    WHERE id = %s AND confirmed_block IS NULL
+                    """,
+                    (block_num, latency_ms, r["id"]),
+                )
+                counts["confirmed"] += 1
+            except Exception as e:
+                counts["errors"] += 1
+                logger.debug(f"[mempool_watcher] reconcile update failed: {e}")
+        else:
+            # Unconfirmed — if older than drop threshold, mark dropped.
+            if int(r["seen_at_ms"]) < drop_cutoff_ms:
+                try:
+                    execute(
+                        "UPDATE mempool_observations SET dropped = TRUE WHERE id = %s",
+                        (r["id"],),
+                    )
+                    counts["dropped"] += 1
+                except Exception as e:
+                    counts["errors"] += 1
+                    logger.debug(f"[mempool_watcher] drop mark failed: {e}")
+
+    return counts
+
+
+async def run_reconciliation_loop() -> None:
+    """Fires `reconcile_once` every RECONCILIATION_INTERVAL_SEC. Caller
+    schedules as a background task."""
+    while True:
+        try:
+            counts = await reconcile_once()
+            if any(counts.values()):
+                logger.error(
+                    f"[mempool_watcher] reconcile: "
+                    f"checked={counts['checked']} confirmed={counts['confirmed']} "
+                    f"dropped={counts['dropped']} errors={counts['errors']}"
+                )
+        except asyncio.CancelledError:
+            raise
+        except Exception as e:
+            logger.error(f"[mempool_watcher] reconcile loop error: {type(e).__name__}: {e}")
+        await asyncio.sleep(RECONCILIATION_INTERVAL_SEC)
+
+
+# ---------------------------------------------------------------------------
+# Diagnostics
+# ---------------------------------------------------------------------------
+
+def emit_24h_summary() -> None:
+    """Emit the 24h [mempool_observations] summary line expected by the
+    acceptance checklist. Safe to call even if the table doesn't exist
+    yet (logs the absence and returns)."""
+    try:
+        summary = fetch_one(
+            """
+            SELECT
+                COUNT(*) AS captured,
+                COUNT(*) FILTER (WHERE confirmed_block IS NOT NULL) AS confirmed,
+                COUNT(*) FILTER (WHERE dropped = TRUE) AS dropped,
+                AVG(confirmation_latency_ms) FILTER (WHERE confirmation_latency_ms IS NOT NULL) AS avg_latency_ms
+            FROM mempool_observations
+            WHERE seen_at > NOW() - INTERVAL '24 hours'
+            """
+        )
+    except Exception as e:
+        logger.debug(f"[mempool_observations] 24h SUMMARY skipped: {e}")
+        return
+
+    if not summary or not summary.get("captured"):
+        logger.error("[mempool_observations] 24h SUMMARY: no rows yet")
+        return
+
+    top_to = fetch_all(
+        """
+        SELECT to_address AS addr, COUNT(*) AS cnt
+        FROM mempool_observations
+        WHERE seen_at > NOW() - INTERVAL '24 hours' AND to_address IS NOT NULL
+        GROUP BY to_address
+        ORDER BY cnt DESC
+        LIMIT 5
+        """
+    ) or []
+    top_selectors = fetch_all(
+        """
+        SELECT function_selector AS sel, COUNT(*) AS cnt
+        FROM mempool_observations
+        WHERE seen_at > NOW() - INTERVAL '24 hours' AND function_selector IS NOT NULL
+        GROUP BY function_selector
+        ORDER BY cnt DESC
+        LIMIT 5
+        """
+    ) or []
+
+    cu_rolling = _rolling_24h_cu("alchemy")
+    avg_latency = int(summary["avg_latency_ms"]) if summary["avg_latency_ms"] else None
+
+    top_to_str = ", ".join(f"{(r['addr'] or '')[:10]}={r['cnt']}" for r in top_to)
+    top_sel_str = ", ".join(f"{r['sel']}={r['cnt']}" for r in top_selectors)
+
+    logger.error(
+        f"[mempool_observations] 24h SUMMARY: "
+        f"captured={int(summary['captured'])} "
+        f"confirmed={int(summary['confirmed'])} "
+        f"dropped={int(summary['dropped'])} "
+        f"avg_confirmation_latency_ms={avg_latency} "
+        f"alchemy_cu_rolling24h={cu_rolling} "
+        f"top_to=[{top_to_str}] "
+        f"top_selectors=[{top_sel_str}]"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Orchestration entry point
+# ---------------------------------------------------------------------------
+
+async def start_mempool_tasks() -> tuple[asyncio.Task, asyncio.Task] | None:
+    """Launch the watcher and reconciliation loop as background tasks.
+
+    Returns (watcher_task, reconcile_task) on success, or None if the
+    module is disabled (no API key, feature flag off). Safe to call at
+    worker boot. Failure to start never raises — mempool is a telemetry
+    feature and must not block the scoring worker.
+    """
+    if os.environ.get("MEMPOOL_WATCHER_ENABLED", "true").lower() in ("0", "false", "no"):
+        logger.error("[mempool_watcher] disabled by MEMPOOL_WATCHER_ENABLED env var")
+        return None
+
+    if not os.environ.get("ALCHEMY_API_KEY"):
+        logger.error("[mempool_watcher] ALCHEMY_API_KEY not set — watcher not started")
+        return None
+
+    try:
+        watcher_task = asyncio.create_task(run_watcher("ethereum"), name="mempool_watcher")
+        reconcile_task = asyncio.create_task(run_reconciliation_loop(), name="mempool_reconcile")
+        logger.error("[mempool_watcher] background tasks scheduled")
+        return watcher_task, reconcile_task
+    except Exception as e:
+        logger.error(f"[mempool_watcher] failed to start: {type(e).__name__}: {e}")
+        return None

--- a/app/worker.py
+++ b/app/worker.py
@@ -867,6 +867,15 @@ def run_cycle_diagnostics():
     except Exception as _e:
         logger.debug(f"[rpc_capabilities] diagnostic skipped: {_e}")
 
+    # 3e. Mempool observations — 24h SUMMARY line expected by the
+    # mempool-watcher acceptance checklist. Silently skips if migration 091
+    # hasn't run yet or if no rows have landed.
+    try:
+        from app.data_layer.mempool_watcher import emit_24h_summary as _mp_summary
+        _mp_summary()
+    except Exception as _e:
+        logger.debug(f"[mempool_observations] diagnostic skipped: {_e}")
+
     # 4. API usage table verification
     try:
         _hourly = fetch_one("SELECT COUNT(*) as cnt, MAX(hour) as latest FROM api_usage_hourly")
@@ -3228,6 +3237,18 @@ async def main():
         await probe_rpc_capabilities(chain="ethereum")
     except Exception as e:
         logger.error(f"[startup] rpc_probe skipped: {type(e).__name__}: {e}")
+
+    # Mempool observation watcher — long-lived WebSocket subscription to
+    # Alchemy's alchemy_pendingTransactions with server-side address
+    # filtering. Runs as two background asyncio tasks (watcher +
+    # reconciliation loop). Launch never blocks — mempool is a telemetry
+    # feature and failure must not affect the scoring worker. See
+    # app/data_layer/mempool_watcher.py and migrations/091_mempool_observations.sql.
+    try:
+        from app.data_layer.mempool_watcher import start_mempool_tasks
+        await start_mempool_tasks()
+    except Exception as e:
+        logger.error(f"[mempool_watcher] startup skipped: {type(e).__name__}: {e}")
 
     # Seed email alert channel if not configured
     try:

--- a/migrations/091_mempool_observations.sql
+++ b/migrations/091_mempool_observations.sql
@@ -1,0 +1,51 @@
+-- Migration 091 — Mempool observation capture.
+--
+-- Supports app/data_layer/mempool_watcher.py, which subscribes to Alchemy's
+-- alchemy_pendingTransactions WebSocket feed with server-side address
+-- filtering. Each pending tx that targets a watchlisted address lands here,
+-- then a background reconciliation loop updates confirmed_block /
+-- confirmed_at / confirmation_latency_ms once the tx lands in a block
+-- (or marks it dropped after 10 min of no confirmation).
+--
+-- The task spec in the mempool-watcher prompt called for migration 086,
+-- but 086..090 are already taken (track_record_rpi_delta_trigger through
+-- rpc_provider_usage). This migration uses the next free slot.
+--
+-- Partial index on unconfirmed rows keeps the reconciliation loop cheap
+-- even as the table grows to the expected 1K-20K rows/day.
+
+CREATE TABLE IF NOT EXISTS mempool_observations (
+    id BIGSERIAL PRIMARY KEY,
+    tx_hash TEXT NOT NULL,
+    from_address TEXT,
+    to_address TEXT,
+    value_wei NUMERIC,
+    value_usd NUMERIC,
+    gas_price_wei NUMERIC,
+    nonce INT,
+    input_data_truncated TEXT,      -- first 512 bytes of input calldata, hex
+    function_selector TEXT,         -- first 4 bytes of input calldata, hex
+    source TEXT NOT NULL DEFAULT 'alchemy',
+    seen_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    seen_at_ms BIGINT NOT NULL,     -- unix epoch ms for sequence analysis
+    confirmed_block INT,
+    confirmed_at TIMESTAMPTZ,
+    confirmation_latency_ms INT,
+    dropped BOOLEAN NOT NULL DEFAULT FALSE,
+    UNIQUE (tx_hash)
+);
+
+CREATE INDEX IF NOT EXISTS idx_mempool_obs_to_time
+    ON mempool_observations (to_address, seen_at DESC);
+
+-- Partial index keyed only on unconfirmed observations — the
+-- reconciliation loop filters by (confirmed_block IS NULL AND dropped=FALSE)
+-- every 60s.
+CREATE INDEX IF NOT EXISTS idx_mempool_obs_unconfirmed
+    ON mempool_observations (seen_at)
+    WHERE confirmed_block IS NULL AND dropped = FALSE;
+
+CREATE INDEX IF NOT EXISTS idx_mempool_obs_seen_at
+    ON mempool_observations (seen_at DESC);
+
+INSERT INTO migrations (name) VALUES ('091_mempool_observations') ON CONFLICT DO NOTHING;

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,4 +14,5 @@ python-dotenv==1.0.1
 scipy>=1.11.0
 tornado>=6.5.5
 uvicorn[standard]==0.34.0
+websockets>=12.0
 x402>=2.6.0


### PR DESCRIPTION
## Summary

Ship mempool observation capture via Alchemy's `alchemy_pendingTransactions` WebSocket subscription with server-side address filtering. Phase 1 scope: **Ethereum mainnet only**. No new vendor — uses existing `ALCHEMY_API_KEY` on free tier.

## Migration number

The spec called for migration 086, but 086..090 are already taken. This PR uses the next free slot, **091** — `migrations/091_mempool_observations.sql`.

## What lands

### `app/data_layer/mempool_watcher.py`
- **`build_watchlist`** — derived at connect time from:
  - `stablecoins.contract` where `scoring_enabled=TRUE` (mainnet tokens)
  - `protocol_pool_wallets.pool_contract_address` ranked by summed balance
  
  Deduped, lowercased, capped at 100. Sources that are missing are skipped with a warning. (The task spec referenced a `psi_protocols` table that doesn't exist in the schema — addresses come from `protocol_pool_wallets` instead, which is the actual source of discovered protocol contracts.)

- **`run_watcher`** — long-lived WS client. Connects to `wss://eth-mainnet.g.alchemy.com/v2/{key}`. Exponential backoff (2s → 120s cap) on reconnect. Ping every 30s, timeout 10s. Emits `[mempool_watcher] SUBSCRIBED chain=ethereum addresses=N subscription_id=...` once the subscription confirmation lands.

- **`_insert_observation`** — one row per pending-tx event into `mempool_observations`. `ON CONFLICT (tx_hash) DO NOTHING` handles the occasional dupe. Truncates input calldata to 512 bytes; extracts 4-byte selector.

- **`_attest_observation`** — per-row `state_attestations` with `domain='mempool_observations'`, `batch_hash = SHA-256(tx_hash | seen_at_ms | source)`.

- **`run_reconciliation_loop`** — every 60s calls `rpc_provider.call("eth_getTransactionByHash", ...)` for each unconfirmed row older than 60s. Stamps `confirmed_block` / `confirmed_at` / `confirmation_latency_ms` when the chain has sealed it; marks `dropped=TRUE` after 10 min.

- **Cost control** — thresholds derived from Alchemy free-tier (~1M CU/day):
  - WARN when hourly `api_usage_hourly.total_calls` for alchemy exceeds **50,000**
  - PAUSE subscription for **3600s** when 24h rolling exceeds **800,000**
  - Pause/resume attested via `state_attestations` with `domain='mempool_capture_status'` so capture gaps are visible in the audit trail.

- **`start_mempool_tasks`** — launches watcher + reconciliation as named `asyncio.create_task`s. Never raises. Honors `MEMPOOL_WATCHER_ENABLED=false` kill switch.

- **`emit_24h_summary`** — the `[mempool_observations] 24h SUMMARY` line with captured/confirmed/dropped/avg_latency_ms/top_to/top_selectors/alchemy_cu_rolling24h.

### `app/worker.py`
- `main()`: after the `probe_rpc_capabilities` block, calls `await start_mempool_tasks()` (non-blocking, never raises).
- `run_cycle_diagnostics`: emits the 24h summary after the `[rpc_capabilities]` block.

### `migrations/091_mempool_observations.sql`
- `mempool_observations` with `tx_hash UNIQUE`, partial index on unconfirmed rows (keyed on `seen_at` where `confirmed_block IS NULL AND dropped=FALSE`), indexes on `(to_address, seen_at DESC)` and `seen_at DESC`.

### `requirements.txt`
- Adds `websockets>=12.0`. (`uvicorn[standard]` pulls it transitively for ASGI, but importing it directly as a module requires it as a first-class dep.)

## Acceptance (one cycle post-deploy)

1. `[mempool_watcher] SUBSCRIBED chain=ethereum addresses=N subscription_id=...` within 30s of worker startup.
2. First `mempool_observations` rows within 5 min.
3. Reconciliation loop stamps `confirmed_block` within 1-2 blocks of the chain.
4. No Alchemy 429s (watch `[api_usage_7d]` alchemy row).
5. Within 24h: table has 1K-20K rows; distribution covers the watchlist.
6. `[mempool_observations] 24h SUMMARY` line visible on next diagnostic tick.

## What this PR does NOT change

- No LLL pipeline logic. Telemetry only.
- No per-call CU accounting (Alchemy doesn't return it); cost control uses the existing `api_usage_hourly.total_calls` as a conservative proxy.
- Kill switch: `MEMPOOL_WATCHER_ENABLED=false` disables without code changes.
- No writes to oracle/scoring tables.

## Deferred (Phase 2)

- Dwellir WebSocket as verification source (compare against Alchemy's feed).
- Base / Arbitrum mempool capture.
- Solana mempool (different architecture, defer).

## Tests

- Syntax checks clean on both edited files.
- Module imports and smoke-tests clean (`build_watchlist`, `_alchemy_ws_url`, `emit_24h_summary`, thresholds).
- 55/55 non-env tests pass.
- `e2e_test.py` + `test_contract_upgrades.py` continue requiring live server/DB (unrelated).

https://claude.ai/code/session_012Kdm7QyJLDSmGyrjiXueqx