### PR TITLE
hotfix: add missing async imports broken in 90ae9c8

### DIFF
--- a/app/indexer/api.py
+++ b/app/indexer/api.py
@@ -15,7 +15,7 @@ from typing import Optional
 from fastapi import FastAPI, Query, HTTPException, BackgroundTasks, Request
 from fastapi.responses import JSONResponse
 
-from app.database import execute, fetch_all, fetch_one
+from app.database import execute, fetch_all, fetch_one, fetch_one_async, fetch_all_async, execute_async
 from app.indexer.backlog import get_backlog, get_backlog_detail
 from app.indexer.pipeline import get_coverage_diagnostic
 from app.specs.methodology_versions import WALLET_METHODOLOGY_VERSIONS

--- a/app/ops/routes.py
+++ b/app/ops/routes.py
@@ -12,7 +12,7 @@ from fastapi import APIRouter, BackgroundTasks, Request, HTTPException, Query
 from fastapi.responses import JSONResponse
 from typing import Optional
 
-from app.database import fetch_one, fetch_all, execute
+from app.database import fetch_one, fetch_all, execute, fetch_one_async, fetch_all_async, execute_async
 
 logger = logging.getLogger(__name__)
 

--- a/app/server.py
+++ b/app/server.py
@@ -27,6 +27,7 @@ from app.config import STABLECOIN_REGISTRY, CORS_ORIGINS
 from app.database import (
     init_pool, close_pool, health_check as db_health_check,
     fetch_one, fetch_all,
+    fetch_one_async, fetch_all_async, execute_async,
 )
 from app.scoring import (
     SII_V1_WEIGHTS, STRUCTURAL_SUBWEIGHTS, FORMULA_VERSION,


### PR DESCRIPTION
## Summary

PR-A1 retry (90ae9c8) converted ~370 call sites from `fetch_one(...)` → `await fetch_one_async(...)` across three files but **didn't add `fetch_one_async`, `fetch_all_async`, `execute_async` to the `from app.database import` lines**. Every endpoint that touches the DB 500-errors with `NameError: name 'fetch_one_async' is not defined`.

This PR adds the three missing imports to each file's existing import block. No other changes.

## Files changed

- `app/server.py` — 1 line added to import block
- `app/ops/routes.py` — import line extended
- `app/indexer/api.py` — import line extended

**3 insertions, 2 deletions. Import-only.**

## Verification gates (all passed)

- Gate 1: `py_compile` — exit 0
- Gate 2: AST name-resolution — 9/9 OK (all three helpers × all three files)
- Gate 3: Module import with stubs — all three files import successfully, no NameError
- Gate 4: `git diff` confirms only import additions
- Gate 5: `--stat` shows 3 insertions, 2 deletions across 3 files

## Tracebacks fixed

- `server.py:1468` (get_scores)
- `server.py:4676` (psi_scores)
- `server.py:8490` (state_root_latest)
- `server.py:8589` (provenance_register)
- `server.py:8749` (provenance_cda_sources)
- startup: historical_protocol_data execute_async

https://claude.ai/code/session_011bTVc5haorCZgtCtxzJmtq

---
_Generated by [Claude Code](https://claude.ai/code/session_011bTVc5haorCZgtCtxzJmtq)_