### PR TITLE
fix(edges): distinguish API failure from success in edge_build_status

### DIFF
--- a/app/indexer/edges.py
+++ b/app/indexer/edges.py
@@ -113,6 +113,7 @@ async def build_edges_for_wallet(
     edge_map: dict[tuple[str, str], dict] = {}
     total_transfers = 0
     pages_fetched = 0
+    first_page_failed = False
 
     for page in range(1, max_pages + 1):
         transfers = await _fetch_tokentx_page(
@@ -120,6 +121,12 @@ async def build_edges_for_wallet(
             explorer_base=explorer_base, chain_id=chain_id,
         )
         await asyncio.sleep(EXPLORER_RATE_LIMIT_DELAY)
+
+        if transfers is None:
+            if page == 1:
+                first_page_failed = True
+            break
+
         pages_fetched += 1
 
         if not transfers:
@@ -206,26 +213,50 @@ async def build_edges_for_wallet(
         )
         edges_upserted += 1
 
-    # Update build status
-    await execute_async(
-        """
-        INSERT INTO wallet_graph.edge_build_status
-            (wallet_address, chain, last_built_at, transfers_processed, edges_created, pages_fetched, status)
-        VALUES (%s, %s, NOW(), %s, %s, %s, 'complete')
-        ON CONFLICT (wallet_address, chain) DO UPDATE SET
-            last_built_at = NOW(),
-            transfers_processed = EXCLUDED.transfers_processed,
-            edges_created = EXCLUDED.edges_created,
-            pages_fetched = EXCLUDED.pages_fetched,
-            status = 'complete'
-        """,
-        (wallet_lower, chain, total_transfers, edges_upserted, pages_fetched),
-    )
+    # Update build status — only mark complete if API actually responded
+    if first_page_failed:
+        await execute_async(
+            """
+            INSERT INTO wallet_graph.edge_build_status
+                (wallet_address, chain, build_attempted_at, transfers_processed, edges_created, pages_fetched, status)
+            VALUES (%s, %s, NOW(), 0, 0, 0, 'api_failure')
+            ON CONFLICT (wallet_address, chain) DO UPDATE SET
+                build_attempted_at = NOW(),
+                status = 'api_failure'
+            """,
+            (wallet_lower, chain),
+        )
+        try:
+            from app.worker import _record_cycle_error
+            _record_cycle_error(
+                error_type="edge_builder_api_failure",
+                error_message=f"First page fetch returned None for {wallet_lower[:10]}… on {chain}",
+                cycle_phase="edge_builder",
+            )
+        except Exception:
+            pass
+    else:
+        await execute_async(
+            """
+            INSERT INTO wallet_graph.edge_build_status
+                (wallet_address, chain, last_built_at, build_attempted_at, transfers_processed, edges_created, pages_fetched, status)
+            VALUES (%s, %s, NOW(), NOW(), %s, %s, %s, 'complete')
+            ON CONFLICT (wallet_address, chain) DO UPDATE SET
+                last_built_at = NOW(),
+                build_attempted_at = NOW(),
+                transfers_processed = EXCLUDED.transfers_processed,
+                edges_created = EXCLUDED.edges_created,
+                pages_fetched = EXCLUDED.pages_fetched,
+                status = 'complete'
+            """,
+            (wallet_lower, chain, total_transfers, edges_upserted, pages_fetched),
+        )
 
     return {
         "transfers_processed": total_transfers,
         "edges_upserted": edges_upserted,
         "pages_fetched": pages_fetched,
+        "api_failure": first_page_failed,
     }
 
 

--- a/migrations/104_edge_build_attempted_at.sql
+++ b/migrations/104_edge_build_attempted_at.sql
@@ -1,0 +1,14 @@
+-- Migration 104: Add build_attempted_at to edge_build_status
+-- Distinguishes "we tried and it failed" from "we succeeded".
+-- Gate at worker.py:2018 reads last_built_at (success only).
+-- build_attempted_at tracks every attempt regardless of outcome.
+
+ALTER TABLE wallet_graph.edge_build_status
+    ADD COLUMN IF NOT EXISTS build_attempted_at TIMESTAMPTZ;
+
+-- Backfill: existing rows with last_built_at get the same value
+UPDATE wallet_graph.edge_build_status
+SET build_attempted_at = last_built_at
+WHERE last_built_at IS NOT NULL AND build_attempted_at IS NULL;
+
+INSERT INTO migrations (name) VALUES ('104_edge_build_attempted_at') ON CONFLICT DO NOTHING;

--- a/tests/test_edge_build_status.py
+++ b/tests/test_edge_build_status.py
@@ -1,0 +1,79 @@
+"""
+Test: edge_build_status is NOT marked 'complete' when API fails on first page.
+"""
+import asyncio
+import unittest
+from unittest.mock import AsyncMock, patch, MagicMock
+
+
+class TestEdgeBuildStatusOnApiFailure(unittest.TestCase):
+    """Verify that build_edges_for_wallet writes status='api_failure'
+    when _fetch_tokentx_page returns None on page 1."""
+
+    @patch("app.indexer.edges.execute_async", new_callable=AsyncMock)
+    @patch("app.indexer.edges.get_chain_contracts")
+    @patch("app.indexer.edges._fetch_tokentx_page", new_callable=AsyncMock)
+    def test_first_page_none_writes_api_failure(self, mock_fetch, mock_contracts, mock_execute):
+        mock_fetch.return_value = None
+        mock_contracts.return_value = {}
+
+        client = AsyncMock()
+
+        result = asyncio.run(
+            __import__("app.indexer.edges", fromlist=["build_edges_for_wallet"]).build_edges_for_wallet(
+                client, "0x1234567890abcdef1234567890abcdef12345678", "fake_key",
+                max_pages=3, chain="ethereum",
+            )
+        )
+
+        assert result["api_failure"] is True
+        assert result["transfers_processed"] == 0
+        assert result["edges_upserted"] == 0
+
+        # Find the execute_async call that writes to edge_build_status
+        status_calls = [
+            c for c in mock_execute.call_args_list
+            if "edge_build_status" in str(c)
+        ]
+        assert len(status_calls) >= 1, "Expected at least one edge_build_status write"
+
+        status_sql = str(status_calls[0])
+        assert "api_failure" in status_sql, f"Expected status='api_failure' in SQL, got: {status_sql}"
+        assert "last_built_at = NOW()" not in status_sql or "build_attempted_at = NOW()" in status_sql, \
+            "last_built_at should NOT be updated on API failure"
+
+    @patch("app.indexer.edges.execute_async", new_callable=AsyncMock)
+    @patch("app.indexer.edges.get_chain_contracts")
+    @patch("app.indexer.edges._fetch_tokentx_page", new_callable=AsyncMock)
+    def test_successful_fetch_writes_complete(self, mock_fetch, mock_contracts, mock_execute):
+        mock_fetch.side_effect = [
+            [{"contractAddress": "0xabc", "from": "0x111", "to": "0x222",
+              "value": "1000000", "timeStamp": "1700000000"}],
+            [],
+        ]
+        mock_contracts.return_value = {
+            "0xabc": {"decimals": 6, "symbol": "USDC"},
+        }
+
+        client = AsyncMock()
+
+        result = asyncio.run(
+            __import__("app.indexer.edges", fromlist=["build_edges_for_wallet"]).build_edges_for_wallet(
+                client, "0x1234567890abcdef1234567890abcdef12345678", "fake_key",
+                max_pages=3, chain="ethereum",
+            )
+        )
+
+        assert result["api_failure"] is False
+
+        status_calls = [
+            c for c in mock_execute.call_args_list
+            if "edge_build_status" in str(c)
+        ]
+        assert len(status_calls) >= 1
+        status_sql = str(status_calls[0])
+        assert "'complete'" in status_sql, f"Expected status='complete', got: {status_sql}"
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem

`build_edges_for_wallet` writes `status='complete'` and `last_built_at = NOW()` even when `_fetch_tokentx_page` returns `None` on page 1 (API failure). The worker gate at `worker.py:2018` reads `MAX(last_built_at)` and sees fresh timestamps, so it skips edge building — even though no edges were actually built.

## Fix

1. Track `first_page_failed`: if page 1 returns `None`, write `status='api_failure'` and do NOT update `last_built_at`
2. Migration 104: add `build_attempted_at` column (tracks every attempt; `last_built_at` only updates on success)
3. Write to `cycle_errors` with `error_type='edge_builder_api_failure'` for V9.11 Layer 2 visibility
4. Return `api_failure` flag in result dict

## Tests

2 tests pass:
- `test_first_page_none_writes_api_failure` — verifies `status='api_failure'`, `last_built_at` NOT updated
- `test_successful_fetch_writes_complete` — verifies `status='complete'`

https://claude.ai/code/session_011bTVc5haorCZgtCtxzJmtq

---
_Generated by [Claude Code](https://claude.ai/code/session_011bTVc5haorCZgtCtxzJmtq)_