### PR TITLE
engine: C5 operator workflow — Slack + approve/reject + git commit

### DIFF
--- a/app/engine/approval.py
+++ b/app/engine/approval.py
@@ -1,0 +1,269 @@
+"""
+Component 5: Approval orchestration.
+
+Public entries:
+  approve_artifact(artifact_id, reviewer, notes) → ApprovalResult
+  reject_artifact(artifact_id, reviewer, notes)  → ApprovalResult
+
+The auto-render-on-finalize hook lives in event_pipeline.py
+(post_analysis_render_default_artifact); approve/reject is the
+operator-driven mirror that lives here.
+
+State machine for engine_artifacts.status (canonical literals from
+schemas.ArtifactStatus):
+
+    draft ──approve──► published
+       └──reject──► discarded
+
+Idempotency rules:
+  - approving an artifact already in 'published' is a no-op success
+    (returns the existing published_url).
+  - approving anything in 'discarded' is a 409.
+  - rejecting an artifact already in 'discarded' is a no-op success.
+  - rejecting anything in 'published' is a 409 (you can't unpublish via
+    this surface; that requires a fresh render + re-approve cycle).
+
+The ArtifactResponse model has no review_notes field and the
+engine_artifacts table has no review_notes column. Per the C5 prompt
+("no schema changes"), we stash the reviewer + free-text notes inside
+the existing warnings JSONB array as tagged strings, e.g.:
+
+    "[review:approved by alex@basis.foundation] looks good, ship it"
+    "[review:rejected by ops@basis.foundation] coverage too sparse"
+
+Renderers can filter these out by prefix when displaying warnings.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from dataclasses import dataclass
+from typing import Optional
+from uuid import UUID
+
+import psycopg2.extras
+
+from app.database import fetch_one, get_cursor
+from app.engine.artifact_persistence import get_artifact
+from app.engine.git_commit import CommitResult, commit_artifact
+from app.engine.schemas import ArtifactResponse, ArtifactStatus
+
+logger = logging.getLogger(__name__)
+
+# Idempotent. Mirrors precedent in artifact_persistence.py and
+# analysis_persistence.py — module import registers the UUID adapter.
+psycopg2.extras.register_uuid()
+
+
+# Tag prefixes — lets renderers strip review chatter from operator
+# warnings if they want a clean display.
+_APPROVE_TAG_PREFIX = "[review:approved"
+_REJECT_TAG_PREFIX = "[review:rejected"
+
+
+@dataclass
+class ApprovalResult:
+    artifact: ArtifactResponse
+    commit: Optional[CommitResult] = None
+    notification: Optional[dict] = None
+    detail: Optional[str] = None
+
+
+class ArtifactStateError(ValueError):
+    """Raised when the requested transition isn't legal for the
+    artifact's current status. Endpoints map to 409."""
+
+
+# ─────────────────────────────────────────────────────────────────
+# Status updates — local sync helpers (no edits to artifact_persistence)
+# ─────────────────────────────────────────────────────────────────
+
+def _update_artifact_sync(
+    artifact_id: UUID,
+    *,
+    new_status: ArtifactStatus,
+    published_url: Optional[str],
+    warnings: list[str],
+) -> None:
+    with get_cursor() as cur:
+        cur.execute(
+            """
+            UPDATE engine_artifacts
+            SET status = %s,
+                published_url = COALESCE(%s, published_url),
+                warnings = %s
+            WHERE id = %s
+            """,
+            (
+                new_status,
+                published_url,
+                psycopg2.extras.Json(list(warnings)),
+                str(artifact_id),
+            ),
+        )
+
+
+async def _persist_status(
+    artifact_id: UUID,
+    *,
+    new_status: ArtifactStatus,
+    published_url: Optional[str],
+    warnings: list[str],
+) -> None:
+    await asyncio.to_thread(
+        _update_artifact_sync,
+        artifact_id,
+        new_status=new_status,
+        published_url=published_url,
+        warnings=warnings,
+    )
+
+
+def _format_review_note(action: str, reviewer: Optional[str], notes: Optional[str]) -> str:
+    who = reviewer or "unknown"
+    text = (notes or "").strip()
+    body = f" {text}" if text else ""
+    return f"[review:{action} by {who}]{body}"
+
+
+# ─────────────────────────────────────────────────────────────────
+# Approve
+# ─────────────────────────────────────────────────────────────────
+
+async def approve_artifact(
+    artifact_id: UUID,
+    reviewer: Optional[str] = None,
+    notes: Optional[str] = None,
+) -> ApprovalResult:
+    """Commit the artifact to the repo and flip its status to 'published'.
+
+    Idempotent on already-published rows (returns the existing
+    published_url). Raises ArtifactStateError when the artifact is in a
+    state that can't be approved.
+    """
+    artifact = await get_artifact(artifact_id)
+    if artifact is None:
+        raise LookupError(f"No artifact with id {artifact_id}")
+
+    if artifact.status == "published":
+        logger.info(
+            "approve_artifact: artifact_id=%s already published — no-op",
+            artifact_id,
+        )
+        return ApprovalResult(
+            artifact=artifact,
+            detail="already published; no-op",
+        )
+
+    if artifact.status == "discarded":
+        raise ArtifactStateError(
+            f"artifact {artifact_id} is discarded; cannot approve"
+        )
+
+    if artifact.status != "draft":
+        raise ArtifactStateError(
+            f"artifact {artifact_id} has status {artifact.status!r}; "
+            "only 'draft' can be approved"
+        )
+
+    commit_result = await commit_artifact(artifact)
+    if commit_result.status == "failed":
+        logger.warning(
+            "approve_artifact: commit failed artifact_id=%s detail=%s",
+            artifact_id, commit_result.detail,
+        )
+        return ApprovalResult(
+            artifact=artifact,
+            commit=commit_result,
+            detail=f"commit failed: {commit_result.detail}",
+        )
+
+    new_warnings = list(artifact.warnings)
+    new_warnings.append(_format_review_note("approved", reviewer, notes))
+
+    published_url = commit_result.commit_url
+    await _persist_status(
+        artifact_id,
+        new_status="published",
+        published_url=published_url,
+        warnings=new_warnings,
+    )
+
+    refreshed = await get_artifact(artifact_id)
+    assert refreshed is not None  # we just updated it
+    logger.info(
+        "approve_artifact: artifact_id=%s -> published url=%s reviewer=%s",
+        artifact_id, published_url, reviewer,
+    )
+    return ApprovalResult(
+        artifact=refreshed,
+        commit=commit_result,
+        detail="approved + committed",
+    )
+
+
+# ─────────────────────────────────────────────────────────────────
+# Reject
+# ─────────────────────────────────────────────────────────────────
+
+async def reject_artifact(
+    artifact_id: UUID,
+    reviewer: Optional[str] = None,
+    notes: Optional[str] = None,
+) -> ApprovalResult:
+    """Mark the artifact 'discarded' and stash the reviewer + reason in
+    warnings. No git operations; rejected drafts never leave the DB.
+    """
+    artifact = await get_artifact(artifact_id)
+    if artifact is None:
+        raise LookupError(f"No artifact with id {artifact_id}")
+
+    if artifact.status == "discarded":
+        logger.info(
+            "reject_artifact: artifact_id=%s already discarded — no-op",
+            artifact_id,
+        )
+        return ApprovalResult(artifact=artifact, detail="already discarded; no-op")
+
+    if artifact.status == "published":
+        raise ArtifactStateError(
+            f"artifact {artifact_id} is already published; reject is "
+            "not a rollback path. Render a fresh artifact and approve "
+            "the replacement instead."
+        )
+
+    if artifact.status != "draft":
+        raise ArtifactStateError(
+            f"artifact {artifact_id} has status {artifact.status!r}; "
+            "only 'draft' can be rejected"
+        )
+
+    new_warnings = list(artifact.warnings)
+    new_warnings.append(_format_review_note("rejected", reviewer, notes))
+    await _persist_status(
+        artifact_id,
+        new_status="discarded",
+        published_url=None,  # no overwrite
+        warnings=new_warnings,
+    )
+
+    refreshed = await get_artifact(artifact_id)
+    assert refreshed is not None
+    logger.info(
+        "reject_artifact: artifact_id=%s -> discarded reviewer=%s",
+        artifact_id, reviewer,
+    )
+    return ApprovalResult(artifact=refreshed, detail="rejected + discarded")
+
+
+# ─────────────────────────────────────────────────────────────────
+# Read helper used by tests / inspection
+# ─────────────────────────────────────────────────────────────────
+
+def fetch_artifact_status_sync(artifact_id: UUID) -> Optional[str]:
+    row = fetch_one(
+        "SELECT status FROM engine_artifacts WHERE id = %s",
+        (str(artifact_id),),
+    )
+    return row["status"] if row else None

