### PR TITLE
engine: fix admin rate limit + test teardown reliability

### DIFF
--- a/app/server.py
+++ b/app/server.py
@@ -244,9 +244,34 @@ async def rate_limit_and_track(request: Request, call_next):
     elif path.startswith("/api/discovery"):
         entity_type = "discovery"
 
-    # Admin / ops / provenance-write endpoints — exempt from rate limiting but still logged
-    if path.startswith("/api/admin") or path.startswith("/api/ops") or (
-        path.startswith("/api/provenance/") and request.method == "POST"
+    # Admin / ops / provenance-write endpoints — exempt from rate limiting but still logged.
+    #
+    # Path-based exemptions: /api/admin/*, /api/ops/*, POST /api/provenance/* — historic
+    # convention; these endpoints are admin-protected by their own _check_admin_key() calls.
+    #
+    # Auth-based exemption (added with /api/engine/* admin routes): any request that presents
+    # a valid X-Admin-Key (or ?key=) matching the ADMIN_KEY env var is treated as admin
+    # context, regardless of path. This generalizes the prior path-list approach so future
+    # admin-protected endpoints don't have to be added to a list to escape the public
+    # 10/min limit. Public endpoints called WITHOUT the admin key remain rate-limited
+    # normally — e.g., /api/engine/coverage/{id} called by an anonymous user still gets the
+    # public tier.
+    _admin_key_env = os.environ.get("ADMIN_KEY", "")
+    _provided_admin_key = (
+        request.headers.get("x-admin-key", "")
+        or request.query_params.get("key", "")
+    )
+    is_admin_authenticated = (
+        bool(_admin_key_env)
+        and bool(_provided_admin_key)
+        and hmac.compare_digest(_provided_admin_key, _admin_key_env)
+    )
+
+    if (
+        path.startswith("/api/admin")
+        or path.startswith("/api/ops")
+        or (path.startswith("/api/provenance/") and request.method == "POST")
+        or is_admin_authenticated
     ):
         response = await call_next(request)
         elapsed_ms = int((time.time() - start_time) * 1000)

--- a/tests/test_engine_analyze.py
+++ b/tests/test_engine_analyze.py
@@ -7,16 +7,26 @@ skip cleanly if ADMIN_KEY isn't available in the environment.
 
 Run:
     ADMIN_KEY=<key> BASE_URL=https://basisprotocol.xyz \\
+      DATABASE_URL=<prod-or-replica-url> \\
       pytest tests/test_engine_analyze.py -v
 
-Rate-limit budget (admin tier, 120/min): well under. ~15 requests across
-the eight tests including cleanup.
+DATABASE_URL is optional — if set, teardown deletes test rows directly via
+psycopg2 (fast, doesn't trip rate limit, works on test failure). If unset,
+teardown falls back to HTTP DELETE with a 0.5s sleep between calls so the
+admin rate budget stays intact.
 
-Test cleanup: each test appends any analysis IDs it creates to a shared
-list. An autouse fixture runs after every test and DELETEs them all. If
-DELETE fails (transient, already-gone, or linked-artifact 409), the test
-logs and continues — cleanup best-effort; production operator can GC
-stragglers via GET /api/engine/analyses?status=archived if needed.
+Rate-limit budget: with the auth-based exemption fix in app/server.py,
+requests carrying a valid X-Admin-Key are exempt from rate limiting
+entirely. The HTTP-DELETE fallback path still includes inter-call sleeps
+in case the test is run against a server without that fix applied.
+
+Test cleanup (two layers):
+  1. Session-start orphan sweep — at the start of the pytest session,
+     DELETE every (entity, event_date) row from the canonical test set.
+     Catches debris from prior failed runs.
+  2. Per-test cleanup — each test appends any analysis IDs it creates to
+     a shared list. After each test, DELETE them by ID. Direct DB delete
+     when DATABASE_URL is set; HTTP DELETE with sleep fallback otherwise.
 
 Tests:
   1. test_analyze_drift_returns_202              — happy path
@@ -25,6 +35,8 @@ Tests:
   4. test_analyze_unknown_entity_returns_404     — coverage check
   5. test_analyze_duplicate_returns_409          — uniqueness constraint
   6. test_analyze_force_new_archives_previous    — revision chain
+  6a. test_analyze_force_new_archives_previous_uuid_adapter
+                                                  — psycopg2 UUID regression
   7. test_list_analyses_filters_by_entity        — list endpoint
   8. test_get_analysis_unknown_id_returns_404    — GET 404
 """
@@ -32,11 +44,96 @@ Tests:
 from __future__ import annotations
 
 import os
+import sys
 import time
 import uuid
-from typing import Any, Iterator
+from datetime import date
+from typing import Any, Iterator, Optional
 
 import pytest
+
+
+# ═════════════════════════════════════════════════════════════════
+# Test fixture row keys
+#
+# Every (entity, event_date) pair used by tests in this file plus any
+# operator-run diagnostic curls. The session-start orphan sweep DELETEs
+# all rows matching this set so a hard test crash leaves no debris next
+# session.
+#
+# Adding a new test that uses a new (entity, event_date)? Add it here too.
+# ═════════════════════════════════════════════════════════════════
+
+TEST_FIXTURE_KEYS: list[tuple[str, date]] = [
+    ("drift", date(2026, 4, 1)),    # test_analyze_drift_returns_202
+    ("drift", date(2026, 4, 2)),    # test_analyze_duplicate_returns_409
+    ("drift", date(2026, 4, 3)),    # test_analyze_force_new_archives_previous
+    ("kelp-rseth", date(2026, 4, 18)),  # test_analyze_pending_flips_to_draft
+    ("usdc", date(2026, 4, 5)),     # uuid-adapter regression
+    ("layerzero", date(2026, 4, 4)),    # test_list_analyses_filters_by_entity
+    ("layerzero", date(2026, 4, 15)),   # operator diagnostic curl debris
+    ("layerzero", date(2026, 4, 30)),   # operator verification curl
+]
+
+
+# ═════════════════════════════════════════════════════════════════
+# DB connection helpers (used by cleanup; optional)
+#
+# psycopg2 import is local so the test module still imports cleanly when
+# the host doesn't have psycopg2 installed. Cleanup degrades to HTTP-only
+# in that case.
+# ═════════════════════════════════════════════════════════════════
+
+def _db_delete_by_ids(ids: list[str]) -> bool:
+    """Direct DB delete by primary key. Returns True if cleanup succeeded
+    (or there was nothing to clean up), False if DATABASE_URL isn't set
+    or the connection/query failed — caller falls back to HTTP."""
+    conn_string = os.environ.get("DATABASE_URL")
+    if not conn_string:
+        return False
+    try:
+        import psycopg2  # local import — may not be installed in the test env
+        with psycopg2.connect(conn_string) as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    "DELETE FROM engine_analyses WHERE id = ANY(%s::uuid[])",
+                    ([str(i) for i in ids],),
+                )
+            conn.commit()
+        return True
+    except Exception as exc:
+        print(f"cleanup: DB delete by id failed: {exc}", file=sys.stderr)
+        return False
+
+
+def _db_delete_by_fixture_keys() -> int:
+    """Session-start sweep: delete every row matching the canonical test
+    (entity, event_date) set. Returns the row count deleted on success,
+    -1 if cleanup wasn't performed (no DATABASE_URL or connection error).
+    """
+    conn_string = os.environ.get("DATABASE_URL")
+    if not conn_string:
+        return -1
+    try:
+        import psycopg2
+        with psycopg2.connect(conn_string) as conn:
+            with conn.cursor() as cur:
+                # Postgres tuple-IN: (entity, event_date) IN ((%s, %s), ...)
+                # Use a single bound tuple-of-tuples; psycopg2 renders this
+                # as a row-constructor IN list.
+                cur.execute(
+                    """
+                    DELETE FROM engine_analyses
+                    WHERE (entity, event_date) IN %s
+                    """,
+                    (tuple(TEST_FIXTURE_KEYS),),
+                )
+                deleted = cur.rowcount
+            conn.commit()
+        return deleted
+    except Exception as exc:
+        print(f"cleanup: session-start sweep failed: {exc}", file=sys.stderr)
+        return -1
 
 
 # ═════════════════════════════════════════════════════════════════
@@ -46,7 +143,7 @@ import pytest
 # Accept either ADMIN_KEY (server convention) or BASIS_ADMIN_KEY (S2a
 # prompt variant). Tests skip if neither is present so CI without the
 # secret doesn't break the build.
-def _resolve_admin_key() -> str | None:
+def _resolve_admin_key() -> Optional[str]:
     return os.environ.get("ADMIN_KEY") or os.environ.get("BASIS_ADMIN_KEY")
 
 
@@ -98,23 +195,56 @@ def admin_api(base_url, session, admin_key) -> _AdminAPI:
     return _AdminAPI(session, base_url, admin_key)
 
 
+# Session-start orphan sweep — runs once per pytest session, before any
+# tests in this file. Catches debris from crashed prior runs by DELETEing
+# rows for every (entity, event_date) in the canonical test set.
+#
+# Silently skips if DATABASE_URL isn't set; per-test cleanup will do its
+# best via HTTP. If the sweep fails for any other reason, the session
+# continues — tests will still run, they'll just have to coexist with any
+# stale rows (and 409 on duplicates).
+@pytest.fixture(scope="session", autouse=True)
+def session_engine_cleanup():
+    deleted = _db_delete_by_fixture_keys()
+    if deleted > 0:
+        print(
+            f"\n[engine-tests] session-start sweep: deleted {deleted} stale row(s)",
+            file=sys.stderr,
+        )
+    yield
+    # End-of-session sweep: same cleanup, in case crashes left debris.
+    _db_delete_by_fixture_keys()
+
+
 # Shared list of analysis IDs created during a single test. Reset per test.
 _created_ids: list[str] = []
 
 
 @pytest.fixture(autouse=True)
 def cleanup_created_analyses(admin_api) -> Iterator[None]:
-    """After each test, DELETE every analysis it created. Best-effort;
-    failures are logged (via assertion message context) but don't fail
-    the test since we're already past the assertions."""
+    """Per-test cleanup. Direct DB DELETE if DATABASE_URL is set;
+    HTTP DELETE with sleeps as fallback. Best-effort — failures are
+    logged but don't fail the test."""
     _created_ids.clear()
     yield
-    for aid in list(_created_ids):
+    if not _created_ids:
+        return
+
+    ids_to_delete = list(_created_ids)
+    if _db_delete_by_ids(ids_to_delete):
+        _created_ids.clear()
+        return
+
+    # Fallback: HTTP DELETE with inter-call sleep so the admin rate budget
+    # stays intact even on a server without the auth-based rate-limit
+    # exemption. With the exemption applied, the sleep is unnecessary but
+    # harmless.
+    for aid in ids_to_delete:
         try:
             admin_api.delete(f"/api/engine/analyses/{aid}")
+            time.sleep(0.5)
         except Exception as exc:
-            # Don't let cleanup crash the test session; log via stderr.
-            print(f"cleanup: failed to delete {aid}: {exc}")
+            print(f"cleanup: HTTP delete failed for {aid}: {exc}", file=sys.stderr)
     _created_ids.clear()
 
 


### PR DESCRIPTION
Two operational bugs blocking S2a usability + making tests unreliable. Single commit, two files (`app/server.py`, `tests/test_engine_analyze.py`), no engine handler / schema / migration changes.

## Bug 1: `/api/engine/*` admin routes were rate-limited at 10/min

The middleware exempts `/api/admin/*`, `/api/ops/*`, and POST `/api/provenance/*` via path-prefix match. New admin-protected `/api/engine/*` routes weren't on the list and fell through to the public 10/min tier. Diagnostic confirmed `x-ratelimit-limit: 10` on `POST /api/engine/analyze` with a valid `X-Admin-Key`.

**Fix:** generalize from path-based to **auth-based** exemption. Detect `X-Admin-Key` (or `?key=`) in the middleware, HMAC-compare against `ADMIN_KEY`, and exempt any request whose admin key validates — regardless of path.

```python
_admin_key_env = os.environ.get("ADMIN_KEY", "")
_provided_admin_key = (
    request.headers.get("x-admin-key", "")
    or request.query_params.get("key", "")
)
is_admin_authenticated = (
    bool(_admin_key_env)
    and bool(_provided_admin_key)
    and hmac.compare_digest(_provided_admin_key, _admin_key_env)
)

if (
    path.startswith("/api/admin")
    or path.startswith("/api/ops")
    or (path.startswith("/api/provenance/") and request.method == "POST")
    or is_admin_authenticated   # ← new
):
    response = await call_next(request)
    # ... existing logging path ...
    return response
```

Existing path-prefix exemptions kept intact (no regression). Public endpoints called **without** the admin key remain rate-limited normally — e.g., `GET /api/engine/coverage/{id}` from an anonymous client still gets the public 10/min tier. **The change generalizes the rule for future admin endpoints**: anywhere `_check_admin_key()` is called in a handler, the middleware will also recognize the admin context and exempt from rate limiting.

The codebase's existing convention for `/api/admin/*` is **full exemption**, not "elevated to keyed tier" — I matched that. Operator's verification curl will show no `x-ratelimit-*` headers at all on admin-keyed engine requests, same as `/api/admin/*` already shows.

## Bug 2: Test teardown was unreliable

Per-test cleanup hit the same `/api/engine/analyses/{id}` endpoint it just hammered, so cleanup DELETEs counted against the (broken) rate limit and 429'd — leaving test rows in production. Crashes before `_track()` orphaned rows entirely.

**Fix in three parts:**

(a) **Per-test teardown switches to direct `psycopg2` DELETE when `DATABASE_URL` is set.** Fast, doesn't trip rate limit, works on test failure. Falls back to HTTP DELETE with 0.5s sleeps when `DATABASE_URL` isn't available.

(b) **New session-scope autouse fixture sweeps the canonical key set at session start AND end.** Catches debris from crashed prior runs.

(c) **Canonical key set named explicitly:**

```python
TEST_FIXTURE_KEYS: list[tuple[str, date]] = [
    ("drift", date(2026, 4, 1)),    # test_analyze_drift_returns_202
    ("drift", date(2026, 4, 2)),    # test_analyze_duplicate_returns_409
    ("drift", date(2026, 4, 3)),    # test_analyze_force_new_archives_previous
    ("kelp-rseth", date(2026, 4, 18)),  # test_analyze_pending_flips_to_draft
    ("usdc", date(2026, 4, 5)),     # uuid-adapter regression
    ("layerzero", date(2026, 4, 4)),    # test_list_analyses_filters_by_entity
    ("layerzero", date(2026, 4, 15)),   # operator diagnostic curl debris
    ("layerzero", date(2026, 4, 30)),   # operator verification curl
]
```

Adding a test that uses a new entity/date pair only requires appending to this list.

The two layerzero rows (2026-04-15, 2026-04-30) from operator diagnostic + verification curls are included so they get swept on next session start.

## Verification (operator-run)

```bash
# Rate limit elevated (no x-ratelimit-* headers expected)
curl -i -s -X POST "https://basisprotocol.xyz/api/engine/analyze" \
  -H "X-Admin-Key: $ADMIN_KEY" \
  -H "Content-Type: application/json" \
  -d '{"entity":"layerzero","event_date":"2026-04-30","peer_set":[]}' \
  | grep -i ratelimit
# expect: empty (no rate-limit headers — full exemption)

# Anonymous coverage still rate-limited (sanity)
curl -i -s "https://basisprotocol.xyz/api/engine/coverage/drift" \
  | grep -i ratelimit
# expect: x-ratelimit-limit: 10

# Full S2a suite passes 9/9
ADMIN_KEY=$ADMIN_KEY DATABASE_URL=$DATABASE_URL BASE_URL=https://basisprotocol.xyz \
  pytest tests/test_engine_analyze.py -v --tb=short

# C1 still passes 12/12
BASE_URL=https://basisprotocol.xyz \
  pytest tests/test_engine_coverage.py -v --tb=short

# No debris left after test run
psql "$DATABASE_URL" -c "
SELECT COUNT(*) FROM engine_analyses
WHERE entity IN ('drift','usdc','kelp-rseth','layerzero')
  AND event_date BETWEEN '2026-04-01' AND '2026-04-30';
"
# expect: 0
```

## Confirmation: no scope creep

```
$ git diff --name-only main
app/server.py
tests/test_engine_analyze.py
```

Untouched: `app/engine/*.py` (all 8 modules), `app/engine/schemas.py`, all migrations, `tests/test_engine_coverage.py`, `tests/fixtures/canonical_coverage.py`.

## Commit

`6aecf6d` — `engine: fix admin rate limit + test teardown reliability` (2 files, +173/-18)

Refs: PR #39 (S2a), PR #40 (UUID adapter fix)

https://claude.ai/code/session_01FWDKHwn3cevR8MMLTV8Fn2

---
_Generated by [Claude Code](https://claude.ai/code/session_01FWDKHwn3cevR8MMLTV8Fn2)_