### PR TITLE
engine: three test fixes blocking 51/51 (timeout, recommendation, cache)

### DIFF
--- a/tests/test_engine_analyze.py
+++ b/tests/test_engine_analyze.py
@@ -297,9 +297,10 @@ def test_analyze_pending_flips_to_draft(admin_api):
     aid = _track(resp.json()["analysis_id"])
 
     # Background task: ~2s scheduler delay + up to ~15s for the LLM
-    # roundtrip in S2c. Poll until the status leaves pending or we
-    # hit the 30s ceiling.
-    deadline = time.time() + 30.0
+    # roundtrip + signal build + recommendation derivation. Poll until
+    # the status leaves pending or we hit the 60s ceiling (was 30s pre-C3,
+    # but sequential test runs serialize enough work to need the headroom).
+    deadline = time.time() + 60.0
     analysis: dict = {}
     while time.time() < deadline:
         get_resp = admin_api.get(f"/api/engine/analyses/{aid}")
@@ -354,8 +355,17 @@ def test_analyze_pending_flips_to_draft(admin_api):
         f"event={len(signal['event_window'])}, "
         f"post={len(signal['post_event'])}"
     )
-    # Recommendation still blocks all artifact types — stays stub through S2c
-    assert analysis["artifact_recommendation"]["recommended"] == "nothing"
+    # Real recommendation (post-C3): kelp-rseth has partial-live LSTI
+    # coverage with deep history, so the recommendation primary should
+    # be retrospective_internal. If the LLM returned confidence=
+    # insufficient (sparse signal or fallback path), the floor logic
+    # in derive_recommendation collapses to internal_memo. Accept
+    # either; reject the S2a stub value of "nothing".
+    recommended = analysis["artifact_recommendation"]["recommended"]
+    assert recommended in ("retrospective_internal", "internal_memo"), (
+        f"expected real C3 recommendation; got {recommended!r}. "
+        f"Recommendation: {analysis['artifact_recommendation']}"
+    )
 
 
 # ═════════════════════════════════════════════════════════════════

--- a/tests/test_engine_interpretation.py
+++ b/tests/test_engine_interpretation.py
@@ -181,9 +181,10 @@ def _track(analysis_id: str) -> str:
     return analysis_id
 
 
