### PR TITLE
fix: wire track_record to both cycle paths + auto-seed methodology hashes

### DIFF
--- a/app/track_record.py
+++ b/app/track_record.py
@@ -616,11 +616,12 @@ def detect_and_log_entries() -> dict:
         try:
             # Freshness gate
             if _is_domain_stale(source_domain):
-                logger.info(f"Skipped track_record rule {rule_name}: source domain {source_domain} stale")
+                logger.error(f"[track_record] rule {rule_name}: SKIPPED (source domain {source_domain} stale)")
                 skipped_stale += 1
                 continue
 
             entries = rule_fn()
+            logger.error(f"[track_record] rule {rule_name}: {len(entries)} candidates found")
             for entry in entries:
                 entry["state_root"] = state_root
                 if _entry_exists(entry["content_hash"]):
@@ -629,13 +630,14 @@ def detect_and_log_entries() -> dict:
                 try:
                     _insert_entry(entry)
                     all_entries.append(entry["trigger_kind"])
+                    logger.error(f"[track_record] INSERTED: {entry['entity_slug']}/{entry['trigger_kind']}")
                 except Exception as e:
-                    logger.warning(f"Failed to insert track_record entry: {e}")
+                    logger.error(f"[track_record] INSERT FAILED: {e}")
         except Exception as e:
-            logger.warning(f"Track record rule {rule_name} failed: {e}")
+            logger.error(f"[track_record] rule {rule_name} FAILED: {e}")
 
-    logger.info(
-        f"Track record: {len(all_entries)} entries logged, "
+    logger.error(
+        f"[track_record] SUMMARY: {len(all_entries)} entries logged, "
         f"{skipped_duplicate} duplicates skipped, "
         f"{skipped_stale} rules skipped (stale domain)"
     )

--- a/app/worker.py
+++ b/app/worker.py
@@ -2434,6 +2434,15 @@ async def run_slow_cycle():
     except Exception as e:
         logger.warning(f"Coherence sweep failed: {e}")
 
+    # Track record: also run in fallback slow cycle path
+    try:
+        from app.track_record import detect_and_log_entries
+        logger.error("[track_record] running detect_and_log_entries (fallback path)")
+        tr_result = detect_and_log_entries()
+        logger.error(f"[track_record] result: {tr_result}")
+    except Exception as e:
+        logger.error(f"[track_record] auto-log failed (fallback): {e}", exc_info=True)
+
     elapsed = time.time() - start
     logger.info(f"=== Slow cycle complete in {elapsed:.0f}s ===")
 
@@ -2755,10 +2764,11 @@ async def run_slow_cycle_parallel():
     # Track record: auto-log qualifying entries from this cycle's signals
     try:
         from app.track_record import detect_and_log_entries
+        logger.error("[track_record] running detect_and_log_entries")
         tr_result = detect_and_log_entries()
-        logger.info(f"Track record: {tr_result.get('entries_logged', 0)} entries logged")
+        logger.error(f"[track_record] result: {tr_result}")
     except Exception as e:
-        logger.error(f"track_record auto-log failed: {e}", exc_info=True)
+        logger.error(f"[track_record] auto-log failed: {e}", exc_info=True)
 
     # Track record: evaluate pending followups (daily)
     try:
@@ -3249,6 +3259,22 @@ async def main():
         logger.error(f"[schema_validator] failed to run: {e}")
 
     logger.error("[startup] schema fixes complete, diagnostics will fire in 60s via independent loop")
+
+    # Seed methodology hashes (idempotent — skips existing)
+    try:
+        from app.methodology_hashes import register_methodology
+        _meth_seeded = 0
+        _meth_skipped = 0
+        import scripts.seed_initial_methodology as _seed_meth
+        for _mid, _content, _desc in _seed_meth.METHODOLOGIES:
+            try:
+                register_methodology(_mid, _content, _desc)
+                _meth_seeded += 1
+            except ValueError:
+                _meth_skipped += 1
+        logger.error(f"[startup] methodology hashes: seeded={_meth_seeded}, skipped={_meth_skipped}")
+    except Exception as e:
+        logger.error(f"[startup] methodology seed failed: {e}")
 
     # Dwellir RPC capability probe — one-shot at boot. Never raises.
     # Records results in rpc_capabilities so ops can see what Dwellir's free


### PR DESCRIPTION
## Summary

Two production tables have been empty for 2+ weeks despite the underlying code existing. Root causes found and fixed.

### track_record_entries (0 rows)

**Root cause:** `detect_and_log_entries()` lives in the post-pipeline section of `run_slow_cycle_parallel()` (line 2755). When the enrichment pipeline crashed (which it did for 2 weeks due to the httpx/semaphore/liquidity storms), the fallback `run_slow_cycle()` was called instead — and it `return`ed at line 2466, **skipping all post-pipeline tasks** including track_record.

**Fix:**
- Added `detect_and_log_entries()` call to the `run_slow_cycle()` fallback path so it runs regardless of which cycle path executes
- Upgraded all rule logging from `logger.info`/`logger.warning` to `logger.error` for Railway visibility
- Each rule now logs candidate count: `[track_record] rule score_change: 3 candidates found`
- Each insert logs: `[track_record] INSERTED: usdc/score_change`

### methodology_hashes (0 rows)

**Root cause:** The seed script `scripts/seed_initial_methodology.py` exists and is correct, but it's a manual script — nothing auto-runs it. It was never executed in production.

**Fix:** Added methodology seeding to worker startup (after schema validator, before cycle loop). Uses `register_methodology()` directly with the METHODOLOGIES list from the seed script. Idempotent — skips existing IDs. Logs `[startup] methodology hashes: seeded=4, skipped=0`.

## Test plan
- [ ] After deploy, `[startup] methodology hashes: seeded=4` appears in logs
- [ ] `SELECT COUNT(*) FROM methodology_hashes` returns 4
- [ ] `[track_record] running detect_and_log_entries` appears in logs each cycle
- [ ] `[track_record] SUMMARY:` shows rule-by-rule candidate counts
- [ ] If any rule finds candidates, `track_record_entries` gets rows

https://claude.ai/code/session_011bTVc5haorCZgtCtxzJmtq

---
_Generated by [Claude Code](https://claude.ai/code/session_011bTVc5haorCZgtCtxzJmtq)_