### PR TITLE
fix(alerter): Decimal serialization in alert context payload

### DIFF
--- a/app/ops/tools/alerter.py
+++ b/app/ops/tools/alerter.py
@@ -131,7 +131,7 @@ async def send_alert(alert_type: str, message: str, context: dict = None, severi
     try:
         await execute_async(
             "INSERT INTO ops_alert_log (alert_type, channel, message, context) VALUES (%s, %s, %s, %s)",
-            (alert_type, "telegram" if sent_any else "log_only", message, json.dumps(context or {})),
+            (alert_type, "telegram" if sent_any else "log_only", message, json.dumps(context or {}, default=str)),
         )
     except Exception:
         pass


### PR DESCRIPTION
1-line fix: `json.dumps(context or {})` → `json.dumps(context or {}, default=str)`\n\npsycopg2 returns `Decimal` from `EXTRACT(EPOCH FROM ...)`. The health check `round(age_hours, 2)` preserves the Decimal type. `json.dumps` chokes, masking the actual freshness alert content with a serialization error.\n\nhttps://claude.ai/code/session_011bTVc5haorCZgtCtxzJmtq

---
_Generated by [Claude Code](https://claude.ai/code/session_011bTVc5haorCZgtCtxzJmtq)_