-def _wait_for_draft(admin_api, analysis_id: str, timeout: float = 30.0) -> dict:
+def _wait_for_draft(admin_api, analysis_id: str, timeout: float = 60.0) -> dict:
     """Poll until status != pending. LLM call can take 5-15s in addition
-    to the ~2s background-task delay; allow 30s ceiling."""
+    to the ~2s background-task delay + signal/recommendation derivation;
+    60s ceiling accommodates sequential-test serialization."""
     deadline = time.time() + timeout
     body: dict = {}
     while time.time() < deadline:
@@ -367,17 +368,15 @@ def test_drift_analysis_produces_real_interpretation(admin_api):
     has populated content fields (not the stub) and is tagged with the
     Sonnet 4.6 model_id and prompt v1.
 
-    event_date=2099-01-01 is a sentinel "never analyzed before" value
-    that guarantees a cache miss on the first run after this PR
-    deploys, so from_cache=False is reachable. The signal will be
-    empty (no observations exist for any 2099 window), so the
-    interpretation runs against coverage + empty signal — the LLM
-    should still mention drift by name and produce a valid response.
-
-    Caveat: subsequent runs of this test against the same database
-    will cache the 2099-01-01 entry and from_cache becomes True. If
-    that becomes a recurring nuisance, a follow-up should clear the
-    interpretation cache row in the per-test teardown.
+    event_date=2099-01-01 is a sentinel "never analyzed before" value.
+    Originally chosen to guarantee a cache miss on first run — that's
+    no longer asserted here (cache correctness is owned by
+    test_cache_hit_on_second_identical_call). The sentinel date is
+    kept because it doesn't collide with any real-event date the
+    operator might curl manually. The signal will be empty (no
+    observations exist for any 2099 window), so the interpretation
+    runs against coverage + empty signal; the LLM should still mention
+    drift by name and produce a valid response.
     """
     body = {
         "entity": "drift",
@@ -388,7 +387,7 @@ def test_drift_analysis_produces_real_interpretation(admin_api):
     assert resp.status_code == 202, resp.text[:400]
     aid = _track(resp.json()["analysis_id"])
 
-    full = _wait_for_draft(admin_api, aid, timeout=30.0)
+    full = _wait_for_draft(admin_api, aid, timeout=60.0)
     assert full.get("status") == "draft", (
         f"status didn't flip within 30s; last seen: {full}"
     )
@@ -412,7 +411,13 @@ def test_drift_analysis_produces_real_interpretation(admin_api):
     # Real LLM path
     assert interp["prompt_version"] == ACTIVE_PROMPT_VERSION
     assert interp["confidence"] in ("high", "medium", "low", "insufficient")
-    assert interp["from_cache"] is False
+    # Note: NOT asserting from_cache here. The cache layer is verified
+    # explicitly by test_cache_hit_on_second_identical_call. This test's
+    # value is verifying that interpretation populates correctly —
+    # whether the population came from a fresh API call or a cache hit
+    # is orthogonal. (Sentinel-date approach broke after the first run
+    # cached the entry; rather than chase a clean-cache invariant, the
+    # other test owns cache correctness end-to-end.)
     # Required content fields populated
     assert interp["event_summary"]
     assert interp["headline"]
@@ -458,7 +463,7 @@ def test_cache_hit_on_second_identical_call(admin_api):
     r1 = admin_api.post("/api/engine/analyze", body)
     assert r1.status_code == 202, r1.text[:400]
     aid_1 = _track(r1.json()["analysis_id"])
-    a1 = _wait_for_draft(admin_api, aid_1, timeout=30.0)
+    a1 = _wait_for_draft(admin_api, aid_1, timeout=60.0)
     assert a1.get("status") == "draft"
 
     interp_1 = a1["interpretation"]
@@ -472,7 +477,7 @@ def test_cache_hit_on_second_identical_call(admin_api):
     r2 = admin_api.post("/api/engine/analyze", body_force)
     assert r2.status_code == 202, r2.text[:400]
     aid_2 = _track(r2.json()["analysis_id"])
-    a2 = _wait_for_draft(admin_api, aid_2, timeout=30.0)
+    a2 = _wait_for_draft(admin_api, aid_2, timeout=60.0)
     assert a2.get("status") == "draft"
 
     interp_2 = a2["interpretation"]

--- a/tests/test_engine_observations.py
+++ b/tests/test_engine_observations.py
@@ -173,13 +173,14 @@ def _track(analysis_id: str) -> str:
     return analysis_id
 
 
-def _wait_for_draft(admin_api, analysis_id: str, timeout: float = 30.0) -> dict:
+def _wait_for_draft(admin_api, analysis_id: str, timeout: float = 60.0) -> dict:
     """Poll GET /api/engine/analyses/{id} until status != 'pending'.
     Returns the final response body.
 
-    Timeout bumped from 6s to 30s for S2c-async: the LLM roundtrip in
-    finalize_analysis can take 5–15s on a cache miss before status
-    flips to draft. Cache hits and fallback paths complete in <1s.
+    Default timeout 60s: background task includes the LLM roundtrip
+    (5–15s) plus signal build, recommendation derivation, and an
+    UPDATE. Sequential test runs can serialize a few of these and
+    accumulate latency; 30s was too tight in practice.
     """
     deadline = time.time() + timeout
     body: dict = {}

--- a/tests/test_engine_renderers.py
+++ b/tests/test_engine_renderers.py
@@ -203,8 +203,8 @@ def _track(analysis_id: str) -> str:
     return analysis_id
 
 
-def _wait_for_draft(admin_api, analysis_id: str, timeout: float = 30.0) -> dict:
-    """Same pattern as test_engine_observations.py — poll up to 30s for
+def _wait_for_draft(admin_api, analysis_id: str, timeout: float = 60.0) -> dict:
+    """Same pattern as test_engine_observations.py — poll up to 60s for
     the background finalize task to flip status to draft."""
     deadline = time.time() + timeout
     body: dict = {}


### PR DESCRIPTION
All three fixes you flagged. Tests-only — no production code touched.

**Commit:** `f8d3dd4` — 4 files, +44/-28.

## Fix 1 — `_wait_for_draft` default timeout 30s → 60s

Bumped in three test files. Plus the three explicit `timeout=30.0` overrides in `test_engine_interpretation.py` (mechanical sed). Plus the inline `deadline = time.time() + 30.0` in `test_engine_analyze.py::test_analyze_pending_flips_to_draft`. All four files now use 60s.

Stale "30s ceiling" docstrings cleaned up.

## Fix 2 — `test_analyze_pending_flips_to_draft` recommendation assertion

Was:
```python
assert analysis["artifact_recommendation"]["recommended"] == "nothing"
```

Now:
```python
recommended = analysis["artifact_recommendation"]["recommended"]
assert recommended in ("retrospective_internal", "internal_memo"), (
    f"expected real C3 recommendation; got {recommended!r}. "
    f"Recommendation: {analysis['artifact_recommendation']}"
)
```

Two-element tuple instead of strict pin to `"retrospective_internal"`: kelp-rseth's partial-live coverage normally maps to `retrospective_internal`, but if the LLM returns `confidence=insufficient` (sparse signal or fallback path), `derive_recommendation`'s confidence-floor collapses to `internal_memo`. Either is correct post-C3; the stub `"nothing"` is what we're rejecting.

## Fix 3 — drop `from_cache is False` assertion in interpretation test

Replaced with a comment pointing at the test that owns cache correctness:

```python
# Note: NOT asserting from_cache here. The cache layer is verified
# explicitly by test_cache_hit_on_second_identical_call. This test's
# value is verifying that interpretation populates correctly —
# whether the population came from a fresh API call or a cache hit
# is orthogonal.
```

Sentinel `event_date=2099-01-01` stays — no longer needed for cache-miss guarantees, kept because it doesn't collide with manual curl dates. Docstring updated.

## Files

```
$ git diff --name-only main
tests/test_engine_analyze.py
tests/test_engine_interpretation.py
tests/test_engine_observations.py
tests/test_engine_renderers.py
```

## Verification

```bash
git pull origin main  # picks up this PR
ADMIN_KEY=$ADMIN_KEY DATABASE_URL=$DATABASE_URL BASE_URL=https://basisprotocol.xyz \
  pytest tests/test_engine_renderers.py tests/test_engine_interpretation.py \
        tests/test_engine_observations.py tests/test_engine_analyze.py \
        tests/test_engine_coverage.py -v --tb=short
```

Expected: 51/51.

Refs: PR #50 (C3), PR #49 (sentinel-date), PR #47 (the timeout grew from this stack)

https://claude.ai/code/session_01FWDKHwn3cevR8MMLTV8Fn2

---
_Generated by [Claude Code](https://claude.ai/code/session_01FWDKHwn3cevR8MMLTV8Fn2)_