### PR TITLE
engine: fix S2c background task — analyses no longer stuck pending

### DIFF
--- a/app/engine/background_tasks.py
+++ b/app/engine/background_tasks.py
@@ -18,6 +18,19 @@ This task does the heavy work asynchronously:
 Spawned via asyncio.create_task() from the async POST handler. Runs in
 the same event loop as the request handler; no external queue.
 
+Task GC safety:
+  asyncio.create_task() only registers a WEAK reference in the event
+  loop. If the only strong reference is the local Task variable in
+  spawn_finalize_task, Python can garbage-collect the Task object the
+  moment that function returns — interrupting work mid-flight. The
+  S2a sleep-only task dodged this by accident (2s sleep finished
+  before GC ran); the S2c background task does 5–15s of LLM work and
+  hit the GC reliably, leaving rows stuck at status='pending'.
+
+  Fix: keep a module-level set of in-flight tasks, add each task on
+  spawn, remove via add_done_callback when the task completes. This
+  is the standard pattern documented in the asyncio.create_task docs.
+
 Failure handling:
   - get_or_call_interpretation already returns a fallback template on
     API failure / budget exhaustion — won't raise.
@@ -27,15 +40,15 @@ Failure handling:
     The persisted signal/interpretation will be the stubs from INSERT
     time; the operator sees template:stub model_id and can re-run via
     force_new=true.
+  - Pre/post-UPDATE logging makes background-task progress visible in
+    Railway logs so the operator can confirm the task ran without
+    polling the DB directly.
 
 Known limitation (acknowledged in Step 0 §3 and S2a prompt): in-process
 tasks don't survive worker restart. If uvicorn restarts a worker between
 the INSERT and the scheduled finalization, the row stays pending forever.
 S0's reaper job (separate concern) sweeps orphaned pending rows older
-than 10 minutes.
-
-Exceptions from the background task are caught and logged via an
-add_done_callback so they don't vanish silently.
+than 10 minutes. Not blocking for v1; tracked as a follow-up.
 """
 
 from __future__ import annotations
@@ -55,12 +68,22 @@ from app.engine.observation_builder import build_signal
 logger = logging.getLogger(__name__)
 
 
+# Strong references to in-flight finalize tasks. Without this, Python
+# garbage-collects asyncio.Tasks whose only reference is local to the
+# spawning function — the S2c bug (PR #47) where analyses got stuck at
+# status='pending' because the LLM-roundtrip-bearing task disappeared
+# mid-flight. add_done_callback below removes entries on completion so
+# the set doesn't grow unbounded.
+_IN_FLIGHT_TASKS: set[asyncio.Task] = set()
+
+
 async def finalize_analysis(analysis_id: UUID) -> None:
     """Replace the skeleton signal + interpretation with real values and
     flip status pending → draft. The slow path here is the LLM call
     inside get_or_call_interpretation — typically 5–15s on a cache miss,
     sub-second on a cache hit, near-instant on the API-unavailable
     fallback path."""
+    logger.info("finalize_analysis: starting for id=%s", analysis_id)
     try:
         analysis = await get_analysis(analysis_id)
         if analysis is None:
@@ -69,6 +92,10 @@ async def finalize_analysis(analysis_id: UUID) -> None:
                 analysis_id,
             )
             return
+        logger.info(
+            "finalize_analysis: loaded analysis id=%s entity=%s event_date=%s",
+            analysis_id, analysis.entity, analysis.event_date,
+        )
 
         # build_signal is sync (DB queries via psycopg2). Wrap in to_thread
         # so the event loop is free during the ~50–100ms of DB work.
@@ -78,6 +105,14 @@ async def finalize_analysis(analysis_id: UUID) -> None:
             event_date=analysis.event_date,
             peer_set=analysis.peer_set,
             coverage=analysis.coverage,
+        )
+        signal_obs_total = (
+            len(signal.baseline) + len(signal.pre_event)
+            + len(signal.event_window) + len(signal.post_event)
+        )
+        logger.info(
+            "finalize_analysis: built signal id=%s observations=%d",
+            analysis_id, signal_obs_total,
         )
 
         # get_or_call_interpretation is also sync — wraps an Anthropic
@@ -91,8 +126,22 @@ async def finalize_analysis(analysis_id: UUID) -> None:
             signal=signal,
             context=analysis.context,
         )
+        logger.info(
+            "finalize_analysis: built interpretation id=%s model_id=%s "
+            "from_cache=%s confidence=%s",
+            analysis_id, interpretation.model_id,
+            interpretation.from_cache, interpretation.confidence,
+        )
 
+        logger.info(
+            "finalize_analysis: about to UPDATE id=%s (signal + interpretation, status=draft)",
+            analysis_id,
+        )
         await update_analysis_finalization(analysis_id, signal, interpretation)
+        logger.info(
+            "finalize_analysis: UPDATE complete id=%s — analysis is now status=draft",
+            analysis_id,
+        )
     except Exception as exc:
         logger.exception(
             "finalize_analysis: failed for id=%s: %s — flipping to "
@@ -115,13 +164,22 @@ async def finalize_analysis(analysis_id: UUID) -> None:
 
 
 def spawn_finalize_task(analysis_id: UUID) -> asyncio.Task:
-    """Schedule finalize_analysis on the running event loop and attach a
-    done-callback that logs exceptions. Public API used by analyze_router;
-    name preserved across the S2a → S2c-async-fix transition so the
-    router doesn't need to change."""
+    """Schedule finalize_analysis on the running event loop. Holds a
+    strong reference in _IN_FLIGHT_TASKS so the task survives until it
+    completes; the done callback removes it so the set doesn't leak.
+
+    Public API used by analyze_router; name preserved across the
+    S2a → S2c-async-fix → S2c-bg-task-fix transitions so the router
+    doesn't need to change.
+    """
     task = asyncio.create_task(finalize_analysis(analysis_id))
