### PR TITLE
fix: Phase 2 — migrate 2 collectors, surface fast-cycle timing, probe Blockscout failures

### DIFF
--- a/app/collectors/registry.py
+++ b/app/collectors/registry.py
@@ -160,19 +160,29 @@ class CycleStats:
         self._data[name]["error"] += 1
 
     def log_summary(self):
+        # Bumped from logger.info to logger.error so Railway surfaces this
+        # prominently. Prior level meant the fast-cycle 30-min timeout
+        # diagnosis was invisible to operators — exactly when we need it.
         if not self._data:
-            logger.info("CycleStats: no collector data recorded")
+            logger.error("[cycle_stats] no collector data recorded")
             return
-        logger.info("=== Collector cycle stats ===")
-        for name, d in sorted(self._data.items()):
+        logger.error("=== [cycle_stats] Collector cycle stats ===")
+        # Sort by avg latency descending so slowest collectors surface first.
+        rows = []
+        for name, d in self._data.items():
             avg_ms = (
                 int(sum(d["latencies"]) / len(d["latencies"]))
                 if d["latencies"]
                 else 0
             )
-            logger.info(
+            max_ms = max(d["latencies"]) if d["latencies"] else 0
+            rows.append((name, d, avg_ms, max_ms))
+        rows.sort(key=lambda r: -r[2])
+        for name, d, avg_ms, max_ms in rows:
+            logger.error(
                 f"  {name:30s}  ok={d['ok']:3d}  timeout={d['timeout']:2d}  "
-                f"error={d['error']:2d}  avg={avg_ms:5d}ms  components={d['components']}"
+                f"error={d['error']:2d}  avg={avg_ms:5d}ms  max={max_ms:5d}ms  "
+                f"components={d['components']}"
             )
 
     def store(self):
@@ -307,6 +317,13 @@ async def run_all_collectors(
     # --- async collectors (parallel with per-collector timeout) ---
     async_collectors = _make_async_collectors()
 
+    # Per-collector call that exceeds this fraction of its timeout is
+    # logged as a slow call so fast-cycle 30-min timeouts can be
+    # attributed to specific (collector, stablecoin) pairs without
+    # re-running the cycle.
+    SLOW_CALL_FRACTION = 0.75
+    slow_threshold_ms = int(timeout * SLOW_CALL_FRACTION * 1000)
+
     async def _instrumented(name, coro):
         t0 = time.monotonic()
         try:
@@ -315,6 +332,11 @@ async def run_all_collectors(
             count = len(result) if result else 0
             if cycle_stats:
                 cycle_stats.record_ok(name, elapsed_ms, count)
+            if elapsed_ms >= slow_threshold_ms:
+                logger.error(
+                    f"[slow_collector] {name} took {elapsed_ms}ms for {stablecoin_id} "
+                    f"(>={int(SLOW_CALL_FRACTION*100)}% of {int(timeout*1000)}ms timeout)"
+                )
             return result or []
         except asyncio.TimeoutError:
             logger.warning(f"{name} timed out for {stablecoin_id}")

--- a/app/data_layer/approval_collector.py
+++ b/app/data_layer/approval_collector.py
@@ -5,9 +5,11 @@ Diff-capture of ERC-20 approval state for top wallets via Blockscout v2.
 Budget: ~500 Blockscout calls/day (<0.5% of 100K daily budget).
 """
 
+import asyncio
 import hashlib
 import logging
 import time
+from datetime import datetime, timezone
 
 import httpx
 
@@ -182,3 +184,47 @@ async def run_approval_collection() -> dict:
         "errors": total_errors,
         "blockscout_calls": total_calls,
     }
+
+
+# ---------------------------------------------------------------------------
+# Independent background loop — sidestep pattern (matches trace_collector_bg,
+# holder_ingestion_bg, multichain_holder_bg, wallet_presence_bg)
+# ---------------------------------------------------------------------------
+
+LOOP_CHECK_INTERVAL = 3600       # hourly tick
+LOOP_GATE_HOURS = 24             # run at most daily
+
+
+async def approval_collector_background_loop():
+    logger.error("[approval_bg] background loop started")
+    await asyncio.sleep(120)      # initial delay — let pool init + trace_bg start
+    while True:
+        try:
+            last = fetch_one(
+                "SELECT MAX(snapshot_at) AS latest FROM token_approval_snapshots"
+            )
+            latest = last.get("latest") if last else None
+            if latest is None:
+                age_h = float("inf")
+            else:
+                if latest.tzinfo is None:
+                    latest = latest.replace(tzinfo=timezone.utc)
+                age_h = (datetime.now(timezone.utc) - latest).total_seconds() / 3600
+
+            if age_h >= LOOP_GATE_HOURS:
+                logger.error(
+                    f"[approval_bg] gate open (last_run={age_h:.1f}h ago, "
+                    f"threshold={LOOP_GATE_HOURS}h) — running scan"
+                )
+                result = await run_approval_collection()
+                logger.error(f"[approval_bg] scan complete: {result}")
+            else:
+                logger.error(
+                    f"[approval_bg] gate closed (last_run={age_h:.1f}h ago, "
+                    f"threshold={LOOP_GATE_HOURS}h) — sleeping 1h"
+                )
+        except Exception as e:
+            logger.error(f"[approval_bg] loop error: {type(e).__name__}: {e}")
+            await asyncio.sleep(300)
+            continue
+        await asyncio.sleep(LOOP_CHECK_INTERVAL)

--- a/app/data_layer/multichain_holder_collector.py
+++ b/app/data_layer/multichain_holder_collector.py
@@ -76,12 +76,23 @@ async def _fetch_holders_blockscout(
     if not host:
         return []
 
-    resp = await client.get(
-        f"https://{host}/api/v2/tokens/{contract}/holders",
-        timeout=30,
-    )
+    url = f"https://{host}/api/v2/tokens/{contract}/holders"
+    resp = await client.get(url, timeout=30)
     if resp.status_code != 200:
-        logger.error(f"[multichain_holder] blockscout {chain} returned HTTP {resp.status_code} for {contract[:12]}...")
+        # Log URL + body truncation so ops sees the actual Blockscout error
+        # message without having to reproduce with curl. BBBB (3eee9c7)
+        # removed limit=50 and added follow_redirects=True; any remaining
+        # non-200 means the per-chain Blockscout instance has drifted URL
+        # shape or parameter contract, and the response body tells us what.
+        body_snippet = (resp.text or "")[:200].replace("\n", " ")
+        final_url = str(resp.url)
+        redirect_info = (
+            f" via_redirect={final_url}" if final_url != url else ""
+        )
+        logger.error(
+            f"[multichain_holder] blockscout {chain} returned HTTP {resp.status_code} "
+            f"for {contract[:12]}... url={url}{redirect_info} body={body_snippet!r}"
+        )
         return []
 
     items = resp.json().get("items", [])

--- a/app/data_layer/trace_collector.py
+++ b/app/data_layer/trace_collector.py
@@ -5,10 +5,12 @@ Fetches raw traces for top PSI protocol transactions via Blockscout v2.
 Budget: ~143 Blockscout calls/day (<0.15% of 100K daily budget).
 """
 
+import asyncio
 import hashlib
 import json
 import logging
 import time
+from datetime import datetime, timezone
 
 import httpx
 
@@ -215,3 +217,52 @@ async def run_trace_collection() -> dict:
         "errors": total_errors,
         "blockscout_calls": total_calls,
     }
+
+
+# ---------------------------------------------------------------------------
+# Independent background loop — sidestep pattern
+# ---------------------------------------------------------------------------
+# The enrichment_worker pipeline path was dispatching this collector with a
+# `gate_check` that hung before the "starting: N..." log line could flush
+# (same failure mode as the now-sidestepped SSS / multichain / presence
+# collectors). This standalone loop runs the collector on its own cadence
+# and is launched from app/worker.py at startup. Logs one tick per hour
+# so Railway shows liveness.
+
+LOOP_CHECK_INTERVAL = 3600       # hourly tick
+LOOP_GATE_HOURS = 6              # run at most every 6h
+
+
+async def trace_collector_background_loop():
+    logger.error("[trace_bg] background loop started")
+    await asyncio.sleep(90)       # initial delay — let pool init complete
+    while True:
+        try:
+            last = fetch_one(
+                "SELECT MAX(captured_at) AS latest FROM protocol_trace_observations"
+            )
+            latest = last.get("latest") if last else None
+            if latest is None:
+                age_h = float("inf")
+            else:
+                if latest.tzinfo is None:
+                    latest = latest.replace(tzinfo=timezone.utc)
+                age_h = (datetime.now(timezone.utc) - latest).total_seconds() / 3600
+
+            if age_h >= LOOP_GATE_HOURS:
+                logger.error(
+                    f"[trace_bg] gate open (last_run={age_h:.1f}h ago, "
+                    f"threshold={LOOP_GATE_HOURS}h) — running scan"
+                )
+                result = await run_trace_collection()
+                logger.error(f"[trace_bg] scan complete: {result}")
+            else:
+                logger.error(
+                    f"[trace_bg] gate closed (last_run={age_h:.1f}h ago, "
+                    f"threshold={LOOP_GATE_HOURS}h) — sleeping 1h"
+                )
+        except Exception as e:
+            logger.error(f"[trace_bg] loop error: {type(e).__name__}: {e}")
+            await asyncio.sleep(300)
+            continue
+        await asyncio.sleep(LOOP_CHECK_INTERVAL)

--- a/app/enrichment_worker.py
+++ b/app/enrichment_worker.py
@@ -836,34 +836,17 @@ async def run_enrichment_pipeline() -> dict:
     # moved to independent background loops in worker.py main() — see ZZZ sidestep.
 
     # =========================================================================
-    # LLL Phase 1 Pipelines (daily, low-priority)
+    # LLL Phase 1 Pipelines — MIGRATED to independent background loops
     # =========================================================================
-
-    async def _run_trace_collection():
-        from app.data_layer.trace_collector import run_trace_collection
-        return await run_trace_collection()
-
-    pipeline.add(EnrichmentTask(
-        name="protocol_traces", func=_run_trace_collection,
-        timeout_seconds=600, group="data_layer", priority=4,
-        gate_check=make_db_gate(
-            "SELECT MAX(captured_at) AS latest FROM protocol_trace_observations",
-            min_hours=24,
-        ),
-    ))
-
-    async def _run_approval_collection():
-        from app.data_layer.approval_collector import run_approval_collection
-        return await run_approval_collection()
-
-    pipeline.add(EnrichmentTask(
-        name="token_approvals", func=_run_approval_collection,
-        timeout_seconds=600, group="data_layer", priority=4,
-        gate_check=make_db_gate(
-            "SELECT MAX(snapshot_at) AS latest FROM token_approval_snapshots",
-            min_hours=24,
-        ),
-    ))
+    # protocol_traces and token_approvals used to run here via pipeline.add()
+    # with a gate_check, but both hung after "starting: N..." logs (same
+    # failure mode as the previously-sidestepped SSS / multichain /
+    # presence collectors). They now run as independent asyncio.create_task
+    # background loops launched from app/worker.py's main() around the
+    # existing Phase 2 loop launches. See:
+    #   app/data_layer/trace_collector.py::trace_collector_background_loop
+    #   app/data_layer/approval_collector.py::approval_collector_background_loop
+    # Do NOT re-register them here — that would double-execute the scan.
 
     # =========================================================================
     # Wave 5: Computed surfaces

--- a/app/worker.py
+++ b/app/worker.py
@@ -923,25 +923,35 @@ async def run_fast_cycle():
     logger.info(f"Starting scoring cycle for {len(stablecoins)} stablecoins")
 
     results = []
+    # Per-stablecoin elapsed at error level for fast-cycle timeout
+    # attribution. Combined with [slow_collector] lines from the registry,
+    # this lets operators identify which (stablecoin, collector) pair is
+    # driving the 30-min cycle limit without re-running.
+    SLOW_SID_THRESHOLD_SEC = 60  # half of the per-sid 120s timeout
     async with httpx.AsyncClient(timeout=30) as client:
         for sid in stablecoins:
-            # For promoted coins (not in hardcoded registry), mark in_progress
             is_promoted = sid not in STABLECOIN_REGISTRY
             if is_promoted:
                 cfg = get_stablecoin_config(sid)
                 if cfg:
                     _mark_scoring_status(cfg["coingecko_id"], "in_progress")
+            sid_t0 = time.time()
             try:
                 result = await asyncio.wait_for(
                     score_stablecoin(client, sid), timeout=120
                 )
                 results.append(result)
-                # After success, mark scored for promoted coins
                 if is_promoted and "score" in result:
                     cfg = get_stablecoin_config(sid)
                     if cfg:
                         _mark_scoring_status(cfg["coingecko_id"], "scored")
-                # Rate limit: pause between coins
+                sid_elapsed = time.time() - sid_t0
+                if sid_elapsed >= SLOW_SID_THRESHOLD_SEC:
+                    logger.error(
+                        f"[slow_stablecoin] {sid} scored in {sid_elapsed:.1f}s "
+                        f"(>={SLOW_SID_THRESHOLD_SEC}s threshold — see [slow_collector] "
+                        f"lines above for the slow collector attribution)"
+                    )
                 await asyncio.sleep(2.0)
             except asyncio.TimeoutError:
                 logger.warning(f"Timeout scoring {sid} (>120s) — skipping")
@@ -3352,6 +3362,24 @@ async def main():
                 logger.error("[startup] wallet_presence background loop launched (daily)")
             except Exception as _wp_err:
                 logger.error(f"[startup] wallet_presence loop failed to launch: {_wp_err}")
+
+            # LLL Phase 1 Pipeline 1 & 2 — migrated from enrichment pipeline
+            # to independent background loops (same sidestep pattern). Both
+            # dispatch through their own _background_loop fn; enrichment_worker
+            # no longer registers them.
+            try:
+                from app.data_layer.trace_collector import trace_collector_background_loop
+                asyncio.create_task(trace_collector_background_loop(), name="trace_bg")
+                logger.error("[startup] trace_collector background loop launched (6h)")
+            except Exception as _tc_err:
+                logger.error(f"[startup] trace_collector loop failed to launch: {_tc_err}")
+
+            try:
+                from app.data_layer.approval_collector import approval_collector_background_loop
+                asyncio.create_task(approval_collector_background_loop(), name="approval_bg")
+                logger.error("[startup] approval_collector background loop launched (daily)")
+            except Exception as _ac_err:
+                logger.error(f"[startup] approval_collector loop failed to launch: {_ac_err}")
 
             cycle_counter = 0
             while True:


### PR DESCRIPTION
## Summary

Three-item Phase 2 cleanup. BBBB (`3eee9c7`) already landed on main and handled the Blockscout 422/301 / follow_redirects fix, so FIX 3 scope narrows to adding the observability that turns any remaining `FAIL` into an actionable diagnosis.

## State before this PR

| Item | Pre-PR state |
|---|---|
| BBBB deployed? | ✅ commit `3eee9c7` — gate logic + removed `limit=50` + `follow_redirects=True` on all 5 httpx clients |
| trace_collector / approval_collector | ❌ still in `enrichment_worker.py:842-866` via `pipeline.add`, hanging after `starting: N...` |
| holder_ingestion_bg / multichain_bg / presence_bg | ✅ already sidestepped in `worker.py:3336-3354` |
| Fast-cycle log visibility | `CycleStats.log_summary` at `logger.info`, invisible when cycle times out |

Verification query — sandbox has no `DATABASE_URL`; operator should run after deploy:

```bash
psql "$DATABASE_URL" -c "SELECT 'holders', COUNT(*) FROM wallet_holder_discovery
  UNION ALL SELECT 'presence', COUNT(*) FROM wallet_chain_presence
  UNION ALL SELECT 'wallet_graph', COUNT(*) FROM wallet_graph.wallets
  UNION ALL SELECT 'traces', COUNT(*) FROM protocol_trace_observations
  UNION ALL SELECT 'approvals', COUNT(*) FROM token_approval_snapshots;"
```

## FIX 1 — trace + approval → independent background loops

Same sidestep pattern as the three existing Phase 2 loops.

- `app/data_layer/trace_collector.py` — `trace_collector_background_loop()`, 6-hour gate, hourly tick, 90s initial delay. Checks `MAX(captured_at) FROM protocol_trace_observations`.
- `app/data_layer/approval_collector.py` — `approval_collector_background_loop()`, 24-hour gate, hourly tick, 120s initial delay (staggered after trace). Checks `MAX(snapshot_at) FROM token_approval_snapshots`.
- `app/worker.py main()` — two `asyncio.create_task` launches alongside the existing Phase 2 block, named `trace_bg` / `approval_bg`.
- `app/enrichment_worker.py` — both `pipeline.add()` entries removed; replaced with a comment block pointing at the new loops so nothing double-executes.

**Dispatch grep (per guardrail):**
```
enrichment_worker.py: only comments reference trace_collector / approval_collector
worker.py:3371-3382:  two create_task launches + 4 logger lines
```

## FIX 2 — fast-cycle timeout diagnostic

I can't read production logs from the sandbox, so I can't run the `grep "Timeout scoring"` triage. What I can do is make the next cycle name the culprit at error level so operators don't have to re-run.

- `app/collectors/registry.py::CycleStats.log_summary` bumped from `logger.info` → `logger.error`. Rows sorted by avg latency desc; added `max` latency column.
- `app/collectors/registry.py::_instrumented` — when a single collector call exceeds 75% of its timeout (15s of 20s), emits:
  ```
  [slow_collector] <name> took <Nms> for <sid> (>=75% of 20000ms timeout)
  ```
- `app/worker.py run_fast_cycle` — per-stablecoin elapsed at error level when >= 60s:
  ```
  [slow_stablecoin] <sid> scored in N.Ns (>=60s threshold — see [slow_collector] lines above)
  ```

**Pair them to triangulate.** No timeout bumps.

## FIX 3 — Blockscout non-200 body logging

- `app/data_layer/multichain_holder_collector.py` — non-200 path now logs URL, final URL (if redirected), and first 200 chars of response body. No behavior change — still returns `[]`; no retry.

This makes any remaining `[multichain_holder] {symbol}/{chain}: FAIL` show the Blockscout error directly, so ops doesn't need to reproduce with curl.

## Acceptance

After deploy + one cycle:
- `traces > 50` after 6h (trace_bg's first run)
- `approvals > 100` after 24h (approval_bg's first run)
- `holders` continues to grow (BBBB's gate fix is already working)
- `presence > 200` as multichain_bg's 422/301 path stays clean
- `wallet_graph > 55K`
- Next fast cycle emits `[slow_collector]` + `[slow_stablecoin]` at error level so we identify what regressed from the 17-min baseline

## Guardrails honored

- ✅ No change to the 5 working background loops (holder_ingestion / multichain / presence / oracle_cadence / mempool_watcher).
- ✅ No new features.
- ✅ Only 2 collectors migrated from enrichment_worker.
- ✅ No database schema changes.
- ✅ No timeout bump.

## Tests

- Syntax clean on all 6 edited files.
- 55/55 non-env tests pass. `e2e_test.py` + `test_contract_upgrades.py` continue requiring live server/DB — unrelated.

https://claude.ai/code/session_012Kdm7QyJLDSmGyrjiXueqx

---
_Generated by [Claude Code](https://claude.ai/code/session_012Kdm7QyJLDSmGyrjiXueqx)_