### PR TITLE
fix: Blockscout V2 422 storm (dict-form limit) + 10s inner timeout on solana/actor_metrics

### DIFF
--- a/app/collectors/registry.py
+++ b/app/collectors/registry.py
@@ -247,11 +247,33 @@ def _make_async_collectors():
     async def _smart_contract(client, _cg_id, sid):
         return await collect_smart_contract_components(client, sid)
 
+    # Per-collector inner timeout. Production observation (PR #35 timing
+    # diagnostics) shows solana + actor_metrics regularly consume 30s+
+    # each per stablecoin, pushing the fast cycle past its 30-min outer
+    # budget (36 coins × 30s = ~18 min on these two alone). Capping the
+    # inner wait at 10s lets the registry's `_instrumented` timeout path
+    # record the miss and move on. Other collectors keep the default 20s.
+    _SLOW_COLLECTOR_TIMEOUT_SEC = 10.0
+
+    async def _with_inner_timeout(name, coro):
+        try:
+            return await asyncio.wait_for(coro, timeout=_SLOW_COLLECTOR_TIMEOUT_SEC)
+        except asyncio.TimeoutError:
+            logger.warning(
+                f"{name} collector inner-timeout ({_SLOW_COLLECTOR_TIMEOUT_SEC:.0f}s) — "
+                f"skipping this cycle's reading"
+            )
+            return []
+
     async def _solana(client, _cg_id, sid):
-        return await collect_solana_components(client, sid)
+        return await _with_inner_timeout(
+            "solana", collect_solana_components(client, sid),
+        )
 
     async def _actor(client, _cg_id, sid):
