### PR TITLE
fix(enrichment): wrap sync DB calls in holder_discovery to_thread + add wait_for guard

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,7 @@
-.PHONY: audit-async
+.PHONY: audit-async audit-sync-db
 
 audit-async:
 	python3 scripts/audit_await_in_args.py
+
+audit-sync-db:
+	python3 scripts/audit_sync_db_in_async.py

--- a/app/data_layer/holder_discovery.py
+++ b/app/data_layer/holder_discovery.py
@@ -20,6 +20,7 @@ Feeds:
 Schedule: Daily via enrichment pipeline
 """
 
+import asyncio
 import logging
 import os
 import time
@@ -127,6 +128,35 @@ async def _fetch_holders_blockscout(
         return []
 
 
+def _insert_holder_addrs_sync(addrs: list[str], symbol: str, chain: str) -> tuple[int, int]:
+    """Sync helper: insert addresses in a single transaction.
+
+    Called via asyncio.to_thread from run_holder_discovery to keep
+    psycopg2 blocking calls off the event loop.
+    """
+    seeded = 0
+    errors = 0
+    with get_cursor() as cur:
+        for addr in addrs:
+            try:
+                cur.execute(
+                    """INSERT INTO wallet_graph.wallets
+                       (address, source, label, created_at, updated_at)
+                       VALUES (%s, 'holder_discovery', %s, NOW(), NOW())
+                       ON CONFLICT (address) DO NOTHING""",
+                    (addr, f"holder:{symbol}:{chain}"),
+                )
+                seeded += 1
+            except Exception as e:
+                errors += 1
+                if errors <= 3:
+                    logger.error(
+                        "Holder insert failed for %s on %s:%s: %s",
+                        addr, chain, symbol, e,
+                    )
+    return seeded, errors
+
+
 async def run_holder_discovery() -> dict:
     """
     Deep holder list pagination for all stablecoins on all chains via Blockscout.
