### PR TITLE
engine: C1 tests use admin-key when available for rate-limit hygiene

### DIFF
--- a/tests/test_engine_coverage.py
+++ b/tests/test_engine_coverage.py
@@ -64,17 +64,53 @@ CANONICAL_ENTITIES = [
 
 
 @pytest.fixture(scope="session")
-def coverage_responses(api):
+def coverage_api(base_url, session):
+    """GET helper for /api/engine/coverage/* that injects X-Admin-Key when
+    ADMIN_KEY is in the environment.
+
+    Why: the coverage endpoint is public (10/min per IP), and a single
+    test session legitimately makes ~10 requests across the canonical
+    entities + fuzzy + cache tests. When the operator runs the broader
+    test session sequence (S2a engine tests, manual diagnostic curls,
+    then C1 tests), any prior public request from the same IP eats into
+    the 60-second window's budget and tips C1 tests into 429s.
+
+    The coverage handler doesn't check the admin header — sending it
+    has no semantic effect on the response. But the rate-limit
+    middleware (after PR #41) recognizes a valid X-Admin-Key and
+    exempts the request, sidestepping the public-tier flake.
+
+    No admin key in env → no header sent → public-tier behavior
+    preserved (tests still subject to 10/min, just like an anonymous
+    consumer would be).
+    """
+    import os
+    admin_key = os.environ.get("ADMIN_KEY") or os.environ.get("BASIS_ADMIN_KEY")
+    headers = {"x-admin-key": admin_key} if admin_key else {}
+
+    def _get(path: str, **kwargs):
+        kwargs.setdefault("timeout", 30)
+        # Allow callers to pass extra headers; admin-key takes precedence
+        # so a caller can't accidentally clobber it.
+        merged_headers = {**kwargs.get("headers", {}), **headers}
+        kwargs["headers"] = merged_headers
+        return session.get(f"{base_url}{path}", **kwargs)
+
+    return _get
+
+
+@pytest.fixture(scope="session")
+def coverage_responses(coverage_api):
     """Fetch each canonical entity once at session start; share across tests.
 
     Avoids hammering the public 10/min rate limit. Tests that just inspect
     response shape consume zero additional requests by reading from this
     dict. Tests that explicitly need fresh requests (cache behavior) make
-    their own calls separately.
+    their own calls separately via coverage_api.
     """
     responses = {}
     for slug in CANONICAL_ENTITIES:
-        responses[slug] = api(f"/api/engine/coverage/{slug}")
+        responses[slug] = coverage_api(f"/api/engine/coverage/{slug}")
     return responses
 
 
@@ -189,9 +225,9 @@ def test_coverage_unknown_entity_returns_404(coverage_responses):
 # preload. Each consumes one request — accounted for in the rate budget.
 # ═════════════════════════════════════════════════════════════════
 
-def test_coverage_fuzzy_match_rseth(api):
+def test_coverage_fuzzy_match_rseth(coverage_api):
     """`rseth` should match `kelp-rseth` via trigram similarity."""
-    resp = api("/api/engine/coverage/rseth")
+    resp = coverage_api("/api/engine/coverage/rseth")
     if resp.status_code == 200:
         data = resp.json()
         assert data["identifier"] == "kelp-rseth"
@@ -203,7 +239,7 @@ def test_coverage_fuzzy_match_rseth(api):
         )
 
 
-def test_coverage_fuzzy_no_false_positive_dai(api):
+def test_coverage_fuzzy_no_false_positive_dai(coverage_api):
     """`dai` must not falsely match `dailyusd` or similar long slugs.
 
     Expected outcomes:
@@ -213,7 +249,7 @@ def test_coverage_fuzzy_no_false_positive_dai(api):
     The one outcome the test rejects: a 200 response whose identifier is not
     'dai' — which would indicate a fuzzy-match false positive.
     """
