### PR TITLE
chore(keeper): enhanced estimateGas error logging + PSI state diagnostic

### DIFF
--- a/keeper/publisher.ts
+++ b/keeper/publisher.ts
@@ -12,6 +12,14 @@ const ORACLE_ABI = [
   "function publishStateRoot(bytes32 stateRoot) external",
   "function reportTimestamps(bytes32 entityId) external view returns (uint48)",
   "function stateRootTimestamp() external view returns (uint48)",
+  // Read-only PSI accessor — used by scripts/diagnose_psi_state.ts to
+  // compare per-slug stored state across chains. Returns
+  // (score, grade, timestamp, version). Returns all zeros if slug was
+  // never published on that chain (mapping default).
+  "function getPsiScore(string calldata protocolSlug) external view returns (uint16, bytes2, uint48, uint16)",
+  // SII equivalent — read by address, surfaces the same struct shape. The
+  // storage name `scores` is auto-generated Solidity public getter.
+  "function scores(address token) external view returns (uint16 score, bytes2 grade, uint48 timestamp, uint16 version)",
 ];
 
 const SBT_ABI = [
@@ -137,9 +145,35 @@ export async function publishUpdates(
     gasLimit = (gasEstimate * 120n) / 100n;
     logger.info("SII gas estimated", { chain: chainKey, estimate: gasEstimate.toString(), limit: gasLimit.toString() });
   } catch (err) {
+    // Enhanced revert diagnostics (diagnose/psi-estimategas-revert). ethers
+    // surfaces contract require() messages via `reason` / `shortMessage`;
+    // raw revert data is on `data`; the attempted tx params on `transaction`.
+    // Also logs batch shape so we can spot array-length mismatches and the
+    // first element of each parallel array so the operator can cross-check
+    // against on-chain state via scripts/diagnose_psi_state.ts (SII uses
+    // the token-address mapping; the PSI script is the closer analog).
+    const errAny = err as any;
     logger.warn("SII gas estimate failed — tx would revert, skipping", {
       chain: chainKey,
-      error: err instanceof Error ? err.message : String(err),
+      method: "batchUpdateScores",
+      message: errAny?.message,
+      code: errAny?.code,
+      reason: errAny?.reason,
+      shortMessage: errAny?.shortMessage,
+      data: errAny?.data,
+      info: errAny?.info,
+      txFrom: errAny?.transaction?.from,
+      txTo: errAny?.transaction?.to,
+      tokensCount: tokens.length,
+      scoresCount: scores.length,
+      gradesCount: grades.length,
+      timestampsCount: timestamps.length,
+      versionsCount: versions.length,
+      firstToken: tokens[0],
+      firstScore: scores[0],
+      firstGrade: grades[0],
+      firstTimestamp: timestamps[0],
+      firstVersion: versions[0],
     });
     return null;
   }
@@ -248,9 +282,39 @@ export async function publishPsiScores(
     psiGasLimit = (gasEstimate * 120n) / 100n;
     logger.info("PSI gas estimated", { chain: chainKey, estimate: gasEstimate.toString(), limit: psiGasLimit.toString() });
   } catch (err) {
+    // Enhanced revert diagnostics (diagnose/psi-estimategas-revert). The
+    // BasisSIIOracle PSI path has four per-slug requires inside
+    // updatePsiScore (called by batchUpdatePsiScores):
+    //   - "Basis: empty slug"
+    //   - "Basis: score out of range"       (score > 10000)
+    //   - "Basis: future timestamp"         (timestamp > block.timestamp)
+    //   - "Basis: stale update"             (timestamp <= stored)
+    // Any single failing slug reverts the whole batch. This block captures
+    // enough context to identify which one fired. Cross-reference with
+    // scripts/diagnose_psi_state.ts which reads on-chain state per slug
+    // from both Base and Arbitrum.
+    const errAny = err as any;
     logger.warn("PSI gas estimate failed — tx would revert, skipping", {
       chain: chainKey,
-      error: err instanceof Error ? err.message : String(err),
+      method: "batchUpdatePsiScores",
+      message: errAny?.message,
+      code: errAny?.code,
+      reason: errAny?.reason,
+      shortMessage: errAny?.shortMessage,
+      data: errAny?.data,
+      info: errAny?.info,
+      txFrom: errAny?.transaction?.from,
+      txTo: errAny?.transaction?.to,
+      slugsCount: slugs.length,
+      scoresCount: scores.length,
+      gradesCount: grades.length,
+      timestampsCount: timestamps.length,
+      versionsCount: versions.length,
+      firstSlug: slugs[0],
+      firstScore: scores[0],
+      firstGrade: grades[0],
+      firstTimestamp: timestamps[0],
+      firstVersion: versions[0],
     });
     return null;
   }
@@ -332,10 +396,23 @@ export async function publishReportHashes(
         );
         reportGasLimit = (est * 120n) / 100n;
       } catch (estErr) {
+        // Enhanced revert diagnostics — mirrors the SII/PSI catch blocks
+        // so every estimateGas failure surfaces the same structured fields.
+        const estErrAny = estErr as any;
         logger.warn("Report hash gas estimate failed — skipping", {
           chain: chainKey,
+          method: "publishReportHash",
           entityId: u.entityId.slice(0, 18),
-          error: estErr instanceof Error ? estErr.message : String(estErr),
+          reportHash: u.reportHash?.slice?.(0, 18),
+          lensId: u.lensId,
+          message: estErrAny?.message,
+          code: estErrAny?.code,
+          reason: estErrAny?.reason,
+          shortMessage: estErrAny?.shortMessage,
+          data: estErrAny?.data,
+          info: estErrAny?.info,
+          txFrom: estErrAny?.transaction?.from,
+          txTo: estErrAny?.transaction?.to,
         });
         continue;
       }
