### PR TITLE
engine: fix from_cache=False assertion in interpretation test

### DIFF
--- a/tests/test_engine_interpretation.py
+++ b/tests/test_engine_interpretation.py
@@ -63,7 +63,7 @@ from app.engine.schemas import (
 # ═════════════════════════════════════════════════════════════════
 
 TEST_FIXTURE_KEYS: list[tuple[str, date]] = [
-    ("drift", date(2026, 4, 8)),       # test_drift_analysis_produces_real_interpretation
+    ("drift", date(2099, 1, 1)),       # test_drift_analysis_produces_real_interpretation (sentinel future date — see test docstring)
     ("drift", date(2026, 4, 9)),       # test_cache_hit_on_second_identical_call (first POST)
 ]
 
@@ -365,10 +365,23 @@ def test_canonicalize_signal_observation_order_independent():
 def test_drift_analysis_produces_real_interpretation(admin_api):
     """POST analyze for drift; after pending→draft flip, interpretation
     has populated content fields (not the stub) and is tagged with the
-    Sonnet 4.6 model_id and prompt v1."""
+    Sonnet 4.6 model_id and prompt v1.
+
+    event_date=2099-01-01 is a sentinel "never analyzed before" value
+    that guarantees a cache miss on the first run after this PR
+    deploys, so from_cache=False is reachable. The signal will be
+    empty (no observations exist for any 2099 window), so the
+    interpretation runs against coverage + empty signal — the LLM
+    should still mention drift by name and produce a valid response.
+
+    Caveat: subsequent runs of this test against the same database
+    will cache the 2099-01-01 entry and from_cache becomes True. If
+    that becomes a recurring nuisance, a follow-up should clear the
+    interpretation cache row in the per-test teardown.
+    """
     body = {
         "entity": "drift",
-        "event_date": "2026-04-08",
+        "event_date": "2099-01-01",
         "peer_set": ["jupiter-perpetual-exchange"],
     }
     resp = admin_api.post("/api/engine/analyze", body)


### PR DESCRIPTION
Two assertions you flagged. One real fix in this PR; the other is already on main and your test runner is on a stale checkout.

## Failure 1 — `test_drift_analysis_produces_real_interpretation` (real, fixed here)

`interp["from_cache"] is False` fails because production's `engine_interpretation_cache` has accumulated `drift/2026-04-08` entries from prior test runs and your manual verification curls. By the time this test runs, the cache is hot and `from_cache` flips to True.

**Fix per your preferred option (a):** switch `event_date` to `2099-01-01` — a sentinel "never analyzed before" date. First run after this PR deploys hits a cache miss; assertion passes.

**Caveat documented inline:** subsequent runs against the same DB will cache the 2099-01-01 entry too, so a future run could fail again. Per your "no DB cleanup" direction, I left out a teardown sweep — if it becomes a nuisance, the follow-up is one line in the per-test cleanup that DELETEs the interpretation cache row by `interpretation->>'input_hash'` from the engine_analyses row before deleting the analysis itself.

```diff
-TEST_FIXTURE_KEYS: list[tuple[str, date]] = [
-    ("drift", date(2026, 4, 8)),
+TEST_FIXTURE_KEYS: list[tuple[str, date]] = [
+    ("drift", date(2099, 1, 1)),       # sentinel — guarantees first-run cache miss
     ("drift", date(2026, 4, 9)),

 def test_drift_analysis_produces_real_interpretation(admin_api):
     body = {
         "entity": "drift",
-        "event_date": "2026-04-08",
+        "event_date": "2099-01-01",
         "peer_set": ["jupiter-perpetual-exchange"],
     }
```

## Failure 2 — `test_drift_analysis_populates_real_observations` (already fixed on main)

```
assert body_full["analysis_version"] == "v0.1-s2b-real-signal"
```

This one's a **stale local checkout**, not a real bug. PR #47 commit `89ec157` already bumped this assertion to `"v0.1-s2c-llm-interpretation"`. Verified on main at `tests/test_engine_observations.py:352`:

```python
assert body_full["analysis_version"] == "v0.1-s2c-llm-interpretation"
```

`git diff d68e232 -- tests/test_engine_observations.py` shows the bump was included. Your local Replit checkout must be lagging behind main.

**Resolution:** `git pull origin main` in your Replit shell, then re-run pytest. No code change needed for this one.

## Files

```
$ git diff --name-only main
tests/test_engine_interpretation.py
```

Single file. +16 lines (most of them inline docstring explaining the sentinel pattern).

## Verification (operator-run, post-merge + post-pull)

```bash
git pull origin main  # picks up THIS PR + the already-merged PR #47 fix to observations.py

ADMIN_KEY=$ADMIN_KEY DATABASE_URL=$DATABASE_URL BASE_URL=https://basisprotocol.xyz \
  pytest tests/test_engine_interpretation.py tests/test_engine_observations.py \
        tests/test_engine_analyze.py tests/test_engine_coverage.py -v --tb=short
```

Expected: 39/39.

## Commit

`319e05a` — `engine: fix from_cache=False assertion in interpretation test` (1 file, +16/-3)

Refs: PR #47 (where the observations.py bump landed and where the cache started accumulating drift entries)

https://claude.ai/code/session_01FWDKHwn3cevR8MMLTV8Fn2

---
_Generated by [Claude Code](https://claude.ai/code/session_01FWDKHwn3cevR8MMLTV8Fn2)_