-    resp = api("/api/engine/coverage/dai")
+    resp = coverage_api("/api/engine/coverage/dai")
     if resp.status_code == 200:
         data = resp.json()
         assert data["identifier"] == "dai", (
@@ -260,17 +296,17 @@ def test_coverage_days_since_last_record_present(coverage_responses):
 # doc §11.3.
 # ═════════════════════════════════════════════════════════════════
 
-def test_coverage_cache_hit_behavior(api):
+def test_coverage_cache_hit_behavior(coverage_api):
     """Two consecutive calls succeed. Timing comparison is relaxed because
     the in-memory cache is per-worker and may not provide a measurable
     speedup under multi-worker deployments. See Step 0 doc §11.3."""
     t0 = time.time()
-    r1 = api("/api/engine/coverage/drift")
+    r1 = coverage_api("/api/engine/coverage/drift")
     t1 = time.time()
     assert r1.status_code == 200
 
     t2 = time.time()
-    r2 = api("/api/engine/coverage/drift")
+    r2 = coverage_api("/api/engine/coverage/drift")
     t3 = time.time()
     assert r2.status_code == 200
 


### PR DESCRIPTION
C1 test rate-limit hygiene. Test-only change — one file, no handler/schema/migration touched.

## What surfaced

Post PR #41 sweep results:

```
S2a suite              9/9 passed   (admin-key exempt — works as designed)
C1 coverage suite      6/12 passed; 6 failed with 429
```

Failures concentrated on the 3rd+ canonical entity in the session-fixture init, plus `fuzzy-match-rseth` and `cache-hit-behavior` — exactly the requests that come after the public-IP budget is depleted.

## Why it happened

C1 has used the public `/api/engine/coverage/*` endpoint with no auth, riding right at the 10/min per-IP edge since PR #38 ("Right at the 10/min limit — if rate-limit issues recur, the fuzzy tests can move into the fixture too"). The S2a → manual diagnostic curls → C1 sequence depletes the same IP's public budget; C1 starts under it.

**Not a regression from PR #41.** PR #41 fixed admin-keyed engine endpoints (S2a went 0% → 100% rate-stable). C1's public endpoint flake is pre-existing.

## Fix

New session-scoped `coverage_api` fixture in `tests/test_engine_coverage.py` that injects `X-Admin-Key` when `ADMIN_KEY` (or `BASIS_ADMIN_KEY`) is set. The coverage handler doesn't check the admin header — sending it has zero semantic effect on the response. The rate-limit middleware (post PR #41) recognizes the valid admin key and exempts the request from the public 10/min budget.

Falls back to anonymous when no admin key is in env (CI without secrets behaves identically to prior code, just rate-limit-bound).

Four `api` references swapped to `coverage_api`:

| Site | Calls |
|---|---|
| `coverage_responses` session fixture | 6 |
| `test_coverage_fuzzy_match_rseth` | 1 |
| `test_coverage_fuzzy_no_false_positive_dai` | 1 |
| `test_coverage_cache_hit_behavior` | 2 |

10 total per session — same as before, just no longer subject to the public budget when an admin key is available.

## What this is NOT

- **Not a behavior change.** The coverage endpoint stays public. Anonymous clients get the same 10/min as before. The fixture only adds the header for the test client.
- **Not a refactor.** Single file, +46/-10 lines. No new abstractions, no shared module changes, no `conftest.py` modifications.
- **Not scope creep into S2b.** Independent of upcoming work.

## Confirmation

```bash
$ git diff --name-only main
tests/test_engine_coverage.py
```

Untouched: every engine handler, schema, migration, S2a test file, conftest.

## Test command (operator-run, post-merge)

```bash
ADMIN_KEY=$ADMIN_KEY BASE_URL=https://basisprotocol.xyz \
  pytest tests/test_engine_coverage.py -v --tb=short
```

Expected: 12/12. With `ADMIN_KEY` set, no requests hit the public limit. Without it (e.g., CI without secrets), the suite still works but inherits the same 10/min flake risk as before.

## Commit

`30a0720` — `engine: C1 tests use admin-key when available for rate-limit hygiene` (1 file, +46/-10)

Refs: PR #38 (C1 fixture refactor that flagged this risk in its body), PR #41 (auth-based exemption that this fix relies on)

https://claude.ai/code/session_01FWDKHwn3cevR8MMLTV8Fn2

---
_Generated by [Claude Code](https://claude.ai/code/session_01FWDKHwn3cevR8MMLTV8Fn2)_