### PR TITLE
fix(edges): classify _fetch_tokentx_page errors for V9.11 Layer 2

### DIFF
--- a/app/indexer/edges.py
+++ b/app/indexer/edges.py
@@ -43,6 +43,37 @@ else:
 _EXPLORER_CHAIN_KEY = "chainid" if BLOCK_EXPLORER_PROVIDER == "etherscan" else "chain_id"
 
 
+class _FetchResult:
+    """Sentinel for _fetch_tokentx_page outcomes."""
+    __slots__ = ("transfers", "error_type", "error_detail")
+
+    def __init__(self, transfers=None, error_type=None, error_detail=None):
+        self.transfers = transfers
+        self.error_type = error_type
+        self.error_detail = error_detail
+
+    @property
+    def ok(self):
+        return self.error_type is None
+
+    @property
+    def transient(self):
+        return self.error_type in ("explorer_timeout", "explorer_network_error", "explorer_server_error")
+
+
+def _record_explorer_error(error_type: str, detail: str, chain: str = "ethereum"):
+    """Write explorer failure to cycle_errors for V9.11 Layer 2 visibility."""
+    try:
+        from app.worker import _record_cycle_error
+        _record_cycle_error(
+            error_type=error_type,
+            error_message=detail[:500],
+            cycle_phase=f"edge_builder:{chain}",
+        )
+    except Exception:
+        pass
+
+
 async def _fetch_tokentx_page(
     client: httpx.AsyncClient,
     wallet_address: str,
@@ -51,8 +82,13 @@ async def _fetch_tokentx_page(
     offset: int = 100,
     explorer_base: str = None,
     chain_id: int = 1,
-) -> list[dict] | None:
-    """Fetch one page of ERC-20 token transfer events for a wallet."""
+) -> _FetchResult:
+    """Fetch one page of ERC-20 token transfer events for a wallet.
+
+    Returns _FetchResult with .transfers (list) on success, or
+    .error_type + .error_detail on failure. Callers use .ok and
+    .transient to decide retry vs escalation.
+    """
     base_url = explorer_base or EXPLORER_BASE
     try:
         resp = await client.get(
@@ -69,17 +105,61 @@ async def _fetch_tokentx_page(
             },
             timeout=15.0,
         )
-        data = resp.json()
-        if data.get("status") == "1" and isinstance(data.get("result"), list):
-            return data["result"]
-        msg = data.get("result", "")
-        if "Max rate limit" in str(msg):
-            logger.warning("Explorer rate limit hit, backing off")
-            await asyncio.sleep(2.0)
-        return None
+    except httpx.TimeoutException:
+        detail = f"Timeout fetching tokentx for {wallet_address[:10]}… page={page}"
+        logger.warning(detail)
+        await asyncio.to_thread(_record_explorer_error, "explorer_timeout", detail)
+        return _FetchResult(error_type="explorer_timeout", error_detail=detail)
+    except httpx.NetworkError as e:
+        detail = f"Network error fetching tokentx for {wallet_address[:10]}…: {e}"
+        logger.warning(detail)
+        await asyncio.to_thread(_record_explorer_error, "explorer_network_error", detail)
+        return _FetchResult(error_type="explorer_network_error", error_detail=detail)
     except Exception as e:
-        logger.debug(f"tokentx fetch error for {wallet_address[:10]}…: {e}")
-        return None
+        detail = f"Unexpected error fetching tokentx for {wallet_address[:10]}…: {type(e).__name__}: {e}"
+        logger.error(detail)
+        await asyncio.to_thread(_record_explorer_error, "explorer_unknown_error", detail)
+        return _FetchResult(error_type="explorer_unknown_error", error_detail=detail)
+
+    if resp.status_code >= 500:
+        detail = f"Explorer returned {resp.status_code} for {wallet_address[:10]}…"
+        logger.warning(detail)
+        await asyncio.to_thread(_record_explorer_error, "explorer_server_error", detail)
+        return _FetchResult(error_type="explorer_server_error", error_detail=detail)
+
+    if resp.status_code in (401, 403):
+        detail = f"Explorer auth failure ({resp.status_code}) for {wallet_address[:10]}…"
+        logger.error(detail)
+        await asyncio.to_thread(_record_explorer_error, "explorer_auth_failure", detail)
+        return _FetchResult(error_type="explorer_auth_failure", error_detail=detail)
+
+    if resp.status_code == 429:
+        detail = "Explorer rate limit (HTTP 429)"
+        logger.warning(detail)
+        await asyncio.to_thread(_record_explorer_error, "explorer_rate_limit", detail)
+        await asyncio.sleep(2.0)
+        return _FetchResult(error_type="explorer_rate_limit", error_detail=detail)
+
+    try:
+        data = resp.json()
+    except Exception as e:
+        detail = f"Malformed JSON from explorer for {wallet_address[:10]}…: {e}"
+        logger.error(detail)
+        await asyncio.to_thread(_record_explorer_error, "explorer_malformed_response", detail)
+        return _FetchResult(error_type="explorer_malformed_response", error_detail=detail)
+
+    if data.get("status") == "1" and isinstance(data.get("result"), list):
+        return _FetchResult(transfers=data["result"])
+
+    msg = data.get("result", "")
+    if "Max rate limit" in str(msg):
+        detail = f"Explorer rate limit (in-body) for {wallet_address[:10]}…"
+        logger.warning(detail)
+        await asyncio.to_thread(_record_explorer_error, "explorer_rate_limit", detail)
+        await asyncio.sleep(2.0)
+        return _FetchResult(error_type="explorer_rate_limit", error_detail=detail)
+
+    return _FetchResult(transfers=[])
 
 
 def _compute_weight(total_value_usd: float, transfer_count: int, last_transfer_at: datetime) -> float:
@@ -114,19 +194,26 @@ async def build_edges_for_wallet(
     total_transfers = 0
     pages_fetched = 0
     first_page_failed = False
+    consecutive_transient = 0
 
     for page in range(1, max_pages + 1):
-        transfers = await _fetch_tokentx_page(
+        result = await _fetch_tokentx_page(
             client, wallet_lower, api_key, page=page,
             explorer_base=explorer_base, chain_id=chain_id,
         )
         await asyncio.sleep(EXPLORER_RATE_LIMIT_DELAY)
 
-        if transfers is None:
+        if not result.ok:
             if page == 1:
                 first_page_failed = True
+            if result.transient:
+                consecutive_transient += 1
+                if consecutive_transient < 3:
+                    continue
             break
 
+        consecutive_transient = 0
+        transfers = result.transfers
         pages_fetched += 1
 
         if not transfers:
@@ -213,7 +300,7 @@ async def build_edges_for_wallet(
         )
         edges_upserted += 1
 
-    # Update build status — only mark complete if API actually responded
+    # Update build status — only mark complete if API responded
     if first_page_failed:
         await execute_async(
             """
@@ -226,15 +313,6 @@ async def build_edges_for_wallet(
             """,
             (wallet_lower, chain),
         )
-        try:
-            from app.worker import _record_cycle_error
-            _record_cycle_error(
-                error_type="edge_builder_api_failure",
-                error_message=f"First page fetch returned None for {wallet_lower[:10]}… on {chain}",
-                cycle_phase="edge_builder",
-            )
-        except Exception:
-            pass
     else:
         await execute_async(
             """

--- a/tests/test_edge_build_status.py
+++ b/tests/test_edge_build_status.py
@@ -14,7 +14,8 @@ class TestEdgeBuildStatusOnApiFailure(unittest.TestCase):
     @patch("app.indexer.edges.get_chain_contracts")
     @patch("app.indexer.edges._fetch_tokentx_page", new_callable=AsyncMock)
     def test_first_page_none_writes_api_failure(self, mock_fetch, mock_contracts, mock_execute):
-        mock_fetch.return_value = None
+        from app.indexer.edges import _FetchResult
+        mock_fetch.return_value = _FetchResult(error_type="explorer_timeout", error_detail="test")
         mock_contracts.return_value = {}
 
         client = AsyncMock()
@@ -46,10 +47,11 @@ class TestEdgeBuildStatusOnApiFailure(unittest.TestCase):
     @patch("app.indexer.edges.get_chain_contracts")
     @patch("app.indexer.edges._fetch_tokentx_page", new_callable=AsyncMock)
     def test_successful_fetch_writes_complete(self, mock_fetch, mock_contracts, mock_execute):
+        from app.indexer.edges import _FetchResult
         mock_fetch.side_effect = [
-            [{"contractAddress": "0xabc", "from": "0x111", "to": "0x222",
-              "value": "1000000", "timeStamp": "1700000000"}],
-            [],
+            _FetchResult(transfers=[{"contractAddress": "0xabc", "from": "0x111", "to": "0x222",
+              "value": "1000000", "timeStamp": "1700000000"}]),
+            _FetchResult(transfers=[]),
         ]
         mock_contracts.return_value = {
             "0xabc": {"decimals": 6, "symbol": "USDC"},

--- a/tests/test_fetch_tokentx_errors.py
+++ b/tests/test_fetch_tokentx_errors.py
@@ -1,0 +1,122 @@
+"""
+Test: _fetch_tokentx_page error classification.
+Each exception type should produce a specific error_type and write to cycle_errors.
+"""
+import asyncio
+import unittest
+from unittest.mock import AsyncMock, patch, MagicMock
+
+import httpx
+
+
+class TestFetchTokentxErrorClassification(unittest.TestCase):
+
+    def _run(self, coro):
+        return asyncio.run(coro)
+
+    def _make_client(self, side_effect=None, response=None):
+        client = AsyncMock(spec=httpx.AsyncClient)
+        if side_effect:
+            client.get.side_effect = side_effect
+        elif response:
+            client.get.return_value = response
+        return client
+
+    def _make_response(self, status_code, json_data=None, text=""):
+        resp = MagicMock()
+        resp.status_code = status_code
+        resp.json.return_value = json_data or {}
+        resp.text = text
+        return resp
+
+    @patch("app.indexer.edges._record_explorer_error")
+    def test_timeout_returns_transient(self, mock_record):
+        from app.indexer.edges import _fetch_tokentx_page
+        client = self._make_client(side_effect=httpx.TimeoutException("timed out"))
+        result = self._run(_fetch_tokentx_page(client, "0x1234", "key"))
+        assert not result.ok
+        assert result.error_type == "explorer_timeout"
+        assert result.transient
+        mock_record.assert_called_once()
+        assert mock_record.call_args[0][0] == "explorer_timeout"
+
+    @patch("app.indexer.edges._record_explorer_error")
+    def test_network_error_returns_transient(self, mock_record):
+        from app.indexer.edges import _fetch_tokentx_page
+        client = self._make_client(side_effect=httpx.NetworkError("connection reset"))
+        result = self._run(_fetch_tokentx_page(client, "0x1234", "key"))
+        assert not result.ok
+        assert result.error_type == "explorer_network_error"
+        assert result.transient
+
+    @patch("app.indexer.edges._record_explorer_error")
+    def test_http_500_returns_transient(self, mock_record):
+        from app.indexer.edges import _fetch_tokentx_page
+        resp = self._make_response(502)
+        client = self._make_client(response=resp)
+        result = self._run(_fetch_tokentx_page(client, "0x1234", "key"))
+        assert not result.ok
+        assert result.error_type == "explorer_server_error"
+        assert result.transient
+
+    @patch("app.indexer.edges._record_explorer_error")
+    def test_http_401_returns_auth_failure(self, mock_record):
+        from app.indexer.edges import _fetch_tokentx_page
+        resp = self._make_response(401)
+        client = self._make_client(response=resp)
+        result = self._run(_fetch_tokentx_page(client, "0x1234", "key"))
+        assert not result.ok
+        assert result.error_type == "explorer_auth_failure"
+        assert not result.transient
+
+    @patch("app.indexer.edges._record_explorer_error")
+    def test_http_429_returns_rate_limit(self, mock_record):
+        from app.indexer.edges import _fetch_tokentx_page
+        resp = self._make_response(429)
+        client = self._make_client(response=resp)
+        result = self._run(_fetch_tokentx_page(client, "0x1234", "key"))
+        assert not result.ok
+        assert result.error_type == "explorer_rate_limit"
+        assert not result.transient
+
+    @patch("app.indexer.edges._record_explorer_error")
+    def test_malformed_json_returns_error(self, mock_record):
+        from app.indexer.edges import _fetch_tokentx_page
+        resp = self._make_response(200)
+        resp.json.side_effect = ValueError("invalid json")
+        client = self._make_client(response=resp)
+        result = self._run(_fetch_tokentx_page(client, "0x1234", "key"))
+        assert not result.ok
+        assert result.error_type == "explorer_malformed_response"
+        assert not result.transient
+
+    @patch("app.indexer.edges._record_explorer_error")
+    def test_rate_limit_in_body_returns_error(self, mock_record):
+        from app.indexer.edges import _fetch_tokentx_page
+        resp = self._make_response(200, json_data={"status": "0", "result": "Max rate limit reached"})
+        client = self._make_client(response=resp)
+        result = self._run(_fetch_tokentx_page(client, "0x1234", "key"))
+        assert not result.ok
+        assert result.error_type == "explorer_rate_limit"
+
+    def test_success_returns_transfers(self):
+        from app.indexer.edges import _fetch_tokentx_page
+        transfers = [{"hash": "0xabc", "from": "0x1", "to": "0x2"}]
+        resp = self._make_response(200, json_data={"status": "1", "result": transfers})
+        client = self._make_client(response=resp)
+        result = self._run(_fetch_tokentx_page(client, "0x1234", "key"))
+        assert result.ok
+        assert result.transfers == transfers
+        assert not result.transient
+
+    def test_empty_result_returns_ok_empty(self):
+        from app.indexer.edges import _fetch_tokentx_page
+        resp = self._make_response(200, json_data={"status": "0", "result": "No transactions found"})
+        client = self._make_client(response=resp)
+        result = self._run(_fetch_tokentx_page(client, "0x1234", "key"))
+        assert result.ok
+        assert result.transfers == []
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem

`_fetch_tokentx_page` had `except Exception: logger.debug(); return None` — every API failure (rate limit, auth, network, 5xx) was invisible to cycle_errors, the alerter, and the integrity check.

## Fix

Replace bare except with structured error classification via `_FetchResult` sentinel:

| Error | Type | Transient? | Action |
|-------|------|-----------|--------|
| httpx.TimeoutException | `explorer_timeout` | Yes | Retry up to 3x |
| httpx.NetworkError | `explorer_network_error` | Yes | Retry up to 3x |
| HTTP 5xx | `explorer_server_error` | Yes | Retry up to 3x |
| HTTP 401/403 | `explorer_auth_failure` | No | Fail loud, break |
| HTTP 429 / in-body rate limit | `explorer_rate_limit` | No | Fail loud, break |
| Malformed JSON | `explorer_malformed_response` | No | Fail loud, break |

Every error type writes to `cycle_errors` via `_record_explorer_error` for V9.11 Layer 2 visibility.

`build_edges_for_wallet` updated to use `_FetchResult.ok` / `.transient` — retries transient errors up to 3x, writes `status='api_failure'` on first-page failure.

## Tests

9 tests covering all error paths — all pass.

https://claude.ai/code/session_011bTVc5haorCZgtCtxzJmtq

---
_Generated by [Claude Code](https://claude.ai/code/session_011bTVc5haorCZgtCtxzJmtq)_