### PR TITLE
fix: async validate_api_key + debug exception handler for 500 traceback

### DIFF
--- a/app/server.py
+++ b/app/server.py
@@ -105,6 +105,20 @@ app = FastAPI(
     version="1.0.0",
 )
 
+
+@app.exception_handler(Exception)
+async def _debug_exception_handler(request: Request, exc: Exception):
+    import traceback
+    logger.error(
+        "Unhandled exception on %s %s:\n%s",
+        request.method, request.url.path, traceback.format_exc(),
+    )
+    from starlette.responses import JSONResponse
+    return JSONResponse(
+        status_code=500,
+        content={"detail": "Internal server error"},
+    )
+
 app.add_middleware(
     CORSMiddleware,
     allow_origins=CORS_ORIGINS,
@@ -142,7 +156,7 @@ async def rate_limit_and_track(request: Request, call_next):
         return await call_next(request)
 
     from app.rate_limiter import rate_limiter, PUBLIC_RATE_LIMIT, KEYED_RATE_LIMIT
-    from app.usage_tracker import validate_api_key, hash_api_key, log_request
+    from app.usage_tracker import validate_api_key_async, hash_api_key, log_request
 
     query_key = request.query_params.get("apikey")
     header_key = request.headers.get("x-api-key")
@@ -151,7 +165,11 @@ async def rate_limit_and_track(request: Request, call_next):
 
     # Try query param first; if invalid or absent, fall back to header
     for candidate in filter(None, [query_key, header_key]):
-        api_key_id = validate_api_key(candidate)
+        try:
+            api_key_id = await validate_api_key_async(candidate)
+        except Exception:
+            logger.debug("validate_api_key failed for candidate, treating as anonymous")
+            api_key_id = None
         api_key_hash = hash_api_key(candidate)
         if api_key_id:
             break

--- a/app/usage_tracker.py
+++ b/app/usage_tracker.py
@@ -74,6 +74,31 @@ def validate_api_key(key_string: str) -> Optional[int]:
     return result
 
 
+async def validate_api_key_async(key_string: str) -> Optional[int]:
+    """Async version of validate_api_key for use in async middleware."""
+    if not key_string:
+        return None
+
+    now = _time.time()
+    cached = _key_cache.get(key_string)
+    if cached is not None and (now - cached[1]) < _KEY_CACHE_TTL:
+        return cached[0]
+
+    try:
+        from app.database import fetch_one_async
+        row = await fetch_one_async(
+            "SELECT id FROM api_keys WHERE key = %s AND is_active = TRUE",
+            (key_string,)
+        )
+        result = row["id"] if row else None
+    except Exception as e:
+        logger.debug(f"validate_api_key_async error: {e}")
+        result = None
+
+    _key_cache[key_string] = (result, now)
+    return result
+
+
 def create_api_key(name: str) -> str:
     """Generates a new random API key, stores it, and returns the raw string."""
     from app.database import get_conn


### PR DESCRIPTION
## Summary

- Add `validate_api_key_async` to `app/usage_tracker.py` — uses `fetch_one_async` instead of sync `fetch_one` from async middleware
- Switch middleware at `app/server.py:154` to use `validate_api_key_async` with `await` + try/except isolation
- Add temporary global exception handler that logs **full tracebacks** for unhandled 500s (Railway logs currently truncate to framework frames only)

## Why

The `[sync-in-async] fetch_one called from async context at /app/app/usage_tracker.py:64` warning indicates the sync `validate_api_key` is blocking the event loop on **every single API request**. The try/except isolation ensures a bad key lookup can't 500 every route in lockstep.

The exception handler is diagnostic — deploy, capture one full traceback from `/api/scores` 500, then remove it.

## Test plan

- [ ] Deploy, check Railway logs for full traceback on next 500
- [ ] If 500s stop (validate_api_key was the root cause), remove the exception handler in a follow-up
- [ ] If 500s continue, the traceback will reveal the actual line — fix forward or revert 90ae9c8

https://claude.ai/code/session_011bTVc5haorCZgtCtxzJmtq

---
_Generated by [Claude Code](https://claude.ai/code/session_011bTVc5haorCZgtCtxzJmtq)_