### PR TITLE
hotfix: 2 runtime bugs from PR #5 surfaced post-deploy

### DIFF
--- a/app/collectors/morpho_blue.py
+++ b/app/collectors/morpho_blue.py
@@ -270,7 +270,7 @@ def _batch_upsert_markets(rows: list[dict[str, Any]]) -> int:
         return 0
 
 
-async def _write_exposure_row(
+def _write_exposure_row(
     chain: str, token_symbol: str, tvl_usd: float, is_stable: bool
 ) -> bool:
     """Write one aggregated exposure row per (chain, token).
@@ -280,10 +280,16 @@ async def _write_exposure_row(
     one row per chain, then the outer SUM aggregates across chains.
     _get_stablecoin_exposure's DISTINCT ON (token_symbol, chain, pool_id)
     is already unique per row (one pool_id per (chain, symbol)).
+
+    Sync because run_morpho_blue_collection is sync def called bare from
+    worker async context (worker.py:1058) — asyncio.run from there fails
+    with "cannot run from running event loop". Same trade-off as _track
+    and store_attestation: accept the [sync-in-async] warning until
+    Phase 3 rather than cascade async through more callers.
     """
     pool_id = f"{PROTOCOL_SLUG}:{chain}:{token_symbol.upper()}:agg"
     try:
-        await execute_async(
+        execute(
             """
             INSERT INTO protocol_collateral_exposure
                 (protocol_slug, pool_id, token_symbol, chain, tvl_usd,
@@ -349,7 +355,7 @@ def run_morpho_blue_collection() -> dict[str, Any]:
     stable_usd_total = 0.0
     for (chain, sym), tvl in agg.items():
         is_stable = _is_stablecoin_token(None, sym)
-        if asyncio.run(_write_exposure_row(chain, sym, tvl, is_stable)):
+        if _write_exposure_row(chain, sym, tvl, is_stable):
             rows_written += 1
             if is_stable:
                 stable_rows += 1

--- a/app/integrity.py
+++ b/app/integrity.py
@@ -5,6 +5,7 @@ One module that every surface queries before rendering.
 Answers two questions per domain: "Is the data fresh?" and "Does the data make sense?"
 """
 
+import asyncio
 import json
 import logging
 from datetime import datetime, timezone
@@ -517,6 +518,8 @@ async def check_domain(domain: str) -> dict:
     for rule_fn in cfg["coherence_rules"]:
         try:
             result = rule_fn()
+            if asyncio.iscoroutine(result):
+                result = await result
             if result is None:
                 pass
             elif isinstance(result, list):

--- a/app/worker.py
+++ b/app/worker.py
@@ -998,8 +998,7 @@ async def run_fast_cycle():
                     await _fc_loop.run_in_executor(None, _mark_scoring_status, cfg["coingecko_id"], "in_progress")
             sid_t0 = time.time()
             try:
-                result = await asyncio.wait_for(
-                    await score_stablecoin(_scoring_client, sid), timeout=PER_COIN_TIMEOUT_SEC
+                result = await asyncio.wait_for(score_stablecoin(_scoring_client, sid), timeout=PER_COIN_TIMEOUT_SEC
                 )
                 sid_elapsed = time.time() - sid_t0
                 logger.error(f"[fc-3] coin {sid} computed in {sid_elapsed:.1f}s, score={'score' in result}")
@@ -1692,11 +1691,10 @@ async def run_fast_cycle():
 
     # Gate status diagnostic — log whether expansion and edge gates are open
     try:
-        from app.database import fetch_one as _gate_fo
-        _edge_ts = _gate_fo("SELECT EXTRACT(EPOCH FROM MAX(last_built_at)) AS ts FROM wallet_graph.edge_build_status")
+        _edge_ts = await fetch_one_async("SELECT EXTRACT(EPOCH FROM MAX(last_built_at)) AS ts FROM wallet_graph.edge_build_status")
         _edge_last = float(_edge_ts["ts"]) if _edge_ts and _edge_ts.get("ts") else 0
         _edge_age_h = (time.time() - _edge_last) / 3600 if _edge_last > 0 else 999
-        _wallet_max = _gate_fo("SELECT MAX(created_at) AS latest FROM wallet_graph.wallets WHERE created_at > NOW() - INTERVAL '48 hours'")
+        _wallet_max = await fetch_one_async("SELECT MAX(created_at) AS latest FROM wallet_graph.wallets WHERE created_at > NOW() - INTERVAL '48 hours'")
         _wallet_latest = _wallet_max.get("latest") if _wallet_max else None
         _wallet_age_h = 999
         if _wallet_latest:
@@ -1712,8 +1710,7 @@ async def run_fast_cycle():
 
     # One-time diagnostic: data layer table row counts via pg_stat (instant, no scan)
     try:
-        from app.database import fetch_all as _diag_fa
-        _diag_rows = _diag_fa("""
+        _diag_rows = await fetch_all_async("""
             SELECT relname AS table_name, n_live_tup
             FROM pg_stat_user_tables
             WHERE relname IN (
@@ -2085,8 +2082,7 @@ async def run_slow_cycle():
                 try:
                     from app.indexer.edges import run_edge_builder
                     logger.info(f"Running edge builder for {edge_chain} (top 100 unbuilt wallets by value, 15-min timeout)...")
-                    edge_result = await asyncio.wait_for(
-                        await run_edge_builder(max_wallets=500, priority="value", chain=edge_chain),
+                    edge_result = await asyncio.wait_for(run_edge_builder(max_wallets=500, priority="value", chain=edge_chain),
                         timeout=900,
                     )
                     logger.info(
@@ -2587,7 +2583,7 @@ async def run_slow_cycle_parallel():
                     await check_and_alert_health(health_results)
                 except Exception as alert_err:
                     logger.warning(f"Health alert dispatch failed: {alert_err}")
-        await asyncio.wait_for(await _health_sweep(), timeout=POST_TASK_TIMEOUT)
+        await asyncio.wait_for(_health_sweep(), timeout=POST_TASK_TIMEOUT)
     except asyncio.TimeoutError:
         logger.warning("Health sweep timed out after %ds", POST_TASK_TIMEOUT)
     except Exception as e:
@@ -2599,7 +2595,7 @@ async def run_slow_cycle_parallel():
             from app.integrity import check_all_and_store
             result = await asyncio.to_thread(check_all_and_store)
             logger.info(f"Integrity: {result['status']} across {len(result['domains'])} domains")
-        await asyncio.wait_for(await _integrity(), timeout=POST_TASK_TIMEOUT)
+        await asyncio.wait_for(_integrity(), timeout=POST_TASK_TIMEOUT)
     except asyncio.TimeoutError:
         logger.warning("Integrity check timed out after %ds", POST_TASK_TIMEOUT)
     except Exception as e:
@@ -2611,7 +2607,7 @@ async def run_slow_cycle_parallel():
             from app.actor_classification import classify_all_active
             result = await asyncio.to_thread(classify_all_active)
             logger.info(f"Actor classification: {result.get('classified', 0)} classified")
-        await asyncio.wait_for(await _actors(), timeout=POST_TASK_TIMEOUT)
+        await asyncio.wait_for(_actors(), timeout=POST_TASK_TIMEOUT)
     except asyncio.TimeoutError:
         logger.warning("Actor classification timed out after %ds", POST_TASK_TIMEOUT)
     except Exception as e:
@@ -2622,7 +2618,7 @@ async def run_slow_cycle_parallel():
         async def _discovery():
             from app.discovery import run_discovery_cycle
             await asyncio.to_thread(run_discovery_cycle)
-        await asyncio.wait_for(await _discovery(), timeout=POST_TASK_TIMEOUT)
+        await asyncio.wait_for(_discovery(), timeout=POST_TASK_TIMEOUT)
     except asyncio.TimeoutError:
         logger.warning("Discovery cycle timed out after %ds", POST_TASK_TIMEOUT)
     except Exception as e:
@@ -2649,7 +2645,7 @@ async def run_slow_cycle_parallel():
                 )
             else:
                 logger.info(f"Coherence sweep skipped -- last ran {coherence_age_hours:.1f}h ago")
-        await asyncio.wait_for(await _coherence(), timeout=POST_TASK_TIMEOUT)
+        await asyncio.wait_for(_coherence(), timeout=POST_TASK_TIMEOUT)
     except asyncio.TimeoutError:
         logger.warning("Coherence sweep timed out after %ds", POST_TASK_TIMEOUT)
     except Exception as e:
@@ -2665,7 +2661,7 @@ async def run_slow_cycle_parallel():
             logger.error(f"=== WALLET EXPANSION: started, target=10000, current={_count} ===")
             result = await run_wallet_graph_expansion(target_new_wallets=10_000, max_etherscan_calls=5_000)
             logger.error(f"=== WALLET EXPANSION: {result.get('new_wallets_seeded', 0)} new wallets, result={result} ===")
-        await asyncio.wait_for(await _wallet_expansion(), timeout=POST_TASK_TIMEOUT)
+        await asyncio.wait_for(_wallet_expansion(), timeout=POST_TASK_TIMEOUT)
     except asyncio.TimeoutError:
         logger.error("=== WALLET EXPANSION: timed out after %ds ===" % POST_TASK_TIMEOUT)
     except Exception as e:
@@ -2681,7 +2677,7 @@ async def run_slow_cycle_parallel():
                 f"{result.get('clusters_computed', 0)} clusters, "
                 f"{result.get('snapshots_stored', 0)} snapshots ==="
             )
-        await asyncio.wait_for(await _concentration(), timeout=POST_TASK_TIMEOUT)
+        await asyncio.wait_for(_concentration(), timeout=POST_TASK_TIMEOUT)
     except asyncio.TimeoutError:
         logger.warning("Concentration analysis timed out after %ds", POST_TASK_TIMEOUT)
     except Exception as e:
@@ -2848,7 +2844,7 @@ async def run_slow_cycle_parallel():
                 f"Provenance recheck: {result['checked']} checked, "
                 f"{result['re_enabled']} re-enabled, {result['healed']} healed"
             )
-        await asyncio.wait_for(await _provenance_recheck(), timeout=POST_TASK_TIMEOUT)
+        await asyncio.wait_for(_provenance_recheck(), timeout=POST_TASK_TIMEOUT)
     except asyncio.TimeoutError:
         logger.warning("Provenance recheck timed out after %ds", POST_TASK_TIMEOUT)
     except Exception as e:
@@ -3578,7 +3574,7 @@ async def main():
                     # Fast cycle — runs every interval
                     logger.error("[checkpoint 9] fast cycle starting")
                     try:
-                        await asyncio.wait_for(await run_fast_cycle(), timeout=FAST_CYCLE_TIMEOUT)
+                        await asyncio.wait_for(run_fast_cycle(), timeout=FAST_CYCLE_TIMEOUT)
                     except asyncio.TimeoutError:
                         logger.error("Fast cycle exceeded 30-minute timeout")
                     logger.error("[checkpoint 10] fast cycle complete")
@@ -3587,7 +3583,7 @@ async def main():
                     cycle_counter += 1
                     try:
                         logger.error(f"=== Starting enrichment (cycle {cycle_counter}) ===")
-                        await asyncio.wait_for(await run_slow_cycle_parallel(), timeout=SLOW_CYCLE_TIMEOUT)
+                        await asyncio.wait_for(run_slow_cycle_parallel(), timeout=SLOW_CYCLE_TIMEOUT)
                     except asyncio.TimeoutError:
                         logger.error("Enrichment exceeded 60-minute timeout")
 


### PR DESCRIPTION
1. integrity.py:519 — coherence_rules dispatch loop didn't await async
   rule functions. Added asyncio.iscoroutine guard (matches
   health_checker.py:537 pattern). Symptom: RuntimeWarning at
   pulse_generator.py:300 and health_checker.py:282 for
   _pulse_summary_coherence, _sii_null_scores, _sii_score_range,
   _sii_min_scored coroutines never awaited. Added import asyncio.

2. morpho_blue.py:351 — asyncio.run() called from inside running event
   loop. run_morpho_blue_collection is sync def called bare from
   worker async context (worker.py:1058) — asyncio.run from there
   raises "cannot run from running event loop". Reverted
   _write_exposure_row to sync def (drops async, uses execute()),
   removed asyncio.run wrapper at call site. Same trade-off as
   _track and store_attestation: accept the [sync-in-async] warning
   until Phase 3 rather than cascade async through more callers.
   Symptom: RuntimeWarning at worker.py:1066 for _write_exposure_row
   coroutine never awaited.

Both bugs were the dispatch-table pattern (function refs stored in
data structures, called via variable). Static audit's regex didn't
catch either because function names don't appear at the call site.

Investigated other dispatch sites:
- ops/tools/health_checker.py:537 — already correct.
- services/cda_validator.py:26 — string-dispatch (rule names), not
  callable-dispatch. _run_rule is sync. Not a bug.
- coherence.py:125/275 — iterates string list ALL_DOMAINS, not
  callables. Not a bug.

No data loss — bugs were in tertiary paths (integrity coherence
checks, morpho exposure rows). stale_diagnostic continued reporting
fresh.