### PR TITLE
engine: fix S2c POST latency — move LLM call into the background task

### DIFF
--- a/app/engine/analysis.py
+++ b/app/engine/analysis.py
@@ -28,8 +28,6 @@ from typing import Optional
 from uuid import UUID
 
 from app.engine.coverage import get_entity_coverage
-from app.engine.interpretation import get_or_call_interpretation
-from app.engine.observation_builder import build_signal
 from app.engine.schemas import (
     AnalysisCreate,
     ArtifactRecommendation,
@@ -38,11 +36,15 @@ from app.engine.schemas import (
     Signal,
 )
 
-# Bumped from v0.1-s2b-real-signal: interpretation is now LLM-generated (per
-# S2c). artifact_recommendation remains stubbed; the renderer in C3/S3 fills
-# that in based on coverage_quality + signal + interpretation.
+# Stage stamp on the persisted analysis. Bumped each time the engine's
+# behavior shifts so a future reviewer can tell which version produced
+# any given row.
 ANALYSIS_VERSION_S2A = "v0.1-s2c-llm-interpretation"
-STUB_PROMPT_VERSION = "stub-s2a"  # legacy constants — only used if LLM path is bypassed
+# Stub identifiers — used by the skeleton AnalysisCreate that gets INSERTed
+# at status=pending. The background task replaces signal/interpretation
+# with real values before flipping to draft, so persisted draft rows
+# never have these tags.
+STUB_PROMPT_VERSION = "stub-s2a"
 STUB_MODEL_ID = "template:stub"
 
 
@@ -155,41 +157,28 @@ def build_stub_analysis(
     previous_analysis_id: Optional[UUID] = None,
     supersedes_reason: Optional[str] = None,
 ) -> AnalysisCreate:
-    """Assemble an AnalysisCreate.
+    """Build the SKELETON AnalysisCreate that gets INSERTed at status=pending.
 
-    S2c: Signal is real (S2b) AND interpretation is real (LLM-generated
-    via app.engine.interpretation.get_or_call_interpretation). Only
-    artifact_recommendation remains a stub; C3/S3 ships the renderer
-    that picks it.
+    Signal and interpretation are stubs at this stage. The background task
+    (app.engine.background_tasks.finalize_analysis) replaces them with
+    real values asynchronously and then flips status pending → draft.
 
-    Function name preserved from S2a so analyze_router doesn't need to
-    change. The "stub" qualifier now applies only to
-    artifact_recommendation.
+    This was previously doing the heavy work synchronously, which meant
+    POST /api/engine/analyze blocked for ~5–15 seconds on the LLM
+    roundtrip — defeating the async pending→draft contract from S2a.
+    Restoring the original contract: POST returns 202 in <1s; the
+    background task does signal computation + LLM interpretation.
+
+    Function name preserved so analyze_router doesn't change.
 
     Callers: POST /api/engine/analyze handler. Coverage is fetched once
-    by the handler and passed here. Signal and interpretation are both
-    built synchronously inside this call — DB reads + (potentially) one
-    Anthropic API roundtrip; LLM cache hits are fast (single SELECT).
+    by the handler and passed here. No DB reads, no API calls — fast.
     """
     inputs_hash = compute_inputs_hash(
         entity=entity,
         event_date=event_date,
         peer_set=peer_set,
         coverage_snapshot_hash=coverage.data_snapshot_hash,
-    )
-    signal = build_signal(
-        entity=entity,
-        event_date=event_date,
-        peer_set=peer_set,
-        coverage=coverage,
-    )
-    interpretation = get_or_call_interpretation(
-        entity=entity,
-        event_date=event_date,
-        peer_set=peer_set,
-        coverage=coverage,
-        signal=signal,
-        context=context,
     )
     return AnalysisCreate(
         analysis_version=ANALYSIS_VERSION_S2A,
@@ -198,8 +187,8 @@ def build_stub_analysis(
         peer_set=peer_set,
         context=context,
         coverage=coverage,
-        signal=signal,
-        interpretation=interpretation,
+        signal=_stub_signal(),
+        interpretation=_stub_interpretation(entity, inputs_hash),
         methodology_observations=[],
         follow_ups=[],
         artifact_recommendation=_stub_artifact_recommendation(),

--- a/app/engine/analysis_persistence.py
+++ b/app/engine/analysis_persistence.py
@@ -319,6 +319,50 @@ async def update_analysis_status(
 
 
 # ─────────────────────────────────────────────────────────────────
+# Background-task finalization
+#
+# Atomically swaps the stub signal + stub interpretation with real values
+# and flips status pending → draft. Used by background_tasks.finalize_analysis
+# after build_signal + get_or_call_interpretation complete.
+# ─────────────────────────────────────────────────────────────────
+
+def _update_analysis_finalization_sync(
+    analysis_id: UUID,
+    signal: "Signal",  # forward type — avoids extra import
+    interpretation: "Interpretation",
+) -> None:
+    from app.engine.schemas import Signal, Interpretation  # local to defer cycle
+    signal_json = psycopg2.extras.Json(signal.model_dump(mode="json"))
+    interp_json = psycopg2.extras.Json(interpretation.model_dump(mode="json"))
+    with get_cursor() as cur:
+        cur.execute(
+            """
+            UPDATE engine_analyses
+            SET signal = %s,
+                interpretation = %s,
+                status = 'draft'
+            WHERE id = %s
+            """,
+            (signal_json, interp_json, str(analysis_id)),
+        )
+
+
+async def update_analysis_finalization(
+    analysis_id: UUID,
+    signal,
+    interpretation,
+) -> None:
+    """Replace the stub signal + interpretation with real values and flip
+    status pending → draft, in a single UPDATE. artifact_recommendation
+    is left untouched (still derives from coverage_quality at INSERT time
+    until S3a ships the renderer)."""
+    await asyncio.to_thread(
+        _update_analysis_finalization_sync,
+        analysis_id, signal, interpretation,
+    )
+
+
+# ─────────────────────────────────────────────────────────────────
 # Archive (for force_new flow) + link superseded_by_id on old row
 # ─────────────────────────────────────────────────────────────────
 

--- a/app/engine/background_tasks.py
+++ b/app/engine/background_tasks.py
@@ -1,20 +1,38 @@
 """
 Component 2: Background tasks.
 
-S2a: a single task `finalize_stub_analysis` that sleeps briefly and flips
-a newly-inserted Analysis row from `status='pending'` to `status='draft'`.
-This is the skeleton of the async state machine that S2c will replace with
-real LLM-backed interpretation + cache lookup + result persistence.
+S2c-async-fix: replaces the S2a sleep-only stub with real finalization.
+The POST /api/engine/analyze handler INSERTs a skeleton row with stub
+signal + stub interpretation at status='pending' and returns 202 in <1s.
+This task does the heavy work asynchronously:
 
-Spawned via asyncio.create_task() from the async POST /analyze handler.
-Runs in the same event loop as the request handler; no external queue.
+  1. Load the persisted Analysis (gives us coverage, entity, event_date,
+     peer_set, context — everything needed for finalization)
+  2. Build real signal via app.engine.observation_builder.build_signal
+  3. Build real interpretation via
+     app.engine.interpretation.get_or_call_interpretation (LLM call or
+     cache hit; fallback template on API failure or budget exhaustion)
+  4. UPDATE the row with real signal + interpretation, flip status
+     pending → draft
+
+Spawned via asyncio.create_task() from the async POST handler. Runs in
+the same event loop as the request handler; no external queue.
+
+Failure handling:
+  - get_or_call_interpretation already returns a fallback template on
+    API failure / budget exhaustion — won't raise.
+  - build_signal can raise on DB connection issues. We catch all
+    exceptions, log them with the analysis_id, and flip the row to
+    'draft' anyway so it doesn't stay stuck at 'pending' forever.
+    The persisted signal/interpretation will be the stubs from INSERT
+    time; the operator sees template:stub model_id and can re-run via
+    force_new=true.
 
 Known limitation (acknowledged in Step 0 §3 and S2a prompt): in-process
 tasks don't survive worker restart. If uvicorn restarts a worker between
-the INSERT and the scheduled status flip, the row stays pending forever.
-S2c introduces a reaper job to sweep orphaned pending rows older than
-10 minutes. Deferred here because stub behavior has no cost of being
-re-queued manually.
+the INSERT and the scheduled finalization, the row stays pending forever.
+S0's reaper job (separate concern) sweeps orphaned pending rows older
+than 10 minutes.
 
 Exceptions from the background task are caught and logged via an
 add_done_callback so they don't vanish silently.
@@ -26,43 +44,93 @@ import asyncio
 import logging
 from uuid import UUID
 
-from app.engine.analysis_persistence import update_analysis_status
+from app.engine.analysis_persistence import (
+    get_analysis,
+    update_analysis_finalization,
+    update_analysis_status,
+)
+from app.engine.interpretation import get_or_call_interpretation
+from app.engine.observation_builder import build_signal
 
 logger = logging.getLogger(__name__)
 
 
-# Delay used by the stub finalizer. Kept small for test ergonomics
-# (test_analyze_pending_flips_to_draft waits 3 seconds, so 2 leaves
-# headroom). S2c will replace this with the real LLM roundtrip time.
-STUB_FINALIZE_DELAY_SECONDS = 2
+async def finalize_analysis(analysis_id: UUID) -> None:
+    """Replace the skeleton signal + interpretation with real values and
+    flip status pending → draft. The slow path here is the LLM call
+    inside get_or_call_interpretation — typically 5–15s on a cache miss,
+    sub-second on a cache hit, near-instant on the API-unavailable
+    fallback path."""
+    try:
+        analysis = await get_analysis(analysis_id)
+        if analysis is None:
+            logger.error(
+                "finalize_analysis: row %s vanished before finalization",
+                analysis_id,
+            )
+            return
 
+        # build_signal is sync (DB queries via psycopg2). Wrap in to_thread
+        # so the event loop is free during the ~50–100ms of DB work.
+        signal = await asyncio.to_thread(
+            build_signal,
+            entity=analysis.entity,
+            event_date=analysis.event_date,
+            peer_set=analysis.peer_set,
+            coverage=analysis.coverage,
+        )
 
-async def finalize_stub_analysis(analysis_id: UUID) -> None:
-    """Sleep briefly, then flip pending → draft on the given analysis.
+        # get_or_call_interpretation is also sync — wraps an Anthropic
+        # SDK call. Wrap in to_thread for the same reason.
+        interpretation = await asyncio.to_thread(
+            get_or_call_interpretation,
+            entity=analysis.entity,
+            event_date=analysis.event_date,
+            peer_set=analysis.peer_set,
+            coverage=analysis.coverage,
+            signal=signal,
+            context=analysis.context,
+        )
 
-    S2a stub implementation — no real work performed. Later stages
-    will populate real Signal/Interpretation here and then flip.
-    """
-    await asyncio.sleep(STUB_FINALIZE_DELAY_SECONDS)
-    await update_analysis_status(analysis_id, new_status="draft")
+        await update_analysis_finalization(analysis_id, signal, interpretation)
+    except Exception as exc:
+        logger.exception(
+            "finalize_analysis: failed for id=%s: %s — flipping to "
+            "draft with stub data so the row isn't stuck at pending",
+            analysis_id, exc,
+        )
+        # Best-effort: don't leave the row stuck. Stubs persist; operator
+        # can retry via force_new=true.
+        try:
+            await update_analysis_status(
+                analysis_id,
+                new_status="draft",
+                review_notes=f"finalize_analysis failed: {type(exc).__name__}",
+            )
+        except Exception:
+            logger.exception(
+                "finalize_analysis: status flip also failed for id=%s",
+                analysis_id,
+            )
 
 
 def spawn_finalize_task(analysis_id: UUID) -> asyncio.Task:
-    """Schedule finalize_stub_analysis on the running event loop and
-    attach a done-callback that logs exceptions. Returns the Task so
-    callers can optionally await it (tests) but normally fire-and-forget."""
-    task = asyncio.create_task(finalize_stub_analysis(analysis_id))
+    """Schedule finalize_analysis on the running event loop and attach a
+    done-callback that logs exceptions. Public API used by analyze_router;
+    name preserved across the S2a → S2c-async-fix transition so the
+    router doesn't need to change."""
+    task = asyncio.create_task(finalize_analysis(analysis_id))
 
     def _on_done(t: asyncio.Task) -> None:
         if t.cancelled():
             logger.warning(
-                "finalize_stub_analysis cancelled for id=%s", analysis_id
+                "finalize_analysis cancelled for id=%s", analysis_id
             )
             return
         exc = t.exception()
         if exc is not None:
             logger.exception(
-                "finalize_stub_analysis failed for id=%s: %s", analysis_id, exc
+                "finalize_analysis failed for id=%s: %s", analysis_id, exc
             )
 
     task.add_done_callback(_on_done)

--- a/tests/test_engine_observations.py
+++ b/tests/test_engine_observations.py
@@ -173,9 +173,14 @@ def _track(analysis_id: str) -> str:
     return analysis_id
 
 
-def _wait_for_draft(admin_api, analysis_id: str, timeout: float = 6.0) -> dict:
+def _wait_for_draft(admin_api, analysis_id: str, timeout: float = 30.0) -> dict:
     """Poll GET /api/engine/analyses/{id} until status != 'pending'.
-    Returns the final response body."""
+    Returns the final response body.
+
+    Timeout bumped from 6s to 30s for S2c-async: the LLM roundtrip in
+    finalize_analysis can take 5–15s on a cache miss before status
+    flips to draft. Cache hits and fallback paths complete in <1s.
+    """
     deadline = time.time() + timeout
     body: dict = {}
     while time.time() < deadline:
@@ -341,10 +346,25 @@ def test_drift_analysis_populates_real_observations(admin_api):
     ]
     assert len(psi_obs) > 0, "expected PSI observations from backfill"
 
-    # version stamp: real-signal flavor
-    assert body_full["analysis_version"] == "v0.1-s2b-real-signal"
-    # interpretation is still stub
-    assert body_full["interpretation"]["model_id"] == "template:stub"
+    # Stage stamp: bumped to the S2c value when LLM interpretation
+    # landed. Forward-stable detector continues to flag drift if a
+    # future stage ships without bumping the stamp.
+    assert body_full["analysis_version"] == "v0.1-s2c-llm-interpretation"
+
+    # Real LLM interpretation tags (S2c). Accept the fallback path so
+    # CI doesn't fail on a known-degraded production state (no
+    # ANTHROPIC_API_KEY, budget exhausted). Skip with a clear reason
+    # rather than failing — operator sees the cause.
+    interp_model_id = body_full["interpretation"]["model_id"]
+    assert interp_model_id in ("claude-sonnet-4-6", "template:fallback"), (
+        f"unexpected model_id: {interp_model_id!r}"
+    )
+    if interp_model_id == "template:fallback":
+        pytest.skip(
+            f"LLM unavailable (fallback returned). Reason: "
+            f"{body_full['interpretation'].get('confidence_reasoning')!r}. "
+            "Set ANTHROPIC_API_KEY and ensure budget headroom, then re-run."
+        )
 
 
 # ═════════════════════════════════════════════════════════════════


### PR DESCRIPTION
Real S2c bug + the stale `test_engine_observations.py` version assertion. Both fixes in one commit.

## The bug

Production verification showed `POST /api/engine/analyze` taking ~24s to return 202. The async `pending → draft` contract from S2a was the whole point of returning 202 immediately — the LLM roundtrip should never block the request handler.

**Cause:** when S2c shipped, `build_stub_analysis` was extended to call `build_signal()` AND `get_or_call_interpretation()` synchronously inside the request handler. The "stub" name became inaccurate, the function became slow, and the background task was just sleeping for 2s with nothing to do.

## The fix

Restore the original contract.

**POST handler (now <1s):**
1. Validate, fetch coverage, dedupe-or-archive
2. Build the SKELETON `AnalysisCreate` — stub signal, stub interpretation, just `inputs_hash` and metadata
3. `INSERT` row at `status='pending'`
4. `spawn_finalize_task(new_id)` → returns immediately
5. Return 202

**Background task (does the heavy work):**
1. Load the persisted Analysis from DB (gives us coverage, peer_set, etc.)
2. `build_signal` — sync DB queries, ~50–100ms, wrapped in `asyncio.to_thread`
3. `get_or_call_interpretation` — LLM call (5–15s) or cache hit (<1s) or fallback (~immediate), wrapped in `asyncio.to_thread`
4. UPDATE row's `signal` + `interpretation` JSONB, flip `status` to `draft`, atomic single statement

**Failure handling:** `get_or_call_interpretation` already returns a fallback template on API failure (won't raise). `build_signal` can raise on DB issues — the task wrapper catches everything, logs with `analysis_id`, and flips the row to `draft` anyway so it doesn't stay stuck at `pending` forever. The persisted signal/interpretation will be the stubs from INSERT time; operator sees `template:stub` and can re-run via `force_new=true`.

## Files changed (4)

| File | Status | Lines | What |
|---|---|---|---|
| `app/engine/analysis.py` | modified | -16, +20 | `build_stub_analysis` reverts to skeleton-only; unused imports removed |
| `app/engine/analysis_persistence.py` | modified | +44 | new `update_analysis_finalization` helper (atomic UPDATE) |
| `app/engine/background_tasks.py` | rewritten | -21, +109 | `finalize_stub_analysis` → `finalize_analysis` doing real work |
| `tests/test_engine_observations.py` | modified | -7, +25 | three test fixes (below) |

**Untouched:** `analyze_router.py` (contract unchanged), `interpretation.py`, `observation_builder.py`, `cost_tracker.py`, `budget_router.py`, `coverage.py`, `coverage_router.py`, `router.py`, `schemas.py`, every migration, `app/server.py`, `requirements.txt`.

## Test fixes in `test_engine_observations.py::test_drift_analysis_populates_real_observations`

Three related changes — same comprehensive pattern as the S2a-test bump in PR #46 (`af2e322`):

1. **`_wait_for_draft` timeout: 6.0 → 30.0.** LLM call now happens in the background task; the previous 6s ceiling didn't allow for the 5–15s LLM roundtrip.

2. **`analysis_version` assertion: `"v0.1-s2b-real-signal"` → `"v0.1-s2c-llm-interpretation"`.** Catches the S2c version bump that should have shipped with PR #46.

3. **`interpretation.model_id` assertion: strict `"template:stub"` → accept-and-skip pattern.** The old stub value isn't reachable post-S2c (real LLM path returns `claude-sonnet-4-6`; fallback path returns `template:fallback`). Same skip-on-fallback pattern as `test_engine_interpretation.py`.

## Verification (operator-run, post-merge)

```bash
# Latency check — must be <1s
time curl -X POST -H "X-Admin-Key: $ADMIN_KEY" \
  -H "Content-Type: application/json" \
  -d '{"entity":"drift","event_date":"2026-04-12","peer_set":[]}' \
  https://basisprotocol.xyz/api/engine/analyze

# Wait for the background task; then inspect
sleep 15
curl -s -H "X-Admin-Key: $ADMIN_KEY" \
  "https://basisprotocol.xyz/api/engine/analyses?entity=drift&limit=1" \
  | python3 -m json.tool
# expect: status=draft, populated signal (matched_entities + observations),
#         interpretation.model_id="claude-sonnet-4-6"

# Full suite — expect all 4 engine test files green
ADMIN_KEY=$ADMIN_KEY DATABASE_URL=$DATABASE_URL BASE_URL=https://basisprotocol.xyz \
  pytest tests/test_engine_interpretation.py tests/test_engine_observations.py \
        tests/test_engine_analyze.py tests/test_engine_coverage.py -v --tb=short
```

## Commit

`89ec157` — `engine: fix S2c POST latency — move LLM call into the background task` (4 files, +191/-70)

Refs: PR #46 (S2c that introduced the bug), PR #45 commit `117de08` (precedent for the test-file bump pattern)

https://claude.ai/code/session_01FWDKHwn3cevR8MMLTV8Fn2

---
_Generated by [Claude Code](https://claude.ai/code/session_01FWDKHwn3cevR8MMLTV8Fn2)_