--- a/app/engine/approval_router.py
+++ b/app/engine/approval_router.py
@@ -1,0 +1,148 @@
+"""
+Component 5 router: /api/engine/artifacts/{id}/approve and /reject.
+
+Both endpoints are admin-only. The shape mirrors the inline
+_check_admin_key pattern used in analyze_router/render_router/budget_router
+(no shared dependency module).
+
+POST /api/engine/artifacts/{id}/approve
+    body: {"reviewer": str?, "notes": str?}
+    success 200: {"artifact": ArtifactResponse, "commit": {...},
+                  "detail": "approved + committed"}
+    409 if state != 'draft' (already discarded, etc.) — except
+        already-published which returns 200 as a no-op.
+    502 if git commit failed (artifact stays draft so operator can retry).
+
+POST /api/engine/artifacts/{id}/reject
+    body: {"reviewer": str?, "notes": str?}
+    success 200: {"artifact": ArtifactResponse, "detail": "..."}
+
+Both endpoints catch the local ArtifactStateError into 409s with a
+machine-readable error code so the operator UI can disambiguate
+"already done" from "wrong state".
+"""
+
+from __future__ import annotations
+
+import hmac
+import logging
+import os
+from typing import Any, Optional
+from uuid import UUID
+
+from fastapi import APIRouter, HTTPException, Request
+from pydantic import BaseModel, Field
+
+from app.engine.approval import (
+    ApprovalResult,
+    ArtifactStateError,
+    approve_artifact,
+    reject_artifact,
+)
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+
+def _check_admin_key(request: Request) -> None:
+    admin_key = os.environ.get("ADMIN_KEY", "")
+    provided = (
+        request.query_params.get("key", "")
+        or request.headers.get("x-admin-key", "")
+    )
+    if not admin_key or not provided or not hmac.compare_digest(provided, admin_key):
+        raise HTTPException(status_code=401, detail="Unauthorized")
+
+
+class ReviewRequest(BaseModel):
+    reviewer: Optional[str] = Field(
+        default=None,
+        description="Free-text identifier for the operator approving/rejecting "
+        "(email, github handle, etc.). Stored verbatim in artifact warnings.",
+    )
+    notes: Optional[str] = Field(
+        default=None,
+        description="Optional review notes; stored alongside reviewer in warnings.",
+    )
+
+
+def _result_to_response(result: ApprovalResult) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "artifact": result.artifact.model_dump(mode="json"),
+        "detail": result.detail,
+    }
+    if result.commit is not None:
+        payload["commit"] = {
+            "status": result.commit.status,
+            "commit_url": result.commit.commit_url,
+            "detail": result.commit.detail,
+            "test_mode": result.commit.test_mode,
+        }
+    if result.notification is not None:
+        payload["notification"] = result.notification
+    return payload
+
+
+@router.post("/api/engine/artifacts/{artifact_id}/approve")
+async def approve(
+    artifact_id: UUID,
+    request: Request,
+    payload: Optional[ReviewRequest] = None,
+) -> dict[str, Any]:
+    _check_admin_key(request)
+    payload = payload or ReviewRequest()
+
+    try:
+        result = await approve_artifact(
+            artifact_id,
+            reviewer=payload.reviewer,
+            notes=payload.notes,
+        )
+    except LookupError as exc:
+        raise HTTPException(status_code=404, detail=str(exc))
+    except ArtifactStateError as exc:
+        raise HTTPException(
+            status_code=409,
+            detail={"error": "invalid_state_for_approve", "message": str(exc)},
+        )
+
+    if result.commit is not None and result.commit.status == "failed":
+        # Keep the row in draft so the operator can retry once the
+        # underlying issue (PAT, network, repo policy) is resolved.
+        raise HTTPException(
+            status_code=502,
+            detail={
+                "error": "commit_failed",
+                "message": result.commit.detail or "git commit failed",
+                "artifact_id": str(artifact_id),
+            },
+        )
+
+    return _result_to_response(result)
+
+
+@router.post("/api/engine/artifacts/{artifact_id}/reject")
+async def reject(
+    artifact_id: UUID,
+    request: Request,
+    payload: Optional[ReviewRequest] = None,
+) -> dict[str, Any]:
+    _check_admin_key(request)
+    payload = payload or ReviewRequest()
+
+    try:
+        result = await reject_artifact(
+            artifact_id,
+            reviewer=payload.reviewer,
+            notes=payload.notes,
+        )
+    except LookupError as exc:
+        raise HTTPException(status_code=404, detail=str(exc))
+    except ArtifactStateError as exc:
+        raise HTTPException(
+            status_code=409,
+            detail={"error": "invalid_state_for_reject", "message": str(exc)},
+        )
+
+    return _result_to_response(result)

--- a/app/engine/background_tasks.py
+++ b/app/engine/background_tasks.py
@@ -66,6 +66,10 @@ from app.engine.interpretation import get_or_call_interpretation
 from app.engine.observation_builder import build_signal
 from app.engine.recommendation import derive_recommendation
 
+# Deferred import (inside finalize_analysis) to break the circular
+# import chain: background_tasks → event_pipeline → analysis_pipeline →
+# background_tasks. The import happens lazily on first finalize call.
+
 logger = logging.getLogger(__name__)
 
 
@@ -161,6 +165,15 @@ async def finalize_analysis(analysis_id: UUID) -> None:
             "finalize_analysis: UPDATE complete id=%s — analysis is now status=draft",
             analysis_id,
         )
