### PR TITLE
engine: fix psycopg2 UUID adapter in C2a persistence

### DIFF
--- a/app/engine/analysis_persistence.py
+++ b/app/engine/analysis_persistence.py
@@ -36,6 +36,15 @@ from app.engine.schemas import (
 
 logger = logging.getLogger(__name__)
 
+# Register psycopg2's UUID adapter at module import time so cursor.execute
+# can accept Python uuid.UUID objects directly as query parameters. Without
+# this, INSERTs with a non-None previous_analysis_id raise
+# ProgrammingError: can't adapt type 'UUID' — observed in production when
+# the force_new=true archival path fires. register_uuid() is idempotent and
+# registers a global adapter; safe to call here. Regression guard:
+# tests/test_engine_analyze.py::test_analyze_force_new_archives_previous_uuid_adapter.
+psycopg2.extras.register_uuid()
+
 
 # ─────────────────────────────────────────────────────────────────
 # Row → Analysis conversion

--- a/tests/test_engine_analyze.py
+++ b/tests/test_engine_analyze.py
@@ -287,6 +287,49 @@ def test_analyze_force_new_archives_previous(admin_api):
 
 
 # ═════════════════════════════════════════════════════════════════
+# 6a. Regression guard — psycopg2 UUID adapter registered at import
+#
+# Observed in Railway logs after S2a deploy:
+#   psycopg2.ProgrammingError: can't adapt type 'UUID'
+#   app/engine/analysis_persistence.py:132 in _insert_analysis_sync
+#
+# Root cause: psycopg2 doesn't adapt Python uuid.UUID objects by default.
+# The force_new=true path INSERTs with previous_analysis_id as a UUID and
+# crashes without register_uuid() called at module import time. Fixed by
+# adding psycopg2.extras.register_uuid() at the top of
+# app/engine/analysis_persistence.py.
+#
+# This test explicitly exercises the previous_analysis_id path and asserts
+# the second POST returns 202, not 500, so a future regression (e.g., a
+# refactor that drops the register_uuid call) surfaces as a named test
+# failure rather than a diagnostic-free 500.
+# ═════════════════════════════════════════════════════════════════
+
+def test_analyze_force_new_archives_previous_uuid_adapter(admin_api):
+    """Regression: force_new path must not 500 due to UUID adapter
+    registration being absent. See commentary above."""
+    body = {
+        "entity": "usdc",
+        "event_date": "2026-04-05",
+        "peer_set": [],
+    }
+    first = admin_api.post("/api/engine/analyze", body)
+    assert first.status_code == 202, first.text[:400]
+    _track(first.json()["analysis_id"])
+
+    body_force = dict(body, force_new=True)
+    second = admin_api.post("/api/engine/analyze", body_force)
+    # If register_uuid() is missing from analysis_persistence.py, this
+    # returns 500 with "can't adapt type 'UUID'" in the traceback.
+    assert second.status_code == 202, (
+        f"force_new POST returned {second.status_code} — suspected "
+        f"psycopg2 UUID adapter regression in analysis_persistence.py. "
+        f"Body: {second.text[:400]}"
+    )
+    _track(second.json()["analysis_id"])
+
+
+# ═════════════════════════════════════════════════════════════════
 # 7. List endpoint filters by entity
 # ═════════════════════════════════════════════════════════════════
 


### PR DESCRIPTION
Fixes the psycopg2 UUID adapter issue surfaced in Railway logs after PR #39 deployed. Two files, +52 lines, zero deletions.

## Bug

```
psycopg2.ProgrammingError: can't adapt type 'UUID'
  File "/app/app/engine/analysis_persistence.py", line 132, in _insert_analysis_sync
```

psycopg2 doesn't adapt Python `uuid.UUID` objects for query parameters by default. The `force_new=true` archival path in `POST /api/engine/analyze` passes `analysis.previous_analysis_id` (a UUID) directly into `cursor.execute` and crashes with a 500.

## Fix

One-line call to `psycopg2.extras.register_uuid()` at module import time in `app/engine/analysis_persistence.py`. Global, idempotent adapter registration — no per-connection overhead, no side effects on other psycopg2 users.

## Regression guard

New test `tests/test_engine_analyze.py::test_analyze_force_new_archives_previous_uuid_adapter` that:

- Creates an analysis, then POSTs the same `(entity, event_date)` with `force_new=true`
- Asserts the second POST returns 202, not 500
- Docstring + inline comment name the bug explicitly so a future refactor dropping `register_uuid()` surfaces as a named failure rather than a diagnostic-free 500

Uses a distinct entity/date (`usdc` / `2026-04-05`) from the existing `test_analyze_force_new_archives_previous` so the two run cleanly side-by-side.

## Why this wasn't caught earlier

The existing `test_analyze_force_new_archives_previous` exercises the same path and would have caught it, but it was never run against production with the admin key before the S2a PR merged — the test passes cleanly under a single-worker local deploy where uvicorn and the pending→draft transition behave as the comment suggests, but the UUID adapter failure only manifests on the first force_new INSERT against the production DB. Both tests now serve as guards; the new one names the specific psycopg2 failure mode.

## Scope

Strictly the fix and its regression test. No refactoring, no schema changes, no new endpoints.

## Test command (post-merge)

```bash
ADMIN_KEY=$ADMIN_KEY BASE_URL=https://basisprotocol.xyz \
  pytest tests/test_engine_analyze.py::test_analyze_force_new_archives_previous_uuid_adapter -v
```

Plus the full S2a suite to confirm no regression elsewhere:

```bash
ADMIN_KEY=$ADMIN_KEY BASE_URL=https://basisprotocol.xyz \
  pytest tests/test_engine_analyze.py -v --tb=short
```

## Commit

`0158d11` — `engine: fix psycopg2 UUID adapter registration in C2a persistence` (2 files, +52/-0)

Refs: PR #39 (S2a deploy where the bug landed)

https://claude.ai/code/session_01FWDKHwn3cevR8MMLTV8Fn2

---
_Generated by [Claude Code](https://claude.ai/code/session_01FWDKHwn3cevR8MMLTV8Fn2)_