@@ -395,9 +472,21 @@ export async function publishStateRoot(
       const est = await (oracle.publishStateRoot as ethers.BaseContractMethod).estimateGas(stateRootHash);
       stateRootGasLimit = (est * 120n) / 100n;
     } catch (estErr) {
+      // Enhanced revert diagnostics — consistent shape across every
+      // estimateGas catch in this file.
+      const estErrAny = estErr as any;
       logger.warn("State root gas estimate failed — tx would revert, skipping", {
         chain: chainKey,
-        error: estErr instanceof Error ? estErr.message : String(estErr),
+        method: "publishStateRoot",
+        stateRootHash: stateRootHash?.slice?.(0, 18),
+        message: estErrAny?.message,
+        code: estErrAny?.code,
+        reason: estErrAny?.reason,
+        shortMessage: estErrAny?.shortMessage,
+        data: estErrAny?.data,
+        info: estErrAny?.info,
+        txFrom: estErrAny?.transaction?.from,
+        txTo: estErrAny?.transaction?.to,
       });
       return false;
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,13 +10,14 @@
       "license": "ISC",
       "dependencies": {
         "@vitejs/plugin-react": "^6.0.1",
-        "dotenv": "^17.4.1",
+        "dotenv": "^17.4.2",
         "ethers": "^6.16.0",
         "picomatch": "^4.0.4",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
         "rollup": "^4.60.1",
         "tsx": "^4.21.0",
+        "typescript": "^6.0.3",
         "vite": "^8.0.3"
       }
     },
