### PR TITLE
fix(crypto): use keccak256 for on-chain entityIds, no sha256 fallback

### DIFF
--- a/app/agent/assessor.py
+++ b/app/agent/assessor.py
@@ -16,12 +16,12 @@ logger = logging.getLogger(__name__)
 
 
 def _keccak256_hex(data: bytes) -> str:
-    """Compute keccak256 hash. Falls back to sha256 if pysha3 not available."""
-    try:
-        import sha3
-        return "0x" + sha3.keccak_256(data).hexdigest()
-    except ImportError:
-        return "0x" + hashlib.sha256(data).hexdigest()
+    """Compute keccak256 hash. No sha256 fallback — content_hash on
+    assessment_events feeds the on-chain anchoring path; silent
+    divergence from Solidity would publish unverifiable hashes.
+    """
+    from eth_hash.auto import keccak
+    return "0x" + keccak(data).hex()
 
 
 async def _get_sii_scores() -> dict:

--- a/app/disputes.py
+++ b/app/disputes.py
@@ -41,21 +41,17 @@ def _compute_transition_hash(dispute_id: str, transition_index: int, payload: di
 def compute_on_chain_entity_id(transition: dict) -> str:
     """Compute deterministic bytes32 entityId for on-chain anchoring.
 
-    Uses keccak256 (with sha256 fallback) of canonical
-    {dispute_id, transition_index, transition_kind}.
-    Returns 0x-prefixed hex string.
+    keccak256 of canonical {dispute_id, transition_index, transition_kind}.
+    Returns 0x-prefixed hex string. No sha256 fallback — Solidity uses
+    keccak256, silent divergence would publish unverifiable entityIds.
     """
+    from eth_hash.auto import keccak
     canonical = json.dumps({
         "dispute_id": str(transition.get("dispute_id", "")),
         "transition_index": transition.get("transition_index", 0),
         "transition_kind": transition.get("transition_kind", ""),
     }, sort_keys=True, separators=(",", ":"))
-    try:
-        import sha3
-        h = sha3.keccak_256(canonical.encode()).hexdigest()
-    except ImportError:
-        h = hashlib.sha256(canonical.encode()).hexdigest()
-    return "0x" + h
+    return "0x" + keccak(canonical.encode()).hex()
 
 
 def submit_dispute(entity_slug: str, submitter_identifier: str, submitter_type: str,

--- a/app/methodology_hashes.py
+++ b/app/methodology_hashes.py
@@ -58,11 +58,12 @@ def list_methodologies() -> list[dict]:
 
 
 def compute_on_chain_entity_id(methodology: dict) -> str:
-    """Deterministic bytes32 entityId for on-chain anchoring via publishReportHash."""
+    """Deterministic bytes32 entityId for on-chain anchoring via publishReportHash.
+
+    Solidity uses keccak256; the on-chain oracle expects this exact digest.
+    Don't add a sha256 fallback here — silent divergence from Solidity would
+    publish unverifiable entityIds.
+    """
+    from eth_hash.auto import keccak
     canonical = methodology.get("methodology_id", "")
-    try:
-        import sha3
-        h = sha3.keccak_256(canonical.encode()).hexdigest()
-    except ImportError:
-        h = hashlib.sha256(canonical.encode()).hexdigest()
-    return "0x" + h
+    return "0x" + keccak(canonical.encode()).hex()

--- a/app/track_record.py
+++ b/app/track_record.py
@@ -51,18 +51,19 @@ def _compute_content_hash(entity_slug: str, trigger_kind: str,
 
 
 def compute_on_chain_entity_id(entry: dict) -> str:
-    """Compute deterministic bytes32 entityId for on-chain anchoring via publishReportHash."""
+    """Compute deterministic bytes32 entityId for on-chain anchoring via publishReportHash.
+
+    keccak256 of canonical {entity_slug, trigger_kind, triggered_at}.
+    No sha256 fallback — Solidity uses keccak256, silent divergence would
+    publish unverifiable entityIds.
+    """
+    from eth_hash.auto import keccak
     canonical = json.dumps({
         "entity_slug": entry.get("entity_slug", ""),
         "trigger_kind": entry.get("trigger_kind", ""),
         "triggered_at": str(entry.get("triggered_at", "")),
     }, sort_keys=True, separators=(",", ":"))
-    try:
-        import sha3
-        h = sha3.keccak_256(canonical.encode()).hexdigest()
-    except ImportError:
-        h = hashlib.sha256(canonical.encode()).hexdigest()
-    return "0x" + h
+    return "0x" + keccak(canonical.encode()).hex()
 
 
 def _get_entity_baseline(entity_slug: str, index_name: str) -> dict:

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ apscheduler>=3.10.0
 dbt-core>=1.7.13
 dbt-postgres>=1.7.0
 email-validator>=2.0
+eth-hash[pycryptodome]>=0.7.0
 fastapi==0.115.6
 httpx==0.28.1
 mcp[http]


### PR DESCRIPTION
pysha3 was never declared in requirements.txt. The four compute_on_chain_entity_id / _keccak256_hex sites all had a try-import-sha3 / except-fall-back-to-sha256 pattern, so in production they silently produced sha256 digests. Solidity uses keccak256, so every entity_id_bytes32 the hub serves to the keeper today (and would have served on Phase 2 mainnet anchoring) is wrong.

Verified divergence: keccak("sii_v1.0.0") =
0xdf6f101744adcf7a34b2468cd3be30b031ef77e5ea9a798eaae83c257589dc84 vs sha256("sii_v1.0.0") =
0x617d486e0ba884968179d78afc2a8989b124dd95b098b8e33e87c21dc55a2679.

Switched to eth-hash[pycryptodome] (well-maintained, declared in deps). Removed the sha256 fallback entirely — silent divergence from Solidity on a write-once on-chain anchor is precisely what we don't want; raise loudly if the dep is missing.

No backfill needed: entity_id_bytes32 is computed at request time in ops/routes.py (3 sites), never stored. Once this lands, the next /admin/track-record/pending-on-chain (and dispute / methodology equivalents) returns correct keccak entityIds. content_hash columns remain sha256 — those fingerprint document content and are stored as opaque bytes in Solidity's reportHash, not re-hashed on-chain.

Gates PR 5 keeper work: keeper Day 1 cannot proceed until this PR lands — TS-port golden vectors must be derived from a corrected hub.