### PR TITLE
migration(105): indexes for actor_classification candidate query (#85a)

### DIFF
--- a/migrations/105_actor_classification_indexes.sql
+++ b/migrations/105_actor_classification_indexes.sql
@@ -1,0 +1,23 @@
+-- Migration 105: Indexes for actor_classification candidate query
+--
+-- The candidate query at app/actor_classification.py:322-345 uses
+-- correlated EXISTS with LOWER() on wallet_edges. Without indexes,
+-- this forces a sequential scan over 710K wallets × 256K edges.
+-- Query hung in production since April 12 (23+ days stale).
+--
+-- CONCURRENTLY avoids locking wallet_edges during build.
+-- IF NOT EXISTS makes this idempotent and rerunnable.
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS
+    idx_wallet_edges_from_lower_last
+    ON wallet_graph.wallet_edges (LOWER(from_address), last_transfer_at DESC);
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS
+    idx_wallet_edges_to_lower_last
+    ON wallet_graph.wallet_edges (LOWER(to_address), last_transfer_at DESC);
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS
+    idx_actor_classifications_wallet_classified
+    ON wallet_graph.actor_classifications (wallet_address, classified_at);
+
+INSERT INTO migrations (name) VALUES ('105_actor_classification_indexes') ON CONFLICT DO NOTHING;


### PR DESCRIPTION
## Problem

The candidate query at `actor_classification.py:322-345` uses correlated EXISTS with `LOWER()` on `wallet_edges` addresses. Without expression indexes, Postgres does seq scan over 710K wallets × 256K edges. Query hung in production since April 12 — actors domain stale 23+ days.

## Fix

Migration 105: three expression indexes (all `CONCURRENTLY`, `IF NOT EXISTS`):

1. `idx_wallet_edges_from_lower_last` on `(LOWER(from_address), last_transfer_at DESC)`
2. `idx_wallet_edges_to_lower_last` on `(LOWER(to_address), last_transfer_at DESC)`
3. `idx_actor_classifications_wallet_classified` on `(wallet_address, classified_at)`

## Verification

After applying, run EXPLAIN ANALYZE on the candidate query — should show Index Scan instead of Seq Scan, complete in < 5s.

## Sequencing

Apply this first. If indexes alone bring query under 2s, #85b (query rewrite) becomes optional (but the error handling fixes in #85b should still ship).

https://claude.ai/code/session_011bTVc5haorCZgtCtxzJmtq

---
_Generated by [Claude Code](https://claude.ai/code/session_011bTVc5haorCZgtCtxzJmtq)_