+
+        # C5 auto-render hook: render recommended artifact + post Slack
+        # notification. Best-effort; never raises (catches internally).
+        # Deferred import keeps event_pipeline.py off the import-time
+        # graph (see _IN_FLIGHT_TASKS comment block above for the chain).
+        from app.engine.event_pipeline import (
+            post_analysis_render_default_artifact,
+        )
+        await post_analysis_render_default_artifact(analysis_id)
     except Exception as exc:
         logger.exception(
             "finalize_analysis: failed for id=%s: %s — flipping to "

--- a/app/engine/event_pipeline.py
+++ b/app/engine/event_pipeline.py
@@ -27,6 +27,14 @@ Idempotency: callers are encouraged to spawn process_event(event_id) via
 asyncio.create_task and forget it — running process_event twice on the
 same event_id is harmless (the second pass sees the analysis is already
 linked and short-circuits).
+
+C5 addition: post_analysis_render_default_artifact() lives here as the
+auto-render-on-finalize hook. After background_tasks.finalize_analysis
+flips a row from 'pending' to 'draft', it calls this function which
+loads the analysis, renders the recommended artifact (skipping
+'nothing', blocked, or duplicate cases), and posts a Slack
+notification. Failures are caught and logged — finalize_analysis must
+not be blocked by render or Slack issues.
 """
 
 from __future__ import annotations
@@ -37,7 +45,12 @@ from typing import Optional
 from uuid import UUID
 
 from app.database import fetch_one, get_cursor
+from app.engine.analysis_persistence import get_analysis
 from app.engine.analysis_pipeline import TriggerResult, trigger_analysis
+from app.engine.artifact_persistence import find_active_artifact
+from app.engine.render import KNOWN_ARTIFACT_TYPES, render_artifact
+from app.engine.schemas import ArtifactResponse
+from app.engine.slack import post_artifact_notification
 
 logger = logging.getLogger(__name__)
 
@@ -191,3 +204,87 @@ async def process_event(event_id: UUID) -> dict:
         "analysis_id": str(result.analysis_id) if result.analysis_id else None,
         "status": new_status,
     }
+
+
+# ─────────────────────────────────────────────────────────────────
+# Auto-render hook (C5)
+# ─────────────────────────────────────────────────────────────────
+
+async def post_analysis_render_default_artifact(
+    analysis_id: UUID,
+    review_url_base: Optional[str] = None,
+) -> Optional[ArtifactResponse]:
+    """After finalize_analysis flips an analysis to 'draft', auto-render
+    the recommended artifact and notify Slack.
+
+    Returns the rendered artifact on success, the existing active
+    artifact on duplicate, or None when the hook deliberately skips
+    (recommendation is 'nothing', blocked, unknown type, or analysis
+    missing). Never raises; finalize_analysis must not be blocked.
+    """
+    try:
+        analysis = await get_analysis(analysis_id)
+        if analysis is None:
+            logger.warning(
+                "post_analysis_render_default_artifact: analysis %s not found",
+                analysis_id,
+            )
+            return None
+
+        recommendation = analysis.artifact_recommendation
+        recommended = recommendation.recommended
+
+        if recommended == "nothing":
+            logger.info(
+                "post_analysis_render_default_artifact: analysis_id=%s "
+                "recommendation=nothing — skipping auto-render",
+                analysis_id,
+            )
+            return None
+
+        if recommended in recommendation.blocked:
+            logger.warning(
+                "post_analysis_render_default_artifact: analysis_id=%s "
+                "recommended=%s is also in blocked — skipping",
+                analysis_id, recommended,
+            )
+            return None
+
+        if recommended not in KNOWN_ARTIFACT_TYPES:
+            logger.warning(
+                "post_analysis_render_default_artifact: analysis_id=%s "
+                "recommended type %s not in renderer registry — skipping",
+                analysis_id, recommended,
+            )
+            return None
+
+        existing = await find_active_artifact(analysis_id, recommended)
+        if existing is not None:
+            logger.info(
+                "post_analysis_render_default_artifact: analysis_id=%s "
+                "type=%s already has active artifact %s — skipping",
+                analysis_id, recommended, existing.id,
+            )
+            return existing
+
+        artifact = await render_artifact(analysis, recommended)
+
+        review_url = (
+            f"{review_url_base.rstrip('/')}/api/engine/artifacts/{artifact.id}"
+            if review_url_base
+            else f"/api/engine/artifacts/{artifact.id}"
+        )
+        notification = post_artifact_notification(artifact, analysis, review_url)
+        logger.info(
+            "post_analysis_render_default_artifact: analysis_id=%s "
+            "artifact_id=%s notification=%s",
+            analysis_id, artifact.id, notification,
+        )
+        return artifact
+
+    except Exception as exc:
+        logger.exception(
+            "post_analysis_render_default_artifact: failed for analysis_id=%s: %s",
+            analysis_id, exc,
+        )
+        return None

--- a/app/engine/git_commit.py
+++ b/app/engine/git_commit.py
@@ -1,0 +1,309 @@
+"""
+Component 5: Git commit operations.
+
+When the operator approves an artifact, its rendered markdown lands in
+basis-protocol/basis-hub at the path the renderer suggested. This module
+owns the clone-write-commit-push dance via subprocess so we don't pull
+in GitPython for one workflow.
+
+Public entry: commit_artifact(artifact) → CommitResult
+  - On success: status='committed', commit_url='https://github.com/...'
+  - On TEST_MODE: status='committed', commit_url='.../test-mode/...'
+  - On failure: status='failed', detail explains the stage
+  - When BASIS_ENGINE_TEST_MODE=1, no shell-out happens at all.
+
+Concurrency: GitHub doesn't fail two near-simultaneous pushes on
+unrelated paths but our local clone certainly does (a stale ref between
+two workers walking through clone → write → push will produce a
+non-fast-forward push). We serialize commits with a module-level
+asyncio.Lock so concurrent approvals are safe within a single process.
+Cross-worker safety would need a DB lock — out of scope for v1; current
+deployment runs a single uvicorn worker.
+
+PAT redaction: when stderr from `git push` mentions the PAT (it shouldn't
+— modern git reads creds from a helper — but defense in depth), the
+output is scrubbed before logging or surfacing in the return value.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import shlex
+import shutil
+import subprocess
+import tempfile
+import uuid
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+from app.engine.schemas import ArtifactResponse
+
+logger = logging.getLogger(__name__)
+
+
+_TEST_MODE_ENV = "BASIS_ENGINE_TEST_MODE"
+_PAT_ENV = "BASIS_ENGINE_GITHUB_PAT"
+_REPO_OWNER = "basis-protocol"
+_REPO_NAME = "basis-hub"
+_DEFAULT_BRANCH = "main"
+_DEFAULT_AUTHOR_NAME = "Basis Engine"
+_DEFAULT_AUTHOR_EMAIL = "engine@basis.foundation"
+
+# One lock per process — see module docstring.
+_COMMIT_LOCK: asyncio.Lock = asyncio.Lock()
+
+
+@dataclass
+class CommitResult:
+    status: str  # "committed" | "failed" | "skipped"
+    commit_url: Optional[str] = None
+    detail: Optional[str] = None
+    test_mode: bool = False
+
+
+def _redact(text: str, secret: Optional[str]) -> str:
+    """Scrub `secret` from `text`. No-op if secret is empty."""
+    if not text:
+        return text
+    if not secret:
+        return text
+    return text.replace(secret, "***REDACTED***")
+
+
+def _is_test_mode() -> bool:
+    return os.environ.get(_TEST_MODE_ENV, "").strip().lower() in ("1", "true", "yes")
+
+
+def _validate_relative_path(suggested_path: str, workspace: Path) -> Path:
+    """Resolve `suggested_path` inside `workspace` and ensure it doesn't
+    escape via .. or absolute-path tricks. Raises ValueError on rejection.
+    """
+    if not suggested_path:
+        raise ValueError("artifact has no suggested_path; cannot commit")
+
+    candidate = (workspace / suggested_path).resolve()
+    workspace_resolved = workspace.resolve()
+    try:
+        candidate.relative_to(workspace_resolved)
+    except ValueError as exc:
+        raise ValueError(
+            f"suggested_path {suggested_path!r} resolves outside workspace"
+        ) from exc
+    return candidate
+
+
+def _run(
+    cmd: list[str],
+    cwd: Path,
+    secret: Optional[str],
+    extra_env: Optional[dict] = None,
+) -> subprocess.CompletedProcess:
+    """Run a subprocess, capture both streams, redact PAT from any output
+    we surface. Raises subprocess.CalledProcessError on non-zero exit so
+    the caller can wrap into a CommitResult."""
+    env = os.environ.copy()
+    if extra_env:
+        env.update(extra_env)
+    logger.info(
+        "git_commit._run: cwd=%s cmd=%s",
+        cwd, " ".join(shlex.quote(c) for c in cmd),
+    )
+    proc = subprocess.run(
+        cmd,
+        cwd=str(cwd),
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+    if proc.returncode != 0:
+        stderr = _redact(proc.stderr or "", secret)
+        stdout = _redact(proc.stdout or "", secret)
+        logger.warning(
+            "git_commit._run failed rc=%d cmd=%s stderr=%s stdout=%s",
+            proc.returncode, cmd[0], stderr, stdout,
+        )
+        # Re-raise with redacted streams so the surrounding except can
+        # safely include the message in CommitResult.detail.
+        err = subprocess.CalledProcessError(proc.returncode, cmd, stdout, stderr)
+        raise err
+    return proc
+
+
+def _commit_artifact_sync(artifact: ArtifactResponse) -> CommitResult:
+    """The full clone-write-commit-push dance, blocking. Caller wraps
+    this in asyncio.to_thread so the event loop stays free.
+    """
+    if _is_test_mode():
+        fake_url = (
+            f"https://github.com/{_REPO_OWNER}/{_REPO_NAME}/commit/"
+            f"test-mode-{uuid.uuid4().hex[:12]}"
+        )
+        logger.info(
+            "git_commit: TEST_MODE artifact_id=%s suggested_path=%s — "
+            "skipping git operations, returning fake url %s",
+            artifact.id, artifact.suggested_path, fake_url,
+        )
+        return CommitResult(
+            status="committed",
+            commit_url=fake_url,
+            detail="test_mode bypass",
+            test_mode=True,
+        )
+
+    pat = os.environ.get(_PAT_ENV, "").strip()
+    if not pat:
+        return CommitResult(
+            status="failed",
+            detail=f"{_PAT_ENV} unset; cannot push",
+        )
+
+    if not artifact.suggested_path:
+        return CommitResult(
+            status="failed",
+            detail="artifact.suggested_path is empty; nothing to commit",
+        )
+
+    remote_url = (
+        f"https://x-access-token:{pat}@github.com/"
+        f"{_REPO_OWNER}/{_REPO_NAME}.git"
+    )
+
+    workdir = Path(tempfile.mkdtemp(prefix="basis-engine-commit-"))
+    try:
+        clone_dir = workdir / "repo"
+        try:
+            _run(
+                ["git", "clone", "--depth", "1", "--branch", _DEFAULT_BRANCH,
+                 remote_url, str(clone_dir)],
+                cwd=workdir,
+                secret=pat,
+            )
+        except subprocess.CalledProcessError as exc:
+            return CommitResult(
+                status="failed",
+                detail=f"git clone failed: {_redact(exc.stderr or '', pat)[:300]}",
+            )
+
+        try:
+            target = _validate_relative_path(artifact.suggested_path, clone_dir)
+        except ValueError as exc:
+            return CommitResult(status="failed", detail=str(exc))
+
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(artifact.content_markdown, encoding="utf-8")
+
+        # Configure committer identity per-clone (no global git config writes).
+        for cfg in (
+            ["git", "config", "user.name", _DEFAULT_AUTHOR_NAME],
+            ["git", "config", "user.email", _DEFAULT_AUTHOR_EMAIL],
+        ):
+            try:
+                _run(cfg, cwd=clone_dir, secret=pat)
+            except subprocess.CalledProcessError as exc:
+                return CommitResult(
+                    status="failed",
+                    detail=f"git config failed: {_redact(exc.stderr or '', pat)[:200]}",
+                )
+
+        try:
+            _run(
+                ["git", "add", artifact.suggested_path],
+                cwd=clone_dir,
+                secret=pat,
+            )
+        except subprocess.CalledProcessError as exc:
+            return CommitResult(
+                status="failed",
+                detail=f"git add failed: {_redact(exc.stderr or '', pat)[:200]}",
+            )
+
+        # If nothing actually changed (re-approval after manual revert?),
+        # skip rather than committing an empty diff.
+        try:
+            diff_check = subprocess.run(
+                ["git", "diff", "--cached", "--quiet"],
+                cwd=str(clone_dir),
+                capture_output=True,
+                text=True,
+            )
+        except OSError as exc:
+            return CommitResult(
+                status="failed", detail=f"git diff probe failed: {exc}",
+            )
+        if diff_check.returncode == 0:
+            logger.info(
+                "git_commit: artifact_id=%s produced no diff; skipping commit",
+                artifact.id,
+            )
+            return CommitResult(
+                status="skipped",
+                detail="no diff vs origin/main",
+            )
+
+        commit_subject = (
+            f"engine: publish {artifact.artifact_type} for analysis "
+            f"{artifact.analysis_id}"
+        )
+        try:
+            _run(
+                ["git", "commit", "-m", commit_subject],
+                cwd=clone_dir,
+                secret=pat,
+            )
+        except subprocess.CalledProcessError as exc:
+            return CommitResult(
+                status="failed",
+                detail=f"git commit failed: {_redact(exc.stderr or '', pat)[:200]}",
+            )
+
+        try:
+            _run(
+                ["git", "push", "origin", _DEFAULT_BRANCH],
+                cwd=clone_dir,
+                secret=pat,
+            )
+        except subprocess.CalledProcessError as exc:
+            return CommitResult(
+                status="failed",
+                detail=f"git push failed: {_redact(exc.stderr or '', pat)[:200]}",
+            )
+
+        try:
+            sha_proc = _run(
+                ["git", "rev-parse", "HEAD"],
+                cwd=clone_dir,
+                secret=pat,
+            )
+            sha = (sha_proc.stdout or "").strip()
+        except subprocess.CalledProcessError:
+            sha = ""
+
+        commit_url = (
+            f"https://github.com/{_REPO_OWNER}/{_REPO_NAME}/commit/{sha}"
+            if sha
+            else f"https://github.com/{_REPO_OWNER}/{_REPO_NAME}/commits/{_DEFAULT_BRANCH}"
+        )
+        logger.info(
+            "git_commit: pushed artifact_id=%s sha=%s path=%s",
+            artifact.id, sha, artifact.suggested_path,
+        )
+        return CommitResult(
+            status="committed",
+            commit_url=commit_url,
+            detail=f"pushed sha={sha[:12]}" if sha else "pushed",
+        )
+    finally:
+        shutil.rmtree(workdir, ignore_errors=True)
+
+
+async def commit_artifact(artifact: ArtifactResponse) -> CommitResult:
+    """Acquire the process-wide commit lock and run the sync flow.
+
+    Lock is held across the whole clone-write-push so two parallel
+    approvals don't race a non-fast-forward push.
+    """
+    async with _COMMIT_LOCK:
+        return await asyncio.to_thread(_commit_artifact_sync, artifact)

--- a/app/engine/router.py
+++ b/app/engine/router.py
@@ -17,6 +17,8 @@ Current state:
                                  artifact GET endpoints)
   - events_router    registered (Component 4 / S4 — manual events,
                                  watchlist CRUD, scheduler diagnostic)
+  - approval_router  registered (Component 5 / S5 — POST approve/reject
+                                 endpoints for the operator workflow)
 """
 
 from __future__ import annotations
@@ -24,6 +26,7 @@ from __future__ import annotations
 from fastapi import APIRouter
 
 from app.engine.analyze_router import router as analyze_router
+from app.engine.approval_router import router as approval_router
 from app.engine.budget_router import router as budget_router
 from app.engine.coverage_router import router as coverage_router
 from app.engine.events_router import router as events_router
@@ -35,3 +38,4 @@ router.include_router(analyze_router)
 router.include_router(budget_router)
 router.include_router(render_router)
 router.include_router(events_router)
+router.include_router(approval_router)

--- a/app/engine/slack.py
+++ b/app/engine/slack.py
@@ -1,0 +1,182 @@
+"""
+Component 5: Slack delivery.
+
+Posts notifications about engine artifacts to a Slack incoming webhook so
+the operator sees freshly rendered drafts without polling the DB. When
+SLACK_ENGINE_WEBHOOK_URL is unset (local dev, CI, sandbox) the same
+payload is dumped to stdout via logger.info — no HTTP call, no failure
+mode that blocks the pipeline.
+
+Single public entry: post_artifact_notification(artifact, analysis,
+review_url) returns a dict describing what happened (delivery channel +
+status code or "stdout"). Never raises; transport failures are caught,
+logged, and reported via the return dict so the caller can decide
+whether to record them on the artifact (we tag them onto warnings).
+
+The webhook payload uses Slack Block Kit so the operator gets a
+clickable Approve URL inline, not a wall of plain text. Composition
+mirrors the operator-workflow examples in Step 0 doc §6.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from typing import Optional
+
+import httpx
+
+from app.engine.schemas import Analysis, ArtifactResponse
+
+logger = logging.getLogger(__name__)
+
+
+_WEBHOOK_ENV = "SLACK_ENGINE_WEBHOOK_URL"
+
+# Slack's documented timeout for incoming webhook POSTs is 10s; we
+# tighten to 5s because the operator pipeline already waits on the
+# render call and we'd rather degrade to stdout than stall the request.
+_SLACK_TIMEOUT_SECONDS = 5.0
+
+
+def _build_slack_blocks(
+    artifact: ArtifactResponse,
+    analysis: Analysis,
+    review_url: Optional[str],
+) -> dict:
+    headline = analysis.interpretation.headline if analysis.interpretation else ""
+    confidence = (
+        analysis.interpretation.confidence if analysis.interpretation else "insufficient"
+    )
+    event_label = (
+        analysis.event_date.isoformat() if analysis.event_date else "baseline"
+    )
+
+    title = (
+        f"Engine draft ready — {analysis.entity} ({event_label}) "
+        f"→ {artifact.artifact_type}"
+    )
+
+    fields = [
+        {"type": "mrkdwn", "text": f"*Entity:*\n{analysis.entity}"},
+        {"type": "mrkdwn", "text": f"*Event date:*\n{event_label}"},
+        {"type": "mrkdwn", "text": f"*Artifact type:*\n{artifact.artifact_type}"},
+        {"type": "mrkdwn", "text": f"*Confidence:*\n{confidence}"},
+    ]
+
+    blocks: list[dict] = [
+        {"type": "header", "text": {"type": "plain_text", "text": title}},
+        {"type": "section", "fields": fields},
+    ]
+
+    if headline:
+        blocks.append(
+            {"type": "section", "text": {"type": "mrkdwn", "text": f"_{headline}_"}}
+        )
+
+    if artifact.warnings:
+        warnings_text = "\n".join(f"• {w}" for w in artifact.warnings)
+        blocks.append(
+            {
+                "type": "section",
+                "text": {"type": "mrkdwn", "text": f"*Warnings:*\n{warnings_text}"},
+            }
+        )
+
+    if review_url:
+        blocks.append(
+            {
+                "type": "section",
+                "text": {
+                    "type": "mrkdwn",
+                    "text": (
+                        f"*Review:* <{review_url}|Open artifact>\n"
+                        f"`POST {review_url}/approve` to publish · "
+                        f"`POST {review_url}/reject` to discard"
+                    ),
+                },
+            }
+        )
+
+    blocks.append(
+        {
+            "type": "context",
+            "elements": [
+                {
+                    "type": "mrkdwn",
+                    "text": (
+                        f"artifact_id `{artifact.id}` · "
+                        f"analysis_id `{artifact.analysis_id}`"
+                    ),
+                }
+            ],
+        }
+    )
+
+    return {"text": title, "blocks": blocks}
+
+
+def post_artifact_notification(
+    artifact: ArtifactResponse,
+    analysis: Analysis,
+    review_url: Optional[str] = None,
+) -> dict:
+    """Post a notification for a freshly rendered artifact.
+
+    Returns a result dict:
+      {"channel": "webhook" | "stdout", "ok": bool, "detail": str}
+
+    Never raises. HTTP failures are logged and returned with ok=False
+    so callers can persist the failure into artifact.warnings.
+    """
+    payload = _build_slack_blocks(artifact, analysis, review_url)
+    webhook_url = os.environ.get(_WEBHOOK_ENV, "").strip()
+
+    if not webhook_url:
+        logger.info(
+            "slack.post_artifact_notification: %s unset — stdout fallback. "
+            "payload=%s",
+            _WEBHOOK_ENV,
+            json.dumps(payload),
+        )
+        return {
+            "channel": "stdout",
+            "ok": True,
+            "detail": f"{_WEBHOOK_ENV} unset; logged to stdout",
+        }
+
+    try:
+        with httpx.Client(timeout=_SLACK_TIMEOUT_SECONDS) as client:
+            resp = client.post(webhook_url, json=payload)
+    except httpx.HTTPError as exc:
+        logger.warning(
+            "slack.post_artifact_notification: transport error artifact_id=%s: %s",
+            artifact.id, exc,
+        )
+        return {
+            "channel": "webhook",
+            "ok": False,
+            "detail": f"transport error: {type(exc).__name__}",
+        }
+
+    if resp.status_code >= 400:
+        logger.warning(
+            "slack.post_artifact_notification: webhook %d artifact_id=%s body=%s",
+            resp.status_code, artifact.id, resp.text[:200],
+        )
+        return {
+            "channel": "webhook",
+            "ok": False,
+            "detail": f"webhook returned {resp.status_code}",
+        }
+
+    logger.info(
+        "slack.post_artifact_notification: posted artifact_id=%s status=%d",
+        artifact.id, resp.status_code,
+    )
+    return {
+        "channel": "webhook",
+        "ok": True,
+        "detail": f"webhook returned {resp.status_code}",
+    }

--- a/tests/test_engine_workflow.py
+++ b/tests/test_engine_workflow.py
@@ -1,0 +1,661 @@
+"""
+Component 5: Operator workflow tests — Slack delivery, git commit
+TEST_MODE bypass, and the approve/reject endpoints.
+
+8 unit tests against pure helpers (Slack payload composition, stdout
+fallback, git_commit TEST_MODE bypass, PAT redaction, path traversal
+defense, approval state machine guards) — fast, no HTTP, no DB writes.
+
+4 integration tests against POST /api/engine/artifacts/{id}/approve
+and /reject. Use BASIS_ENGINE_TEST_MODE=1 so no real PAT is needed and
+no real push happens; the endpoint returns the fake commit URL and the
+DB row flips to 'published'.
+
+Run:
+    ADMIN_KEY=<key> BASE_URL=https://basisprotocol.xyz \\
+      DATABASE_URL=<prod-url> BASIS_ENGINE_TEST_MODE=1 \\
+      pytest tests/test_engine_workflow.py -v
+
+Cleanup mirrors test_engine_renderers.py: artifacts → analyses ordering
+because of the FK on engine_artifacts.analysis_id.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import time
+import uuid
+from datetime import date, datetime, timezone
+from pathlib import Path
+from typing import Any, Iterator, Optional
+from unittest.mock import MagicMock, patch
+from uuid import UUID, uuid4
+
+import pytest
+
+from app.engine.approval import (
+    ArtifactStateError,
+    _format_review_note,
+    approve_artifact,
+    reject_artifact,
+)
+from app.engine.git_commit import (
+    CommitResult,
+    _is_test_mode,
+    _redact,
+    _validate_relative_path,
+    commit_artifact,
+)
+from app.engine.schemas import (
+    ArtifactRecommendation,
+    ArtifactResponse,
+    CoverageResponse,
+    EntityCoverage,
+    Interpretation,
+)
+from app.engine.slack import (
+    _WEBHOOK_ENV,
+    _build_slack_blocks,
+    post_artifact_notification,
+)
+
+
+# ═════════════════════════════════════════════════════════════════
+# Test fixture (entity, event_date) keys
+# ═════════════════════════════════════════════════════════════════
+
+TEST_FIXTURE_KEYS: list[tuple[str, date]] = [
+    ("drift", date(2026, 6, 1)),  # test_approve_endpoint_flips_to_published
+    ("drift", date(2026, 6, 2)),  # test_reject_endpoint_flips_to_discarded
+    ("drift", date(2026, 6, 3)),  # test_approve_endpoint_idempotent_on_published
+    ("drift", date(2026, 6, 4)),  # test_reject_endpoint_409_on_published
+]
+
+
+# ═════════════════════════════════════════════════════════════════
+# DB cleanup — artifacts before analyses
+# ═════════════════════════════════════════════════════════════════
+
+def _db_delete_for_test_keys() -> int:
+    conn_string = os.environ.get("DATABASE_URL")
+    if not conn_string:
+        return -1
+    try:
+        import psycopg2
+        with psycopg2.connect(conn_string) as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    """
+                    SELECT id FROM engine_analyses
+                    WHERE (entity, event_date) IN %s
+                    """,
+                    (tuple(TEST_FIXTURE_KEYS),),
+                )
+                ids = [r[0] for r in cur.fetchall()]
+                if not ids:
+                    return 0
+                cur.execute(
+                    "DELETE FROM engine_artifacts WHERE analysis_id = ANY(%s::uuid[])",
+                    ([str(i) for i in ids],),
+                )
+                arts_deleted = cur.rowcount
+                cur.execute(
+                    "DELETE FROM engine_analyses WHERE id = ANY(%s::uuid[])",
+                    ([str(i) for i in ids],),
+                )
+                analyses_deleted = cur.rowcount
+            conn.commit()
+        return arts_deleted + analyses_deleted
+    except Exception as exc:
+        print(f"cleanup: workflow sweep failed: {exc}", file=sys.stderr)
+        return -1
+
+
+def _db_delete_for_analysis_ids(ids: list[str]) -> bool:
+    if not ids:
+        return True
+    conn_string = os.environ.get("DATABASE_URL")
+    if not conn_string:
+        return False
+    try:
+        import psycopg2
+        with psycopg2.connect(conn_string) as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    "DELETE FROM engine_artifacts WHERE analysis_id = ANY(%s::uuid[])",
+                    ([str(i) for i in ids],),
+                )
+                cur.execute(
+                    "DELETE FROM engine_analyses WHERE id = ANY(%s::uuid[])",
+                    ([str(i) for i in ids],),
+                )
+            conn.commit()
+        return True
+    except Exception as exc:
+        print(f"cleanup: per-test delete failed: {exc}", file=sys.stderr)
+        return False
+
+
+# ═════════════════════════════════════════════════════════════════
+# Fixtures (admin auth + cleanup)
+# ═════════════════════════════════════════════════════════════════
+
+def _resolve_admin_key() -> Optional[str]:
+    return os.environ.get("ADMIN_KEY") or os.environ.get("BASIS_ADMIN_KEY")
+
+
+@pytest.fixture(scope="session")
+def admin_key() -> str:
+    key = _resolve_admin_key()
+    if not key:
+        pytest.skip(
+            "ADMIN_KEY not set — skipping admin-authenticated integration tests."
+        )
+    return key
+
+
+class _AdminAPI:
+    def __init__(self, session, base_url: str, admin_key: str):
+        self._session = session
+        self._base = base_url
+        self._headers = {"x-admin-key": admin_key}
+
+    def post(self, path: str, body: dict[str, Any] | None = None):
+        return self._session.post(
+            f"{self._base}{path}",
+            json=body or {},
+            headers=self._headers,
+            timeout=90,
+        )
+
+    def get(self, path: str):
+        return self._session.get(
+            f"{self._base}{path}", headers=self._headers, timeout=30,
+        )
+
+
+@pytest.fixture(scope="session")
+def admin_api(base_url, session, admin_key) -> _AdminAPI:
+    return _AdminAPI(session, base_url, admin_key)
+
+
+@pytest.fixture(scope="session", autouse=True)
+def session_workflow_cleanup():
+    deleted = _db_delete_for_test_keys()
+    if deleted > 0:
+        print(
+            f"\n[workflow-tests] session-start sweep: deleted {deleted} "
+            "stale row(s) (artifacts + analyses)",
+            file=sys.stderr,
+        )
+    yield
+    _db_delete_for_test_keys()
+
+
+_created_ids: list[str] = []
+
+
+@pytest.fixture(autouse=True)
+def cleanup_created_analyses() -> Iterator[None]:
+    _created_ids.clear()
+    yield
+    if _created_ids:
+        _db_delete_for_analysis_ids(list(_created_ids))
+        _created_ids.clear()
+
+
+def _track(analysis_id: str) -> str:
+    _created_ids.append(analysis_id)
+    return analysis_id
+
+
+def _wait_for_draft(admin_api, analysis_id: str, timeout: float = 60.0) -> dict:
+    deadline = time.time() + timeout
+    body: dict = {}
+    while time.time() < deadline:
+        resp = admin_api.get(f"/api/engine/analyses/{analysis_id}")
+        if resp.status_code == 200:
+            body = resp.json()
+            if body.get("status") != "pending":
+                return body
+        time.sleep(0.7)
+    return body
+
+
+def _render_default_artifact(admin_api, analysis_id: str) -> dict:
+    """Return an active draft artifact for the analysis. C5's auto-render
+    hook fires inside finalize_analysis, so by the time the analysis
+    flips to 'draft' there may already be an artifact rendered. Check
+    GET /artifacts first; if none exists, render the recommended type
+    explicitly (falling back to internal_memo when the recommendation
+    is 'nothing' or blocked)."""
+    list_resp = admin_api.get(f"/api/engine/analyses/{analysis_id}/artifacts")
+    if list_resp.status_code == 200:
+        existing = [
+            a for a in list_resp.json()
+            if a.get("status") == "draft"
+        ]
+        if existing:
+            # Return the freshest (DB orders DESC by rendered_at).
+            return existing[0]
+
+    full = admin_api.get(f"/api/engine/analyses/{analysis_id}").json()
+    recommended = full["artifact_recommendation"]["recommended"]
+    candidate = recommended if recommended != "nothing" else "internal_memo"
+    resp = admin_api.post(
+        "/api/engine/render",
+        {"analysis_id": analysis_id, "artifact_type": candidate},
+    )
+    if resp.status_code == 422 and candidate != "internal_memo":
+        resp = admin_api.post(
+            "/api/engine/render",
+            {"analysis_id": analysis_id, "artifact_type": "internal_memo"},
+        )
+    assert resp.status_code == 202, resp.text[:400]
+    return resp.json()
+
+
+# ═════════════════════════════════════════════════════════════════
+# Helper builders
+# ═════════════════════════════════════════════════════════════════
+
+def _make_artifact(
+    *,
+    artifact_id: Optional[UUID] = None,
+    analysis_id: Optional[UUID] = None,
+    suggested_path: Optional[str] = "content/test.md",
+    status: str = "draft",
+    warnings: Optional[list[str]] = None,
+) -> ArtifactResponse:
+    return ArtifactResponse(
+        id=artifact_id or uuid4(),
+        analysis_id=analysis_id or uuid4(),
+        artifact_type="internal_memo",
+        rendered_at=datetime(2026, 4, 27, 12, 0, 0, tzinfo=timezone.utc),
+        content_markdown="# Test\n\nBody.",
+        suggested_path=suggested_path,
+        suggested_url=None,
+        status=status,  # type: ignore[arg-type]
+        published_url=None,
+        warnings=warnings or [],
+    )
+
+
+def _make_minimal_analysis_for_slack() -> Any:
+    """Smallest possible Analysis-like object to test Slack block building.
+    Slack only reads .entity, .event_date, .interpretation. Use a MagicMock
+    so we don't have to construct a full Analysis (peer_set, signal, etc)."""
+    interp = Interpretation(
+        event_summary="Summary.",
+        what_this_does_not_claim="Nothing.",
+        headline="Drift PSI dropped 12pts vs Jupiter.",
+        confidence="medium",
+        confidence_reasoning="Partial coverage.",
+        prompt_version="v1",
+        input_hash="sha256:test",
+        model_id="claude-sonnet-4-6",
+        generated_at=datetime(2026, 4, 27, 12, 0, 0, tzinfo=timezone.utc),
+        from_cache=False,
+    )
+    mock = MagicMock()
+    mock.entity = "drift"
+    mock.event_date = date(2026, 4, 27)
+    mock.interpretation = interp
+    return mock
+
+
+# ═════════════════════════════════════════════════════════════════
+# 1. Unit: slack stdout fallback when env unset
+# ═════════════════════════════════════════════════════════════════
+
+def test_slack_stdout_fallback_when_webhook_unset(monkeypatch):
+    """No SLACK_ENGINE_WEBHOOK_URL env → no HTTP call, returns
+    channel='stdout' with ok=True."""
+    monkeypatch.delenv(_WEBHOOK_ENV, raising=False)
+    artifact = _make_artifact()
+    analysis = _make_minimal_analysis_for_slack()
+
+    with patch("app.engine.slack.httpx.Client") as client_cls:
+        result = post_artifact_notification(
+            artifact, analysis, review_url="https://example/api/engine/artifacts/x"
+        )
+
+    assert client_cls.call_count == 0, (
+        "stdout fallback must not invoke httpx"
+    )
+    assert result["channel"] == "stdout"
+    assert result["ok"] is True
+
+
+# ═════════════════════════════════════════════════════════════════
+# 2. Unit: slack block kit composition includes title + entity + url
+# ═════════════════════════════════════════════════════════════════
+
+def test_slack_blocks_include_required_fields():
+    artifact = _make_artifact(warnings=["sparse coverage"])
+    analysis = _make_minimal_analysis_for_slack()
+    payload = _build_slack_blocks(
+        artifact, analysis, review_url="https://example/api/engine/artifacts/x"
+    )
+
+    # Top-level
+    assert "text" in payload
+    assert "blocks" in payload
+    assert "drift" in payload["text"]
+    assert "internal_memo" in payload["text"]
+
+    # Stringify all block content for substring assertions
+    blob = str(payload["blocks"])
+    assert "drift" in blob
+    assert "2026-04-27" in blob
+    assert "internal_memo" in blob
+    assert "https://example/api/engine/artifacts/x" in blob
+    assert "approve" in blob
+    assert "reject" in blob
+    # Warnings included
+    assert "sparse coverage" in blob
+
+
+# ═════════════════════════════════════════════════════════════════
+# 3. Unit: slack webhook transport error returns ok=False
+# ═════════════════════════════════════════════════════════════════
+
+def test_slack_webhook_transport_error_returns_ok_false(monkeypatch):
+    """A transport error (timeout, connection refused) is caught; the
+    function returns ok=False with a descriptive detail rather than
+    raising."""
+    monkeypatch.setenv(_WEBHOOK_ENV, "https://hooks.slack.com/services/FAKE")
+    import httpx
+
+    class _FakeClient:
+        def __init__(self, *_args, **_kwargs):
+            pass
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_a):
+            return False
+
+        def post(self, *_a, **_kw):
+            raise httpx.ConnectError("simulated DNS failure")
+
+    artifact = _make_artifact()
+    analysis = _make_minimal_analysis_for_slack()
+    with patch("app.engine.slack.httpx.Client", _FakeClient):
+        result = post_artifact_notification(artifact, analysis, review_url="x")
+
+    assert result["channel"] == "webhook"
+    assert result["ok"] is False
+    assert "transport error" in result["detail"]
+
+
+# ═════════════════════════════════════════════════════════════════
+# 4. Unit: git_commit TEST_MODE bypass returns fake URL, no shell-out
+# ═════════════════════════════════════════════════════════════════
+
+def test_git_commit_test_mode_bypass(monkeypatch):
+    monkeypatch.setenv("BASIS_ENGINE_TEST_MODE", "1")
+    artifact = _make_artifact(suggested_path="content/case-study/test.md")
+
+    with patch("app.engine.git_commit.subprocess.run") as run_mock:
+        import asyncio
+        result = asyncio.run(commit_artifact(artifact))
+
+    assert run_mock.call_count == 0, (
+        "TEST_MODE must skip every subprocess.run call"
+    )
+    assert result.status == "committed"
+    assert result.test_mode is True
+    assert result.commit_url is not None
+    assert "test-mode" in result.commit_url
+
+
+# ═════════════════════════════════════════════════════════════════
+# 5. Unit: PAT redaction scrubs secret from output
+# ═════════════════════════════════════════════════════════════════
+
+def test_git_commit_pat_redaction():
+    pat = "ghp_supersecretvalue1234567890"
+    text = (
+        f"fatal: could not push to https://x-access-token:{pat}@github.com/"
+        f"repo: bad creds"
+    )
+    redacted = _redact(text, pat)
+    assert pat not in redacted
+    assert "***REDACTED***" in redacted
+
+    # Defensive: empty/None secret leaves the text unchanged
+    assert _redact("hello", "") == "hello"
+    assert _redact("hello", None) == "hello"
+    # Defensive: empty text passes through
+    assert _redact("", pat) == ""
+
+
+# ═════════════════════════════════════════════════════════════════
+# 6. Unit: path traversal rejected by _validate_relative_path
+# ═════════════════════════════════════════════════════════════════
+
+def test_git_commit_rejects_path_traversal(tmp_path):
+    workspace = tmp_path / "repo"
+    workspace.mkdir()
+
+    # Sane path inside workspace
+    target = _validate_relative_path("content/foo.md", workspace)
+    assert target.is_relative_to(workspace.resolve())
+
+    # Escape via ..
+    with pytest.raises(ValueError):
+        _validate_relative_path("../etc/passwd", workspace)
+
+    # Absolute path
+    with pytest.raises(ValueError):
+        _validate_relative_path("/etc/shadow", workspace)
+
+    # Empty
+    with pytest.raises(ValueError):
+        _validate_relative_path("", workspace)
+
+
+# ═════════════════════════════════════════════════════════════════
+# 7. Unit: approve refuses non-draft state with ArtifactStateError
+# ═════════════════════════════════════════════════════════════════
+
+def test_approve_refuses_non_draft_state(monkeypatch):
+    """When the artifact in the DB is in 'discarded', approve_artifact
+    raises ArtifactStateError. 'published' is special-cased as a no-op
+    and is verified separately by an integration test."""
+    discarded_artifact = _make_artifact(status="discarded")
+
+    async def fake_get(_id):
+        return discarded_artifact
+
+    monkeypatch.setattr("app.engine.approval.get_artifact", fake_get)
+
+    import asyncio
+    with pytest.raises(ArtifactStateError):
+        asyncio.run(approve_artifact(discarded_artifact.id, reviewer="test"))
+
+
+# ═════════════════════════════════════════════════════════════════
+# 8. Unit: reject refuses 'published' state — no rollback path
+# ═════════════════════════════════════════════════════════════════
+
+def test_reject_refuses_published_state(monkeypatch):
+    published = _make_artifact(status="published")
+
+    async def fake_get(_id):
+        return published
+
+    monkeypatch.setattr("app.engine.approval.get_artifact", fake_get)
+
+    import asyncio
+    with pytest.raises(ArtifactStateError):
+        asyncio.run(reject_artifact(published.id, reviewer="test"))
+
+    # Sanity: review-note formatter shape is what the DB will receive
+    note = _format_review_note("approved", "alex@basis.foundation", "ship it")
+    assert note.startswith("[review:approved by alex@basis.foundation]")
+    assert "ship it" in note
+
+
+# ═════════════════════════════════════════════════════════════════
+# 9. Integration: POST /approve flips status to 'published'
+# ═════════════════════════════════════════════════════════════════
+
+def test_approve_endpoint_flips_to_published(admin_api):
+    """End-to-end: create analysis → wait for draft → render artifact →
+    approve. With BASIS_ENGINE_TEST_MODE=1 set the commit returns a fake
+    URL and the artifact status becomes 'published'."""
+    if os.environ.get("BASIS_ENGINE_TEST_MODE", "").lower() not in ("1", "true", "yes"):
+        pytest.skip(
+            "BASIS_ENGINE_TEST_MODE must be set to '1' for approval "
+            "integration tests so no real PAT/push is required."
+        )
+
+    body = {
+        "entity": "drift",
+        "event_date": "2026-06-01",
+        "peer_set": ["jupiter-perpetual-exchange"],
+    }
+    resp = admin_api.post("/api/engine/analyze", body)
+    assert resp.status_code == 202, resp.text[:400]
+    aid = _track(resp.json()["analysis_id"])
+
+    full = _wait_for_draft(admin_api, aid)
+    assert full.get("status") == "draft"
+
+    artifact = _render_default_artifact(admin_api, aid)
+    artifact_id = artifact["id"]
+    assert artifact["status"] == "draft"
+
+    approve_resp = admin_api.post(
+        f"/api/engine/artifacts/{artifact_id}/approve",
+        {"reviewer": "test@basis.foundation", "notes": "C5 integration test"},
+    )
+    assert approve_resp.status_code == 200, approve_resp.text[:400]
+    body_resp = approve_resp.json()
+    assert body_resp["artifact"]["status"] == "published"
+    assert body_resp["commit"]["test_mode"] is True
+    assert "test-mode" in body_resp["commit"]["commit_url"]
+    assert body_resp["artifact"]["published_url"] == body_resp["commit"]["commit_url"]
+
+
+# ═════════════════════════════════════════════════════════════════
+# 10. Integration: POST /reject flips status to 'discarded'
+# ═════════════════════════════════════════════════════════════════
+
+def test_reject_endpoint_flips_to_discarded(admin_api):
+    body = {
+        "entity": "drift",
+        "event_date": "2026-06-02",
+        "peer_set": ["jupiter-perpetual-exchange"],
+    }
+    resp = admin_api.post("/api/engine/analyze", body)
+    assert resp.status_code == 202, resp.text[:400]
+    aid = _track(resp.json()["analysis_id"])
+
+    full = _wait_for_draft(admin_api, aid)
+    assert full.get("status") == "draft"
+
+    artifact = _render_default_artifact(admin_api, aid)
+    artifact_id = artifact["id"]
+
+    reject_resp = admin_api.post(
+        f"/api/engine/artifacts/{artifact_id}/reject",
+        {"reviewer": "test@basis.foundation", "notes": "low confidence; revisit"},
+    )
+    assert reject_resp.status_code == 200, reject_resp.text[:400]
+    body_resp = reject_resp.json()
+    assert body_resp["artifact"]["status"] == "discarded"
+    # No commit happens on reject
+    assert "commit" not in body_resp or body_resp["commit"] is None
+    # Review note stashed in warnings
+    warnings = body_resp["artifact"]["warnings"]
+    assert any(
+        "[review:rejected" in w and "low confidence" in w
+        for w in warnings
+    ), f"expected review-note warning; got {warnings}"
+
+
+# ═════════════════════════════════════════════════════════════════
+# 11. Integration: re-approving a published artifact is a no-op
+# ═════════════════════════════════════════════════════════════════
+
+def test_approve_endpoint_idempotent_on_published(admin_api):
+    if os.environ.get("BASIS_ENGINE_TEST_MODE", "").lower() not in ("1", "true", "yes"):
+        pytest.skip("BASIS_ENGINE_TEST_MODE required.")
+
+    body = {
+        "entity": "drift",
+        "event_date": "2026-06-03",
+        "peer_set": ["jupiter-perpetual-exchange"],
+    }
+    resp = admin_api.post("/api/engine/analyze", body)
+    assert resp.status_code == 202, resp.text[:400]
+    aid = _track(resp.json()["analysis_id"])
+
+    full = _wait_for_draft(admin_api, aid)
+    assert full.get("status") == "draft"
+
+    artifact = _render_default_artifact(admin_api, aid)
+    artifact_id = artifact["id"]
+
+    first = admin_api.post(
+        f"/api/engine/artifacts/{artifact_id}/approve",
+        {"reviewer": "test"},
+    )
+    assert first.status_code == 200
+    first_url = first.json()["artifact"]["published_url"]
+
+    # Second approve → 200 + 'already published; no-op' detail
+    second = admin_api.post(
+        f"/api/engine/artifacts/{artifact_id}/approve",
+        {"reviewer": "test"},
+    )
+    assert second.status_code == 200
+    assert second.json()["artifact"]["status"] == "published"
+    # published_url unchanged
+    assert second.json()["artifact"]["published_url"] == first_url
+    assert "already published" in (second.json().get("detail") or "")
+
+
+# ═════════════════════════════════════════════════════════════════
+# 12. Integration: rejecting a published artifact returns 409
+# ═════════════════════════════════════════════════════════════════
+
+def test_reject_endpoint_409_on_published(admin_api):
+    if os.environ.get("BASIS_ENGINE_TEST_MODE", "").lower() not in ("1", "true", "yes"):
+        pytest.skip("BASIS_ENGINE_TEST_MODE required.")
+
+    body = {
+        "entity": "drift",
+        "event_date": "2026-06-04",
+        "peer_set": ["jupiter-perpetual-exchange"],
+    }
+    resp = admin_api.post("/api/engine/analyze", body)
+    assert resp.status_code == 202, resp.text[:400]
+    aid = _track(resp.json()["analysis_id"])
+
+    full = _wait_for_draft(admin_api, aid)
+    assert full.get("status") == "draft"
+
+    artifact = _render_default_artifact(admin_api, aid)
+    artifact_id = artifact["id"]
+
+    approve_resp = admin_api.post(
+        f"/api/engine/artifacts/{artifact_id}/approve",
+        {"reviewer": "test"},
+    )
+    assert approve_resp.status_code == 200
+
+    reject_resp = admin_api.post(
+        f"/api/engine/artifacts/{artifact_id}/reject",
+        {"reviewer": "test", "notes": "wrong, take it back"},
+    )
+    assert reject_resp.status_code == 409
+    detail = reject_resp.json().get("detail", {})
+    if isinstance(detail, dict):
+        assert detail.get("error") == "invalid_state_for_reject"