@@ -1166,9 +1167,9 @@
       }
     },
     "node_modules/dotenv": {
-      "version": "17.4.1",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.1.tgz",
-      "integrity": "sha512-k8DaKGP6r1G30Lx8V4+pCsLzKr8vLmV2paqEj1Y55GdAgJuIqpRp5FfajGF8KtwMxCz9qJc6wUIJnm053d/WCw==",
+      "version": "17.4.2",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.2.tgz",
+      "integrity": "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==",
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=12"
@@ -1791,6 +1792,19 @@
       },
       "optionalDependencies": {
         "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     },
     "node_modules/undici-types": {

--- a/package.json
+++ b/package.json
@@ -11,13 +11,14 @@
   "license": "ISC",
   "dependencies": {
     "@vitejs/plugin-react": "^6.0.1",
-    "dotenv": "^17.4.1",
+    "dotenv": "^17.4.2",
     "ethers": "^6.16.0",
     "picomatch": "^4.0.4",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
     "rollup": "^4.60.1",
     "tsx": "^4.21.0",
+    "typescript": "^6.0.3",
     "vite": "^8.0.3"
   }
 }

--- a/scripts/diagnose_psi_state.ts
+++ b/scripts/diagnose_psi_state.ts
@@ -1,0 +1,327 @@
+/**
+ * PSI on-chain state diagnostic.
+ *
+ * Read-only cross-chain check: for every PSI slug the hub is currently
+ * publishing, print the stored state on both Base and Arbitrum side-by-side
+ * and flag drift. Built in response to the observed keeper behavior where
+ * `batchUpdatePsiScores` succeeds on one chain and reverts with
+ * `estimateGas failed` on the other from the same wallet, same cycle
+ * (SII publishes successfully on both chains in the same cycle, so it
+ * isn't an auth or basic-connectivity issue).
+ *
+ * The BasisSIIOracle PSI path has four per-slug requires inside
+ * `updatePsiScore` (called by `batchUpdatePsiScores`):
+ *
+ *   1. `bytes(protocolSlug).length > 0`          → "Basis: empty slug"
+ *   2. `score <= 10000`                          → "Basis: score out of range"
+ *   3. `timestamp <= uint48(block.timestamp)`    → "Basis: future timestamp"
+ *   4. `timestamp > psiScores[slugHash].timestamp` → "Basis: stale update"
+ *
+ * Any ONE failing slug reverts the entire batch. The most likely cause of
+ * one-chain-only revert is (4): a prior cycle published a PSI batch on one
+ * chain and failed on the other, leaving the stored timestamp on the
+ * "ahead" chain >= the current cycle's timestamp → keeper submits a batch
+ * where at least one slug's timestamp is not strictly greater than the
+ * stored value → revert. This diagnostic surfaces exactly that.
+ *
+ * Usage:
+ *   # Read-only; no private key required.
+ *   BASIS_API_URL=https://basisprotocol.xyz \
+ *   BASE_RPC_URL=https://base-mainnet.g.alchemy.com/v2/... \
+ *   ARBITRUM_RPC_URL=https://arb-mainnet.g.alchemy.com/v2/... \
+ *   BASE_ORACLE_ADDRESS=0x1651d7b2E238a952167E51A1263FFe607584DB83 \
+ *   ARBITRUM_ORACLE_ADDRESS=0x1651d7b2E238a952167E51A1263FFe607584DB83 \
+ *   npx tsx scripts/diagnose_psi_state.ts
+ *
+ * Output: one line per slug with (Base score/ts/version | Arbitrum score/ts/version
+ * | drift flags). Summary at the end lists slugs that would block
+ * `batchUpdatePsiScores` on each chain for the current cycle timestamp.
+ *
+ * IMPORTANT: This script is read-only. It does not submit transactions,
+ * require a private key, or modify any state. Safe to run from any
+ * environment that can reach the hub API and both RPC endpoints.
+ */
+
+import { ethers } from "ethers";
+
+// ---------------------------------------------------------------------------
+// Configuration
+// ---------------------------------------------------------------------------
+
+const ORACLE_READ_ABI = [
+  "function getPsiScore(string calldata protocolSlug) external view returns (uint16 score, bytes2 grade, uint48 timestamp, uint16 version)",
+  "function getPsiScoreCount() external view returns (uint256)",
+];
+
+interface ChainContext {
+  key: "base" | "arbitrum";
+  rpcUrl: string;
+  oracleAddress: string;
+  chainId: number;
+}
+
+interface HubPsiRow {
+  protocol_slug: string;
+  score: number;      // 0-100 from the hub API
+  grade: string;
+  computed_at?: string;
+}
+
+interface HubPsiResponse {
+  protocols: HubPsiRow[];
+}
+
+interface OnChainRow {
+  score: number;      // 0-10000 (hub*100)
+  grade: string;      // bytes2 hex
+  timestamp: number;  // unix seconds
+  version: number;
+  exists: boolean;    // false when all fields are zero (mapping default)
+}
+
+function requireEnv(key: string): string {
+  const v = process.env[key];
+  if (!v) {
+    throw new Error(`Missing required env var: ${key}`);
+  }
+  return v;
+}
+
+function buildContexts(): ChainContext[] {
+  return [
+    {
+      key: "base",
+      rpcUrl: requireEnv("BASE_RPC_URL"),
+      oracleAddress: requireEnv("BASE_ORACLE_ADDRESS"),
+      chainId: 8453,
+    },
+    {
+      key: "arbitrum",
+      rpcUrl: requireEnv("ARBITRUM_RPC_URL"),
+      oracleAddress: requireEnv("ARBITRUM_ORACLE_ADDRESS"),
+      chainId: 42161,
+    },
+  ];
+}
+
+// ---------------------------------------------------------------------------
+// Fetch hub state
+// ---------------------------------------------------------------------------
+
+async function fetchHubPsiScores(apiUrl: string): Promise<HubPsiRow[]> {
+  const url = `${apiUrl}/api/psi/scores`;
+  const res = await fetch(url, {
+    headers: { Accept: "application/json" },
+    signal: AbortSignal.timeout(30_000),
+  });
+  if (!res.ok) {
+    throw new Error(`PSI API returned HTTP ${res.status}: ${await res.text()}`);
+  }
+  const raw = (await res.json()) as HubPsiResponse;
+  return (raw.protocols || []).filter((p) => p.score != null && p.grade);
+}
+
+// ---------------------------------------------------------------------------
+// Read on-chain PSI state
+// ---------------------------------------------------------------------------
+
+async function readOnChainPsi(
+  ctx: ChainContext,
+  slug: string
+): Promise<OnChainRow> {
+  const provider = new ethers.JsonRpcProvider(ctx.rpcUrl);
+  const oracle = new ethers.Contract(ctx.oracleAddress, ORACLE_READ_ABI, provider);
+
+  // getPsiScore returns (score, grade, timestamp, version). On slugs that
+  // were never published, all fields default to 0 / 0x0000.
+  const [rawScore, rawGrade, rawTs, rawVer] = await oracle.getPsiScore(slug) as [
+    bigint, string, bigint, bigint,
+  ];
+  const score = Number(rawScore);
+  const grade = (rawGrade || "").toLowerCase();
+  const timestamp = Number(rawTs);
+  const version = Number(rawVer);
+  const exists = score !== 0 || timestamp !== 0 || version !== 0
+    || (grade !== "0x0000" && grade !== "");
+
+  return { score, grade, timestamp, version, exists };
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+function pad(s: string, n: number): string {
+  return s.length >= n ? s : s + " ".repeat(n - s.length);
+}
+
+function fmtTs(unix: number): string {
+  if (!unix) return "(unset)";
+  return new Date(unix * 1000).toISOString().replace("T", " ").replace(".000Z", "Z");
+}
+
+async function main(): Promise<void> {
+  const apiUrl = process.env.BASIS_API_URL || "https://basisprotocol.xyz";
+  const chains = buildContexts();
+
+  console.log(`[diagnose_psi_state] api=${apiUrl}`);
+  console.log(
+    `[diagnose_psi_state] chains=${chains.map((c) => `${c.key}(${c.chainId})`).join(", ")}\n`
+  );
+
+  const hubRows = await fetchHubPsiScores(apiUrl);
+  console.log(`[diagnose_psi_state] hub returned ${hubRows.length} scored protocols`);
+
+  // Current cycle's would-submit timestamp — what the keeper would send this
+  // instant. The PSI check that most often fires one-chain-only is
+  // `timestamp > stored` (= "Basis: stale update").
+  const cycleTs = Math.floor(Date.now() / 1000);
+  console.log(`[diagnose_psi_state] cycle_ts=${cycleTs} (${fmtTs(cycleTs)})\n`);
+
+  const header = [
+    pad("slug", 28),
+    pad("hub_score", 10),
+    pad("hub_grade", 10),
+    pad("base(score/ts/ver)", 36),
+    pad("arb(score/ts/ver)", 36),
+    "drift",
+  ].join(" ");
+  console.log(header);
+  console.log("-".repeat(header.length));
+
+  const baseStaleSlugs: string[] = [];
+  const arbStaleSlugs: string[] = [];
+  const baseMissingSlugs: string[] = [];
+  const arbMissingSlugs: string[] = [];
+  const versionDriftSlugs: Array<{ slug: string; base: number; arb: number }> = [];
+  let baseReadErrors = 0;
+  let arbReadErrors = 0;
+
+  for (const row of hubRows) {
+    const slug = row.protocol_slug;
+    const hubScoreScaled = Math.round(row.score * 100);
+
+    let base: OnChainRow | null = null;
+    let arb: OnChainRow | null = null;
+    try {
+      base = await readOnChainPsi(chains[0], slug);
+    } catch (e) {
+      baseReadErrors++;
+      console.error(`[read-error base] ${slug}: ${(e as Error).message}`);
+    }
+    try {
+      arb = await readOnChainPsi(chains[1], slug);
+    } catch (e) {
+      arbReadErrors++;
+      console.error(`[read-error arb] ${slug}: ${(e as Error).message}`);
+    }
+
+    const driftFlags: string[] = [];
+
+    if (base && !base.exists) baseMissingSlugs.push(slug);
+    if (arb && !arb.exists) arbMissingSlugs.push(slug);
+
+    // The "stale update" require: `timestamp > stored`. If stored >= cycleTs
+    // for any slug in the batch, the whole batchUpdatePsiScores reverts.
+    if (base && base.exists && base.timestamp >= cycleTs) baseStaleSlugs.push(slug);
+    if (arb && arb.exists && arb.timestamp >= cycleTs) arbStaleSlugs.push(slug);
+
+    // Cross-chain version drift: stored version on one chain strictly greater
+    // than the other. Informational — the contract does not enforce a
+    // monotonic version invariant on the PSI path (only on SII reports),
+    // but version drift often travels with timestamp drift.
+    if (base && arb && base.exists && arb.exists && base.version !== arb.version) {
+      versionDriftSlugs.push({ slug, base: base.version, arb: arb.version });
+      driftFlags.push(`version_mismatch(b=${base.version},a=${arb.version})`);
+    }
+
+    // Score-range precheck for require (2): score <= 10000 when submitting.
+    if (hubScoreScaled > 10000) {
+      driftFlags.push(`hub_score_overflow(${hubScoreScaled})`);
+    }
+
+    // Flag slugs that would block the current cycle's batchUpdatePsiScores.
+    if (base && base.exists && base.timestamp >= cycleTs) {
+      driftFlags.push(`base_would_revert_stale(stored_ts=${base.timestamp})`);
+    }
+    if (arb && arb.exists && arb.timestamp >= cycleTs) {
+      driftFlags.push(`arb_would_revert_stale(stored_ts=${arb.timestamp})`);
+    }
+
+    const baseStr = base
+      ? (base.exists
+          ? `${base.score}/${fmtTs(base.timestamp)}/${base.version}`
+          : "(unset)")
+      : "(read error)";
+    const arbStr = arb
+      ? (arb.exists
+          ? `${arb.score}/${fmtTs(arb.timestamp)}/${arb.version}`
+          : "(unset)")
+      : "(read error)";
+
+    console.log([
+      pad(slug, 28),
+      pad(String(hubScoreScaled), 10),
+      pad(row.grade, 10),
+      pad(baseStr, 36),
+      pad(arbStr, 36),
+      driftFlags.length ? driftFlags.join(",") : "-",
+    ].join(" "));
+  }
+
+  console.log("");
+  console.log("================ SUMMARY ================");
+  console.log(`hub_protocols=${hubRows.length}`);
+  console.log(`base read errors=${baseReadErrors}`);
+  console.log(`arb  read errors=${arbReadErrors}`);
+  console.log(`slugs missing on base: ${baseMissingSlugs.length}`);
+  if (baseMissingSlugs.length) {
+    console.log(`  ${baseMissingSlugs.join(", ")}`);
+  }
+  console.log(`slugs missing on arb:  ${arbMissingSlugs.length}`);
+  if (arbMissingSlugs.length) {
+    console.log(`  ${arbMissingSlugs.join(", ")}`);
+  }
+  console.log(`version drift (base != arb): ${versionDriftSlugs.length}`);
+  for (const v of versionDriftSlugs) {
+    console.log(`  ${v.slug}: base=${v.base} arb=${v.arb}`);
+  }
+  console.log("");
+  console.log(
+    `slugs that would block batchUpdatePsiScores on BASE this cycle ` +
+    `(timestamp >= ${cycleTs}): ${baseStaleSlugs.length}`
+  );
+  if (baseStaleSlugs.length) {
+    console.log(`  ${baseStaleSlugs.join(", ")}`);
+  }
+  console.log(
+    `slugs that would block batchUpdatePsiScores on ARBITRUM this cycle ` +
+    `(timestamp >= ${cycleTs}): ${arbStaleSlugs.length}`
+  );
+  if (arbStaleSlugs.length) {
+    console.log(`  ${arbStaleSlugs.join(", ")}`);
+  }
+  console.log("=========================================");
+
+  // Exit code reflects the most likely reverts: nonzero if at least one
+  // chain has a stale-update conflict for the current cycle.
+  if (baseStaleSlugs.length > 0 || arbStaleSlugs.length > 0) {
+    console.log("");
+    console.log(
+      "DIAGNOSIS: at least one chain has at least one slug with " +
+      "stored timestamp >= the current cycle timestamp. The require() that " +
+      "will fire is updatePsiScore's `timestamp > psiScores[slugHash].timestamp` " +
+      `("Basis: stale update"). ` +
+      "Fix candidates (to be addressed in a separate PR):\n" +
+      "  - ensure per-chain cycle timestamps advance independently, OR\n" +
+      "  - skip already-up-to-date slugs per chain in the keeper's differ, OR\n" +
+      "  - bump cycleTimestamp to NOW() on every cycle and tolerate occasional drift"
+    );
+    process.exit(1);
+  }
+}
+
+main().catch((err) => {
+  console.error("diagnose_psi_state failed:", err);
+  process.exit(2);
+});


### PR DESCRIPTION
## Summary

Diagnostic PR only. No behavior change to publishing logic.

Surfaces enough data to explain why `batchUpdatePsiScores` reverts on one chain while succeeding on the other from the same wallet in the same cycle (and while `batchUpdateScores` / SII succeeds on both). The actual fix ships in a separate PR once the enhanced logs + diagnostic script identify the failing `require()`.

## What ships

### 1. Enhanced `estimateGas` error logging — `keeper/publisher.ts`

Every `estimateGas` catch block now logs ethers' full revert surface:

- `message` / `code` / `reason` / `shortMessage` / `data` / `info`
- `transaction.from` / `transaction.to`
- Method-specific batch shape: array lengths + first-element preview (first slug, first score, first grade, first timestamp, first version)

Applied consistently across **all four** catches: `batchUpdateScores` (SII), `batchUpdatePsiScores` (PSI), `publishReportHash`, `publishStateRoot`. Cross-chain drift shows up in the same structured fields now.

### 2. ORACLE_ABI read accessors

Added `getPsiScore(string)` → `(score, grade, timestamp, version)` and `scores(address)` → same tuple shape, for the diagnostic script to read per-slug state from both chains. Write-path ABI unchanged.

### 3. `scripts/diagnose_psi_state.ts` — read-only cross-chain state check

```bash
BASIS_API_URL=https://basisprotocol.xyz \
BASE_RPC_URL=... \
ARBITRUM_RPC_URL=... \
BASE_ORACLE_ADDRESS=0x1651d7b2E238a952167E51A1263FFe607584DB83 \
ARBITRUM_ORACLE_ADDRESS=0x1651d7b2E238a952167E51A1263FFe607584DB83 \
npx tsx scripts/diagnose_psi_state.ts
```

Per-slug table with columns: hub score / hub grade / base(score/ts/ver) / arb(score/ts/ver) / drift flags. Summary section lists:
- slugs missing on each chain
- version drift (base ≠ arb)
- slugs where `stored_timestamp >= current_cycle_timestamp` on each chain — these fire the `"Basis: stale update"` require and revert the whole batch

Read-only. No private key. Exits non-zero when at least one stale-update conflict is detected on either chain.

## Root-cause hypothesis (strongly suspected, confirmation pending)

The `BasisSIIOracle.batchUpdatePsiScores` path calls `updatePsiScore` per slug. Each per-slug call has four `require()`s:

| # | require | revert string |
|---|---|---|
| 1 | `bytes(protocolSlug).length > 0` | `"Basis: empty slug"` |
| 2 | `score <= 10000` | `"Basis: score out of range"` |
| 3 | `timestamp <= uint48(block.timestamp)` | `"Basis: future timestamp"` |
| 4 | `timestamp > psiScores[slugHash].timestamp` | `"Basis: stale update"` |

**Any single failing slug reverts the whole batch.**

The pattern "succeeds on one chain, reverts on the other from the same wallet + same batch, while SII succeeds on both" fits **#4 "Basis: stale update"**. A prior partial cycle published PSI on one chain and failed on the other, leaving the ahead chain's stored timestamp >= the current cycle's timestamp for at least one slug. SII uses the equivalent require but on a different storage mapping (`scores` keyed by token address, not slug), so SII can advance cleanly even when PSI drifts.

## Which chain is failing

Can't tell from source alone — which chain "succeeded first" in the prior partial cycle is an operational accident. The enhanced log line at the next cycle will carry `chain=<base|arbitrum>` in the structured fields of `"PSI gas estimate failed"`, and the diagnostic script's summary will print the per-chain list of stale-update slugs.

## Follow-ups (separate PRs)

Not in this diagnostic PR:
- Fix for the stale-update drift (candidates: advance timestamps per-chain in the differ, skip already-up-to-date slugs per chain, or tolerate time drift explicitly).
- No retry-logic change. No gas-estimation-logic change (the revert IS the signal we want). No try/catch wrapping that publishes anyway. No contract change. No on-chain write.

## Typecheck

`tsc --noEmit` clean on `keeper/publisher.ts` + `scripts/diagnose_psi_state.ts`.

## Acceptance criteria (from spec)

- [x] Enhanced error logging on every estimateGas catch block
- [x] Diagnosis script produces per-slug cross-chain state report
- [x] Report structure flags specific revert causes (stale_update / missing / version_drift / score_overflow)

Next step post-merge: next keeper cycle emits the enhanced log line, then run the diagnosis script to get the per-slug picture. Both outputs go into the fix PR.

https://claude.ai/code/session_012Kdm7QyJLDSmGyrjiXueqx

---
_Generated by [Claude Code](https://claude.ai/code/session_012Kdm7QyJLDSmGyrjiXueqx)_