### PR TITLE
fix(async): replace time.sleep with asyncio.sleep in 6 async functions

### DIFF
--- a/app/collectors/governance_proposals.py
+++ b/app/collectors/governance_proposals.py
@@ -8,6 +8,7 @@ Sources: Snapshot GraphQL API (free) and Tally GraphQL API (free basic).
 Runs daily in the slow cycle.  Never raises — all errors logged and skipped.
 """
 
+import asyncio
 import hashlib
 import json
 import logging
@@ -478,12 +479,12 @@ async def collect_governance_proposals() -> dict:
                     proposals = await _fetch_snapshot_proposals(
                         source_cfg["space"], protocol_slug
                     )
-                    time.sleep(0.5)
+                    await asyncio.sleep(0.5)
                 elif source_type == "tally":
                     proposals = await _fetch_tally_proposals(
                         source_cfg["governor_id"], protocol_slug
                     )
-                    time.sleep(1)
+                    await asyncio.sleep(1)
                 else:
                     continue
 

--- a/app/collectors/parameter_history.py
+++ b/app/collectors/parameter_history.py
@@ -9,6 +9,7 @@ Runs in both fast cycle (change detection only) and slow cycle (full snapshots).
 Never raises — all errors logged and skipped.
 """
 
+import asyncio
 import hashlib
 import json
 import logging
@@ -534,7 +535,7 @@ async def check_parameter_changes() -> dict:
                             ),
                         )
 
-                    time.sleep(0.3)  # Rate limit RPC calls
+                    await asyncio.sleep(0.3)  # Rate limit RPC calls
 
                 except Exception as e:
                     logger.debug(f"Parameter read failed: {protocol_slug}/{spec['parameter_key']}: {e}")

--- a/app/collectors/vault_collector.py
+++ b/app/collectors/vault_collector.py
@@ -13,6 +13,7 @@ Key insight: "Underlying Asset Quality" category reads from existing
 SII/PSI scores via CQI lookup — not re-derived.
 """
 
+import asyncio
 import json
 import hashlib
 import logging
@@ -651,7 +652,7 @@ async def store_vault_score(result: dict) -> None:
 async def run_vsri_scoring() -> list[dict]:
     """Score all vault entities. Called from worker."""
     all_pools = fetch_yield_pools()
-    time.sleep(1)
+    await asyncio.sleep(1)
 
     # Pre-fetch DeFiLlama hacks data (cached 24h, shared across all entities)
     hacks_cache = []

--- a/app/services/tti_disclosure_collector.py
+++ b/app/services/tti_disclosure_collector.py
@@ -17,6 +17,7 @@ Data flow:
   7. Map extractions → raw_values for scoring engine
 """
 
+import asyncio
 import json
 import logging
 import re
@@ -546,7 +547,7 @@ async def collect_entity_disclosures(entity_slug: str, entity_name: str) -> dict
         source_type = source["type"]
 
         logger.info(f"TTI disclosure scraping {entity_slug}: {url}")
-        time.sleep(2)  # Rate limit between sources
+        await asyncio.sleep(2)  # Rate limit between sources
 
         markdown = _try_scrape_page(url, entity_slug=entity_slug)
         if not markdown:
@@ -567,7 +568,7 @@ async def collect_entity_disclosures(entity_slug: str, entity_name: str) -> dict
         if attestation_pdfs:
             # Try Reducto on the most promising PDF
             best_pdf = attestation_pdfs[0]
-            time.sleep(2)
+            await asyncio.sleep(2)
             pdf_result = _try_parse_pdf(entity_slug, best_pdf)
             if pdf_result:
                 result_data = pdf_result.get("result", pdf_result)


### PR DESCRIPTION
## Summary

Replace all 6 `time.sleep()` calls inside async functions with `await asyncio.sleep()`. Each one directly blocks the event loop for the sleep duration.

## Changes

- `app/collectors/governance_proposals.py:481` in `async collect_governance_proposals`: `time.sleep(0.5)` → `await asyncio.sleep(0.5)`
- `app/collectors/governance_proposals.py:486` in `async collect_governance_proposals`: `time.sleep(1)` → `await asyncio.sleep(1)`
- `app/collectors/parameter_history.py:537` in `async check_parameter_changes`: `time.sleep(0.3)` → `await asyncio.sleep(0.3)`
- `app/collectors/vault_collector.py:654` in `async run_vsri_scoring`: `time.sleep(1)` → `await asyncio.sleep(1)`
- `app/services/tti_disclosure_collector.py:549` in `async collect_entity_disclosures`: `time.sleep(2)` → `await asyncio.sleep(2)`
- `app/services/tti_disclosure_collector.py:570` in `async collect_entity_disclosures`: `time.sleep(2)` → `await asyncio.sleep(2)`

Added `import asyncio` to each file that didn't have it. `import time` retained (still used elsewhere in each file).

## Verification

- All 4 files pass `py_compile`
- 4 files changed, 10 insertions, 6 deletions

https://claude.ai/code/session_011bTVc5haorCZgtCtxzJmtq

---
_Generated by [Claude Code](https://claude.ai/code/session_011bTVc5haorCZgtCtxzJmtq)_