+    _IN_FLIGHT_TASKS.add(task)
 
     def _on_done(t: asyncio.Task) -> None:
+        # First: drop the strong ref so the Task is collectable now that
+        # it's done. Independent of success/failure path below.
+        _IN_FLIGHT_TASKS.discard(t)
+
         if t.cancelled():
             logger.warning(
                 "finalize_analysis cancelled for id=%s", analysis_id
@@ -130,7 +188,8 @@ def spawn_finalize_task(analysis_id: UUID) -> asyncio.Task:
         exc = t.exception()
         if exc is not None:
             logger.exception(
-                "finalize_analysis failed for id=%s: %s", analysis_id, exc
+                "finalize_analysis raised (caught at done-callback) for id=%s: %s",
+                analysis_id, exc,
             )
 
     task.add_done_callback(_on_done)


### PR DESCRIPTION
PR #47 fixed POST latency (<1s — confirmed in production verification at 0.6s) but introduced a task GC vulnerability. The background task is now killed before it can do its 5–15s of work, leaving 6 of 39 tests failing with `status='pending'` indefinitely.

## Root cause: asyncio task garbage collection

`asyncio.create_task()` only registers a **weak** reference in the event loop. `spawn_finalize_task` created the Task and returned it, but `analyze_router` discarded the return value — meaning the only strong reference was a local variable inside `spawn_finalize_task` that went out of scope the moment the function returned. Python is then free to GC the Task before its work completes.

The S2a sleep-only task (2s sleep + status flip) finished before GC ran. The S2c task added a 5–15s LLM roundtrip via `asyncio.to_thread`, giving GC plenty of opportunity to interrupt it.

Failure was systemic (all 6 background-task-dependent integration tests failed identically) and silent — Python doesn't warn when collecting a still-pending Task; the work just stops mid-flight.

This is the canonical asyncio footgun. The Python docs are explicit:

> Save a reference to the result of this function, to avoid a task disappearing mid-execution.

## Fix

Single file: `app/engine/background_tasks.py`. +68/-9.

**1. Module-level `_IN_FLIGHT_TASKS: set[asyncio.Task]`** holds strong references to in-flight finalize tasks. `spawn_finalize_task` adds on creation; the done-callback removes on completion. Standard pattern from the asyncio docs.

```python
_IN_FLIGHT_TASKS: set[asyncio.Task] = set()

def spawn_finalize_task(analysis_id: UUID) -> asyncio.Task:
    task = asyncio.create_task(finalize_analysis(analysis_id))
    _IN_FLIGHT_TASKS.add(task)

    def _on_done(t: asyncio.Task) -> None:
        _IN_FLIGHT_TASKS.discard(t)  # drop ref so Task is collectable now
        # ... cancellation + exception logging unchanged ...

    task.add_done_callback(_on_done)
    return task
```

**2. Pre/post-step logging** inside `finalize_analysis` makes the background-task lifecycle visible in Railway logs:

```
finalize_analysis: starting for id=<UUID>
finalize_analysis: loaded analysis id=<UUID> entity=drift event_date=2026-04-08
finalize_analysis: built signal id=<UUID> observations=42
finalize_analysis: built interpretation id=<UUID> model_id=claude-sonnet-4-6 from_cache=False confidence=medium
finalize_analysis: about to UPDATE id=<UUID> (signal + interpretation, status=draft)
finalize_analysis: UPDATE complete id=<UUID> — analysis is now status=draft
```

Without these, a silent GC kill (prior symptom) was indistinguishable from a hung task or a working task. Operator had no signal.

## What this is NOT

- **Not a contract change.** `spawn_finalize_task(analysis_id)` signature unchanged. `analyze_router.py` doesn't touch.
- **Not a test change.** The 6 failing integration tests will pass once the task survives long enough to do its work.
- **Not a schema or migration change.**

## Files

```
$ git diff --name-only main
app/engine/background_tasks.py
```

## Known follow-up (deferred, not blocking)

In-process tasks don't survive uvicorn worker restart. If Railway restarts mid-task, the analysis stays pending forever. A reaper job that sweeps `engine_analyses` rows with `status='pending' AND created_at < NOW() - INTERVAL '10 minutes'` is the standard fix. Defer until C4 demands real concurrency.

## Verification (operator-run, post-merge)

```bash
# Trigger a fresh analysis
curl -s -X POST "https://basisprotocol.xyz/api/engine/analyze" \
  -H "X-Admin-Key: $ADMIN_KEY" -H "Content-Type: application/json" \
  -d '{"entity":"layerzero","event_date":"2026-04-30","peer_set":[],"force_new":true}'

sleep 20

# Inspect — status should be 'draft', signal populated, interpretation real
LZ_ID=$(curl -s -H "X-Admin-Key: $ADMIN_KEY" \
  "https://basisprotocol.xyz/api/engine/analyses?entity=layerzero&limit=1" \
  | python3 -c "import sys,json; print(json.load(sys.stdin)[0]['id'])")
curl -s -H "X-Admin-Key: $ADMIN_KEY" \
  "https://basisprotocol.xyz/api/engine/analyses/$LZ_ID" \
  | python3 -c "
import sys, json
d = json.load(sys.stdin)
print('status:', d['status'])
print('signal pre_event obs:', len(d['signal']['pre_event']))
print('headline:', d['interpretation'].get('headline'))
print('model_id:', d['interpretation'].get('model_id'))
"

# Full suite
ADMIN_KEY=$ADMIN_KEY DATABASE_URL=$DATABASE_URL BASE_URL=https://basisprotocol.xyz \
  pytest tests/test_engine_interpretation.py tests/test_engine_observations.py \
        tests/test_engine_analyze.py tests/test_engine_coverage.py -v --tb=short
```

Expected after fix:
- status: draft
- signal pre_event obs: > 0
- headline: real LLM-generated text (not "stub analysis")
- model_id: claude-sonnet-4-6
- 39/39 tests pass (or 38 + cache flake)

Railway logs should show all 6 finalize_analysis log lines per analysis call. If you see "starting" but no subsequent lines, the task is hanging on something specific — would point at a downstream bug (DB pool, Anthropic API hang, etc.) rather than GC.

## Commit

`49d9814` — `engine: fix S2c background task — analyses no longer stuck pending` (1 file, +68/-9)

Refs: PR #47 (the async fix that introduced the GC vulnerability), PR #46 (S2c)

https://claude.ai/code/session_01FWDKHwn3cevR8MMLTV8Fn2

---
_Generated by [Claude Code](https://claude.ai/code/session_01FWDKHwn3cevR8MMLTV8Fn2)_