### PR DESCRIPTION
## Summary

C5 closes the engine loop. After `background_tasks.finalize_analysis` flips an analysis from `pending` to `draft`, a new auto-render hook (`post_analysis_render_default_artifact` in `event_pipeline.py`) renders the recommended artifact and posts a Slack notification with a clickable approve URL. The operator approves or rejects via two new admin-only endpoints; approve runs a clone-write-commit-push subprocess flow against `basis-protocol/basis-hub` main, reject just discards.

### New files

| File | Purpose |
|---|---|
| `app/engine/slack.py` | Webhook poster with stdout fallback when `SLACK_ENGINE_WEBHOOK_URL` is unset |
| `app/engine/git_commit.py` | Clone/write/commit/push, `asyncio.Lock` for concurrent approvals, PAT redaction, path-traversal validation, `BASIS_ENGINE_TEST_MODE` bypass |
| `app/engine/approval.py` | Approve/reject state machine (`draft → published` / `draft → discarded`) |
| `app/engine/approval_router.py` | `POST /api/engine/artifacts/{id}/approve` and `/reject` |
| `tests/test_engine_workflow.py` | 8 unit + 4 integration tests |

### Modified files

- `app/engine/event_pipeline.py` — added `post_analysis_render_default_artifact` auto-render hook
- `app/engine/background_tasks.py` — invokes the hook from `finalize_analysis` (deferred import to break the `analysis_pipeline` cycle)
- `app/engine/router.py` — mounts `approval_router`

