### PR TITLE
feat(worker): cancellation watchdog + slow-callback alerting

### DIFF
--- a/app/worker.py
+++ b/app/worker.py
@@ -47,6 +47,68 @@ logger = logging.getLogger("worker")
 _current_cycle_stats = None
 
 
+async def cancellation_watchdog():
+    """Detect tasks stuck in CANCELLING state.
+
+    When asyncio cancels a task blocked in sync code, the task transitions
+    to CANCELLING but cancellation can't propagate. This watchdog logs at
+    2min and force-exits at 5min so Railway restarts the worker.
+    """
+    cancelling_since: dict[int, float] = {}
+    while True:
+        try:
+            await asyncio.sleep(30)
+            now = time.time()
+            live_ids = set()
+
+            for t in asyncio.all_tasks():
+                tid = id(t)
+                live_ids.add(tid)
+                state = getattr(t, "_state", None)
+
+                if state == "CANCELLING":
+                    first_seen = cancelling_since.setdefault(tid, now)
+                    age = now - first_seen
+
+                    if age > 120:
+                        coro = t.get_coro()
+                        loc = "unknown"
+                        try:
+                            if coro and coro.cr_frame:
+                                loc = f"{coro.cr_code.co_filename}:{coro.cr_frame.f_lineno}"
+                        except Exception:
+                            pass
+
+                        logger.error(
+                            f"WEDGED TASK: name={t.get_name()} "
+                            f"cancelling_for={age:.0f}s coro_at={loc}"
+                        )
+
+                        if age > 300:
+                            logger.error(
+                                f"WEDGED TASK exceeded 5min ({t.get_name()}) — "
+                                f"exiting worker for restart"
+                            )
+                            for h in logging.getLogger().handlers:
+                                try:
+                                    h.flush()
+                                except Exception:
+                                    pass
+                            os._exit(1)
+                else:
+                    cancelling_since.pop(tid, None)
+
+            for tid in list(cancelling_since.keys()):
+                if tid not in live_ids:
+                    cancelling_since.pop(tid)
+
+        except asyncio.CancelledError:
+            raise
+        except Exception as e:
+            logger.error(f"cancellation_watchdog error: {e}")
+            await asyncio.sleep(30)
+
+
 def _record_cycle_error(
     error_type: str,
     error_message: str,
@@ -2845,6 +2907,15 @@ async def main():
         f"(was default min(32, cpu+4)={_prev_default_size})"
     )
 
+    # Slow-callback alerting: log any callback that blocks the event loop >1s.
+    # Default 0.1s floods logs; 1.0s catches genuine sync-in-async blockers.
+    _loop = asyncio.get_running_loop()
+    _loop.slow_callback_duration = 1.0
+    logging.getLogger("asyncio").setLevel(logging.WARNING)
+    logger.error(
+        f"[startup] asyncio loop configured: slow_callback_duration={_loop.slow_callback_duration}s"
+    )
+
     logger.error("[startup] worker main() entered — initializing pool")
     init_pool()
     logger.error("[startup] pool initialized — running schema fixes")
@@ -3425,6 +3496,9 @@ async def main():
 
             asyncio.create_task(_diagnostic_loop())
             logger.error("[checkpoint 6] diagnostic loop launched")
+
+            asyncio.create_task(cancellation_watchdog(), name="cancellation_watchdog")
+            logger.error("[startup] cancellation watchdog launched (30s scan interval)")
 
             # LLL Phase 1 Pipeline 3: Oracle cadence sampling (5-min independent loop)
             try:


### PR DESCRIPTION
Runtime safety net for the bug class behind April 26 (69h freeze) and May 4 (23h freeze) outages.

## Changes

1. **`cancellation_watchdog()`** — new async task, scans `asyncio.all_tasks()` every 30s:
   - 2min wedged: logs `WEDGED TASK` with task name + coroutine location
   - 5min wedged: `os._exit(1)` for Railway auto-restart

2. **`loop.slow_callback_duration = 1.0`** — any sync call blocking the event loop >1s gets logged automatically by asyncio. Default 0.1s floods logs; 1.0s catches genuine blockers.

## Effect

Future sync-in-async bugs get caught in 2-5 minutes instead of hours. The static fixes (PR #65, Wave A) prevent the bugs we know about. This catches the ones we don't.

## Only file touched

`app/worker.py` — 74 insertions, 0 deletions.

https://claude.ai/code/session_011bTVc5haorCZgtCtxzJmtq

---
_Generated by [Claude Code](https://claude.ai/code/session_011bTVc5haorCZgtCtxzJmtq)_