@@ -137,7 +167,9 @@ async def run_holder_discovery() -> dict:
     Returns summary of discovery.
     """
     # Pre-load existing addresses for dedup
-    existing_rows = fetch_all("SELECT address FROM wallet_graph.wallets")
+    existing_rows = await asyncio.to_thread(
+        fetch_all, "SELECT address FROM wallet_graph.wallets"
+    )
     existing_set = set(r["address"].lower() for r in existing_rows) if existing_rows else set()
 
     total_discovered = 0
@@ -203,31 +235,14 @@ async def run_holder_discovery() -> dict:
 
                     if new_addrs:
                         chain_discovered += len(new_addrs)
-
-                        # Per-row insert
-                        row_errors = 0
-                        for addr in new_addrs:
-                            try:
-                                with get_cursor() as cur:
-                                    cur.execute(
-                                        """INSERT INTO wallet_graph.wallets
-                                           (address, source, label, created_at, updated_at)
-                                           VALUES (%s, 'holder_discovery', %s, NOW(), NOW())
-                                           ON CONFLICT (address) DO NOTHING""",
-                                        (addr, f"holder:{symbol}:{chain}"),
-                                    )
-                                chain_seeded += 1
-                            except Exception as e:
-                                row_errors += 1
-                                if row_errors <= 3:
-                                    logger.error(
-                                        "Holder insert failed for %s on %s:%s: %s",
-                                        addr, chain, symbol, e,
-                                    )
+                        seeded, row_errors = await asyncio.to_thread(
+                            _insert_holder_addrs_sync, new_addrs, symbol, chain
+                        )
+                        chain_seeded += seeded
                         if row_errors:
                             logger.error(
                                 "Holder discovery insert: %d seeded, %d errors for %s:%s",
-                                len(new_addrs) - row_errors, row_errors, chain, symbol,
+                                seeded, row_errors, chain, symbol,
                             )
 
                 logger.info(

--- a/app/enrichment_worker.py
+++ b/app/enrichment_worker.py
@@ -739,7 +739,11 @@ async def run_enrichment_pipeline() -> dict:
 
     async def _run_holder_discovery():
         from app.data_layer.holder_discovery import run_holder_discovery
-        return await run_holder_discovery()
+        try:
+            return await asyncio.wait_for(run_holder_discovery(), timeout=3000)
+        except asyncio.TimeoutError:
+            logger.error("holder_discovery exceeded 50min wait_for timeout — aborting cycle")
+            return {"chains_processed": 0, "total_discovered": 0, "total_seeded": 0, "by_chain": {}, "aborted": "timeout"}
 
     pipeline.add(EnrichmentTask(
         name="holder_discovery", func=_run_holder_discovery,

--- a/scripts/audit_sync_db_in_async.py
+++ b/scripts/audit_sync_db_in_async.py
@@ -1,0 +1,178 @@
+#!/usr/bin/env python3
+"""
+Audit: sync DB calls inside async functions.
+
+Finds any async function that calls a sync DB primitive directly without
+wrapping it in asyncio.to_thread or using the _async variant.
+
+Sync primitives (DANGEROUS inside async def):
+  fetch_all, fetch_one, execute, get_cursor
+
+Safe patterns (NOT flagged):
+  fetch_all_async, fetch_one_async, execute_async
+  await asyncio.to_thread(fetch_all, ...)
+  Calls inside a sync def (even if that def is in the same file)
+
+Exit code 1 if violations found, 0 if clean.
+"""
+
+import ast
+import os
+import sys
+
+SYNC_DB_NAMES = {"fetch_all", "fetch_one", "execute", "get_cursor"}
+ASYNC_DB_NAMES = {"fetch_all_async", "fetch_one_async", "execute_async"}
+
+SKIP_DIRS = {"__pycache__", ".git", "node_modules", "frontend", "dbt", "keeper", ".venv", "venv"}
+
+
+def _get_call_name(node: ast.Call) -> str | None:
+    if isinstance(node.func, ast.Name):
+        return node.func.id
+    if isinstance(node.func, ast.Attribute):
+        return node.func.attr
+    return None
+
+
+def _is_to_thread_wrapped(node: ast.Call) -> bool:
+    """Check if this call is asyncio.to_thread(sync_fn, ...) or loop.run_in_executor(None, sync_fn, ...)."""
+    name = _get_call_name(node)
+    if name == "to_thread":
+        return True
+    if name == "run_in_executor":
+        return True
+    return False
+
+
+def _check_async_body(body: list[ast.stmt], func_name: str, filepath: str, violations: list):
+    """Walk the body of an async function looking for bare sync DB calls."""
+    for node in ast.walk(ast.Module(body=body, type_ignores=[])):
+        # Skip sync inner function definitions — their bodies are fine
+        if isinstance(node, ast.FunctionDef):
+            continue
+
+        if not isinstance(node, ast.Call):
+            continue
+
+        call_name = _get_call_name(node)
+        if call_name not in SYNC_DB_NAMES:
+            continue
+
+        # Check: is this call an argument to asyncio.to_thread or run_in_executor?
+        # We need to walk parents for this. Instead, check if the Call is a direct
+        # arg to another Call that's to_thread/run_in_executor.
+        # ast.walk doesn't give parents, so we do a second pass.
+        pass  # handled below
+
+    # More precise: walk with parent tracking
+    _walk_with_parent(body, func_name, filepath, violations)
+
+
+def _walk_with_parent(body: list[ast.stmt], func_name: str, filepath: str, violations: list):
+    """Walk AST body tracking parent to detect if sync call is wrapped in to_thread."""
+
+    class _Visitor(ast.NodeVisitor):
+        def __init__(self):
+            self.in_sync_func = False
+
+        def visit_FunctionDef(self, node):
+            # Sync inner function — don't flag calls inside it
+            old = self.in_sync_func
+            self.in_sync_func = True
+            self.generic_visit(node)
+            self.in_sync_func = old
+
+        def visit_AsyncFunctionDef(self, node):
+            # Nested async — recurse but don't flag (it'll be handled as its own top-level)
+            pass
+
+        def visit_Call(self, node):
+            if self.in_sync_func:
+                self.generic_visit(node)
+                return
+
+            call_name = _get_call_name(node)
+
+            # Check if this is to_thread(sync_fn, ...) — the sync_fn arg is safe
+            if call_name in ("to_thread", "run_in_executor"):
+                # Don't recurse into args — they're intentionally sync
+                return
+
+            if call_name in SYNC_DB_NAMES:
+                violations.append({
+                    "file": filepath,
+                    "line": node.lineno,
+                    "func": func_name,
+                    "call": call_name,
+                })
+
+            self.generic_visit(node)
+
+        def visit_With(self, node):
+            if self.in_sync_func:
+                self.generic_visit(node)
+                return
+
+            for item in node.items:
+                if isinstance(item.context_expr, ast.Call):
+                    cname = _get_call_name(item.context_expr)
+                    if cname == "get_cursor":
+                        violations.append({
+                            "file": filepath,
+                            "line": node.lineno,
+                            "func": func_name,
+                            "call": "get_cursor (with block)",
+                        })
+
+            self.generic_visit(node)
+
+    visitor = _Visitor()
+    for stmt in body:
+        visitor.visit(stmt)
+
+
+def audit_file(filepath: str) -> list[dict]:
+    violations = []
+    try:
+        with open(filepath) as f:
+            source = f.read()
+        tree = ast.parse(source, filename=filepath)
+    except (SyntaxError, UnicodeDecodeError):
+        return []
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.AsyncFunctionDef):
+            _check_async_body(node.body, node.name, filepath, violations)
+    return violations
+
+
+def main():
+    app_dir = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "app")
+    if not os.path.isdir(app_dir):
+        app_dir = "app"
+
+    all_violations = []
+    files_with_violations = set()
+
+    for root, dirs, files in os.walk(app_dir):
+        dirs[:] = [d for d in dirs if d not in SKIP_DIRS]
+        for fname in sorted(files):
+            if not fname.endswith(".py"):
+                continue
+            filepath = os.path.join(root, fname)
+            violations = audit_file(filepath)
+            if violations:
+                all_violations.extend(violations)
+                files_with_violations.add(filepath)
+
+    for v in all_violations:
+        print(f"{v['file']}:{v['line']}: in async {v['func']}: {v['call']}")
+
+    print()
+    print(f"{len(all_violations)} violations across {len(files_with_violations)} files.")
+
+    return 1 if all_violations else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

**Commit 1: holder_discovery fix**
- `fetch_all` at line 140 wrapped in `asyncio.to_thread`
- Per-row insert loop collapsed into `_insert_holder_addrs_sync` (sync helper), called via `asyncio.to_thread` — single transaction, also faster
- `_run_holder_discovery` in enrichment_worker.py wrapped in `asyncio.wait_for(timeout=3000)` as defense-in-depth

Fixes May 4 scoring freeze (23h). Root cause: `run_holder_discovery` is async but called psycopg2 sync functions directly. When asyncio cancelled the task, psycopg2 didn't honor cancellation → task wedged in "Task cancelling" state → blocked event loop → scoring fast cycle never scheduled.

**Commit 2: audit script**
- `scripts/audit_sync_db_in_async.py` — AST-based detector for sync DB calls inside async functions
- `make audit-sync-db` Makefile target
- Current state: **105 violations across 22 files**

## Audit output (105 violations, 22 files)

| Severity | Files | Description |
|----------|-------|-------------|
| HIGH | `app/indexer/expander.py`, `app/indexer/solana_edges.py`, `app/data_layer/peg_monitor.py`, `app/data_layer/oracle_cadence_collector.py` | Long-running loops with per-row sync DB |
| MEDIUM | `app/payments.py` (11), `app/agent/api.py` (6), `app/publisher/page_renderer.py` (13), `app/ops/tools/*` (30+) | Request handlers, per-cycle tasks |
| LOW | `app/worker.py:main` (3), `app/services/cda_collector.py` (11) | Startup DDL, infrequent admin paths |

## Test plan

- [x] `python -c "from app.data_layer.holder_discovery import run_holder_discovery, _insert_holder_addrs_sync"` — imports ok
- [x] `py_compile` passes on both files
- [x] `grep` confirms all sync DB calls are inside `_insert_holder_addrs_sync` or wrapped in `to_thread`
- [x] `audit_sync_db_in_async.py` runs clean (105 pre-existing violations, 0 new)
- [x] Return shape of `run_holder_discovery()` preserved

https://claude.ai/code/session_011bTVc5haorCZgtCtxzJmtq

---
_Generated by [Claude Code](https://claude.ai/code/session_011bTVc5haorCZgtCtxzJmtq)_