### State machine

```
draft ──approve──► published    (commit_url stored in published_url)
   └──reject───► discarded     (review note stashed in warnings)
```

### Idempotency

- approve on already-`published` → 200 no-op
- reject on already-`discarded` → 200 no-op
- approve on `discarded` → 409
- reject on `published` → 409 (no rollback path; render fresh + re-approve)
- failed git commit → 502, artifact stays `draft` for retry

### Notable design decisions

- **No schema changes** (per prompt). `engine_artifacts` has no `review_notes` column, so reviewer + free-text notes are stored in the existing `warnings` JSONB array as tagged strings: `[review:approved by alex@basis.foundation] ship it`. Renderers can filter by the `[review:` prefix.
- **`ArtifactStatus` literal has no `rejected`**, only `discarded`. The reject endpoint maps to `status='discarded'`.
- **PAT redaction in defense-in-depth**: every captured stderr/stdout from `git push`/`git clone` is scrubbed before being logged or surfaced into the API response.
- **Path traversal defense**: `_validate_relative_path` resolves the artifact's `suggested_path` inside the temp clone and rejects `../` escapes and absolute paths.
- **Process-wide `asyncio.Lock`** serializes commits so two parallel approvals don't race a non-fast-forward push. Cross-worker safety is out of scope for v1 (deployment runs a single uvicorn worker).
- **Deferred import in `background_tasks.py`** breaks the cycle: `background_tasks → event_pipeline → analysis_pipeline → background_tasks`.

## Test plan

- [ ] `pytest tests/test_engine_workflow.py -v -k unit` — 8 unit tests pass without any external services
- [ ] `BASIS_ENGINE_TEST_MODE=1 ADMIN_KEY=<key> BASE_URL=https://basisprotocol.xyz DATABASE_URL=<url> pytest tests/test_engine_workflow.py -v` — all 12 pass; `commit.test_mode=true` everywhere; no real git operations occur
- [ ] Existing test suites still green (`tests/test_engine_pipeline.py`, `test_engine_renderers.py`, etc.)
- [ ] Manual: post a Slack webhook URL, set `SLACK_ENGINE_WEBHOOK_URL`, trigger an analysis via `POST /api/engine/analyze`, confirm Slack notification arrives with clickable artifact URL
- [ ] Manual: with TEST_MODE off and a valid `BASIS_ENGINE_GITHUB_PAT`, approve an artifact and verify a real commit lands on `basis-hub` main

https://claude.ai/code/session_01FWDKHwn3cevR8MMLTV8Fn2

---
_Generated by [Claude Code](https://claude.ai/code/session_01FWDKHwn3cevR8MMLTV8Fn2)_