### PR TITLE
fix(integrity): rename actor_classification domain key to actors (#84a)

### DIFF
--- a/app/integrity.py
+++ b/app/integrity.py
@@ -416,7 +416,7 @@ DOMAINS = {
         "max_age_hours": 26,
         "coherence_rules": [_pulse_summary_coherence],
     },
-    "actor_classification": {
+    "actors": {
         "freshness_query": "SELECT COUNT(*) AS cnt, MAX(classified_at) AS latest FROM wallet_graph.actor_classifications WHERE actor_type != 'unknown'",
         "max_age_hours": 48,
         "coherence_rules": [_actor_probability_range, _actor_type_consistency],


### PR DESCRIPTION
## Summary

Rename DOMAINS key from `"actor_classification"` to `"actors"` in `app/integrity.py:419` to match the attestation domain name used by `attest_state("actors", ...)` in `app/actor_classification.py:384`.

## What changed

1 line: dict key rename. Freshness query, coherence rules, max_age_hours all unchanged.

## Why

The mismatch meant any cross-reference between the integrity sweep and `state_attestations` table would silently fail to join. The integrity check worked despite the mismatch because it queries `wallet_graph.actor_classifications` directly for freshness (not `state_attestations`), but the domain name inconsistency is a latent bug for #84b (work-availability conditioning) which will need to correlate domains across both systems.

## Breaking change

`/api/integrity/actor_classification` → `/api/integrity/actors`. Internal ops endpoint only.

https://claude.ai/code/session_011bTVc5haorCZgtCtxzJmtq

---
_Generated by [Claude Code](https://claude.ai/code/session_011bTVc5haorCZgtCtxzJmtq)_