### PR TITLE
engine: migration 101 — engine_events FK cascade to SET NULL

### DIFF
--- a/migrations/101_engine_events_fk_cascade.sql
+++ b/migrations/101_engine_events_fk_cascade.sql
@@ -1,0 +1,73 @@
+-- Migration 101: engine_events FK cascade fix
+--
+-- Original migration 098 declared:
+--   engine_events.analysis_id UUID REFERENCES engine_analyses(id)
+--   engine_events.artifact_id UUID REFERENCES engine_artifacts(id)
+-- with no explicit ON DELETE clause, defaulting to NO ACTION (effectively
+-- RESTRICT). That blocks any DELETE on engine_analyses or engine_artifacts
+-- when a referencing event row exists — which trips the C4 test cleanup
+-- path with:
+--
+--   psycopg2.errors.ForeignKeyViolation: update or delete on table
+--   "engine_analyses" violates foreign key constraint
+--   "engine_events_analysis_id_fkey" on table "engine_events"
+--
+-- Fix: switch both constraints to ON DELETE SET NULL. When an upstream row
+-- is deleted, the engine_events row keeps its other fields (audit trail
+-- preserved — source, entity, event_date, severity, raw_event_data, etc.)
+-- but the FK column becomes NULL. Maintenance ops + test cleanup unblocked.
+--
+-- Idempotency: each ALTER is wrapped in a DO block that checks pg_constraint
+-- before dropping. Re-running the migration is a no-op once applied.
+-- ============================================================================
+
+BEGIN;
+
+-- engine_events.analysis_id → engine_analyses(id)
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1 FROM pg_constraint
+        WHERE conname = 'engine_events_analysis_id_fkey'
+          AND conrelid = 'engine_events'::regclass
+    ) THEN
+        ALTER TABLE engine_events
+            DROP CONSTRAINT engine_events_analysis_id_fkey;
+    END IF;
+
+    ALTER TABLE engine_events
+        ADD CONSTRAINT engine_events_analysis_id_fkey
+            FOREIGN KEY (analysis_id)
+            REFERENCES engine_analyses(id)
+            ON DELETE SET NULL;
+END $$;
+
+-- engine_events.artifact_id → engine_artifacts(id)
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1 FROM pg_constraint
+        WHERE conname = 'engine_events_artifact_id_fkey'
+          AND conrelid = 'engine_events'::regclass
+    ) THEN
+        ALTER TABLE engine_events
+            DROP CONSTRAINT engine_events_artifact_id_fkey;
+    END IF;
+
+    ALTER TABLE engine_events
+        ADD CONSTRAINT engine_events_artifact_id_fkey
+            FOREIGN KEY (artifact_id)
+            REFERENCES engine_artifacts(id)
+            ON DELETE SET NULL;
+END $$;
+
+INSERT INTO migrations (name) VALUES ('101_engine_events_fk_cascade')
+    ON CONFLICT DO NOTHING;
+
+COMMIT;
+
+-- Verify with:
+--   SELECT conname, confrelid::regclass, confdeltype
+--   FROM pg_constraint
+--   WHERE conname LIKE 'engine_events%fkey';
+-- Expected: confdeltype = 'n' (SET NULL) for both rows.


### PR DESCRIPTION
Migration 101: switch the two FKs from `engine_events` (`analysis_id`, `artifact_id`) from default `NO ACTION`/`RESTRICT` to `ON DELETE SET NULL`. Unblocks test cleanup and operator maintenance ops without losing the audit trail on `engine_events`.

## Why

Migration 098 declared both FKs without an explicit `ON DELETE` clause:

```sql
analysis_id UUID REFERENCES engine_analyses(id),
artifact_id UUID REFERENCES engine_artifacts(id),
```

PostgreSQL defaults to `NO ACTION` (effectively `RESTRICT`), which blocks any `DELETE` on `engine_analyses` / `engine_artifacts` that has referencing event rows. C4's test cleanup path trips this:

```
ForeignKeyViolation: update or delete on table "engine_analyses"
violates foreign key constraint "engine_events_analysis_id_fkey"
```

## What

```sql
ALTER TABLE engine_events
    DROP CONSTRAINT engine_events_analysis_id_fkey;
ALTER TABLE engine_events
    ADD CONSTRAINT engine_events_analysis_id_fkey
        FOREIGN KEY (analysis_id)
        REFERENCES engine_analyses(id)
        ON DELETE SET NULL;
```

Same pattern for `artifact_id`. Both wrapped in `DO $$ ... $$` blocks that check `pg_constraint` before dropping, so the migration is idempotent.

## Behavior change

When an analysis is deleted, the linked `engine_events` row keeps `source`, `entity`, `event_date`, `severity`, `raw_event_data`, `status`, `delivered_at`, `operator_response` — the full audit trail. Only `analysis_id` becomes `NULL`. Same for artifacts.

## Apply + verify

```bash
psql "$DATABASE_URL" -f migrations/101_engine_events_fk_cascade.sql

psql "$DATABASE_URL" -c "
  SELECT conname, confrelid::regclass, confdeltype
  FROM pg_constraint
  WHERE conname LIKE 'engine_events%fkey';
"
# Expected: confdeltype = 'n' (SET NULL) for both rows
```

`confdeltype` reference: `'a'` = NO ACTION, `'r'` = RESTRICT, `'c'` = CASCADE, `'n'` = SET NULL, `'d'` = SET DEFAULT.

## Single file

```
$ git diff --name-only main
migrations/101_engine_events_fk_cascade.sql
```

73 lines (mostly comments + the idempotency DO blocks).

https://claude.ai/code/session_01FWDKHwn3cevR8MMLTV8Fn2

---
_Generated by [Claude Code](https://claude.ai/code/session_01FWDKHwn3cevR8MMLTV8Fn2)_