-        return await collect_actor_metrics(client, sid)
+        return await _with_inner_timeout(
+            "actor_metrics", collect_actor_metrics(client, sid),
+        )
 
     return [
         ("peg", collect_peg_components),

--- a/app/data_layer/approval_collector.py
+++ b/app/data_layer/approval_collector.py
@@ -83,7 +83,11 @@ async def run_approval_collection() -> dict:
             total_calls += 1
 
             url = f"https://{host}/api/v2/addresses/{addr}/token-transfers"
-            resp = await client.get(url, params={"type": "ERC-20", "filter": "from", "limit": 50})
+            # Blockscout v9.0+ strictly validates parameters; `limit` is not
+            # in the supported set for this endpoint. Pagination is cursor-
+            # based via `next_page_params` in the response body. First page
+            # (~50 items default) is sufficient for approval diff-capture.
+            resp = await client.get(url, params={"type": "ERC-20", "filter": "from"})
             if wi < 3:
                 logger.error(f"[approval_collector] step E.{wi}: HTTP {resp.status_code}")
 

--- a/app/data_layer/holder_ingestion_collector.py
+++ b/app/data_layer/holder_ingestion_collector.py
@@ -188,9 +188,11 @@ async def _fetch_holders_blockscout(
     }
     host = hosts.get(chain, hosts["ethereum"])
 
+    # Blockscout v9.0+ strictly validates parameters; `limit` is not in the
+    # supported set for /tokens/{contract}/holders. Default page size
+    # (~50 items) is sufficient for holder ingestion's breadth pass.
     resp = await client.get(
         f"https://{host}/api/v2/tokens/{contract}/holders",
-        params={"limit": 50},
         timeout=30,
     )
     if resp.status_code != 200:

--- a/app/data_layer/trace_collector.py
+++ b/app/data_layer/trace_collector.py
@@ -106,16 +106,18 @@ async def run_trace_collection() -> dict:
 
     logger.error("[trace_collector] step 5: entering main loop (using module-level httpx client)")
     client = _client
-    for i, slug in enumerate(slugs):
-        addrs = proto_addrs.get(slug, [])
-        if not addrs:
-            continue
-
-        addr, chain = addrs[0]
+    # Pre-filter to only protocols that have on-chain addresses so the loop
+    # counter matches user-visible progress. Previously the log read
+    # "loop 0/33" → "step C.16" because `i` skipped protocols without
+    # addresses and looked like a skip bug. The addressable set is what
+    # actually drives API calls.
+    addressable = [(slug, proto_addrs[slug][0]) for slug in slugs if proto_addrs.get(slug)]
+    for i, (slug, addr_chain) in enumerate(addressable):
+        addr, chain = addr_chain
         host = CHAIN_HOSTS.get(chain, CHAIN_HOSTS["ethereum"])
 
         if i < 3 or i % 10 == 0:
-            logger.error(f"[trace_collector] loop {i}/{len(slugs)}: {slug} addr={addr[:12]}... chain={chain}")
+            logger.error(f"[trace_collector] loop {i}/{len(addressable)}: {slug} addr={addr[:12]}... chain={chain}")
 
         # Fetch recent txs for this protocol's primary address
         try:
@@ -125,8 +127,11 @@ async def run_trace_collection() -> dict:
             logger.error(f"[trace_collector] step D.{i}: rate limiter acquired, making HTTP GET")
             total_calls += 1
 
+            # Blockscout v9.0+ strictly validates parameters; `limit` is not
+            # in the supported set for /addresses/{addr}/transactions.
+            # Default page size is plenty for trace sampling.
             tx_url = f"https://{host}/api/v2/addresses/{addr}/transactions"
-            resp = await client.get(tx_url, params={"filter": "to", "limit": MAX_TXS_PER_PROTOCOL})
+            resp = await client.get(tx_url, params={"filter": "to"})
             logger.error(f"[trace_collector] step E.{i}: HTTP {resp.status_code}")
             if resp.status_code != 200:
                 total_errors += 1


### PR DESCRIPTION
## Summary

Three fixes after CCCC observation. All fast-cycle / scoring related; no schema changes, no new features.

## FIX 1 — Blockscout V2 422 storm (the real fix)

BBBB (`3eee9c7`) stripped `limit=50` from URL-string constructions. But three call sites were still passing `limit` via the httpx **`params={}` dict**, which the earlier `grep "blockscout.*limit="` missed. Blockscout v9.0+ strictly validates params and 422s unknown names.

Removed `"limit": 50` / `"limit": MAX_TXS_PER_PROTOCOL` from:
- `app/data_layer/approval_collector.py:86` — `/addresses/{addr}/token-transfers`
- `app/data_layer/holder_ingestion_collector.py:193` — `/tokens/{contract}/holders`
- `app/data_layer/trace_collector.py:129` — `/addresses/{addr}/transactions`

All endpoints default to ~50 items per page, which matches what we were asking for. Downstream `items[:MAX_TXS_PER_PROTOCOL]` still enforces the client-side bound.

**Guardrail passed:** `grep -rnE "api/v2.*limit|limit.*api/v2" app/` returns zero. The one remaining `"limit"` param in data_layer is `ohlcv_collector.py` hitting GeckoTerminal — not Blockscout, not in scope.

## FIX 2 — solana + actor_metrics inner 10s timeout (Path A)

PR #35's `[slow_collector]` diagnostic attributed the fast-cycle 30-min cap to `solana` and `actor_metrics` each consuming ~30s per stablecoin (36 × 30s ≈ 18 min on these two alone).

Wrapped both in `_with_inner_timeout()` using `asyncio.wait_for(..., 10.0)`. On inner-timeout the wrapper logs a warning and returns `[]` so scoring proceeds. The outer registry `_instrumented` default of 20s stays as a safety net. All other collectors keep the default outer 20s.

## FIX 3 — trace_collector loop counter polish (included)

Pre-filtered to an `addressable` list before the main loop so `loop 0/N` / `step C.N` / `step D.N` all index the same sequence. Previously `i` iterated the full 33-protocol list and `continue`'d past protocols without addresses, producing confusing log sequences like `loop 0/33` → `step C.16`. Cosmetic; no behavior change.

## Acceptance (post-deploy)

```sql
SELECT 'holders', COUNT(*) FROM wallet_holder_discovery
UNION ALL SELECT 'presence', COUNT(*) FROM wallet_chain_presence
UNION ALL SELECT 'wallet_graph', COUNT(*) FROM wallet_graph.wallets
UNION ALL SELECT 'traces', COUNT(*) FROM protocol_trace_observations
UNION ALL SELECT 'approvals', COUNT(*) FROM token_approval_snapshots;
```

- holders > 9,508, growing
- presence jumps from 161 toward 1,000+ as Mode A succeeds
- wallet_graph > 51,062
- traces > 10 (previously 0)
- approvals > 100 (previously 0)
- Zero Blockscout 422 errors
- Fast cycle completes in <20 min (the next `[slow_collector]` / `[slow_stablecoin]` output should no longer flag solana/actor_metrics at 30s; they'll either finish under 10s or cleanly inner-timeout)

## Guardrails

- ✅ `grep -rnE "api/v2.*limit" app/` returns zero
- ✅ No change to the 5 working background loops beyond URL param fixes
- ✅ No new features
- ✅ No new migrations
- ✅ 55/55 non-env tests pass

## Tests

Syntax clean on all 4 edited files. Unit suite passes.

https://claude.ai/code/session_012Kdm7QyJLDSmGyrjiXueqx

---
_Generated by [Claude Code](https://claude.ai/code/session_012Kdm7QyJLDSmGyrjiXueqx)_