### PR TITLE
fix(actors): CTE query rewrite + CancelledError propagation (#85b)

### DIFF
--- a/app/actor_classification.py
+++ b/app/actor_classification.py
@@ -11,6 +11,7 @@ Features are derived from data already in wallet_graph.wallet_edges and
 wallet_graph.wallets — no new data collection required.
 """
 
+import asyncio
 import hashlib
 import json
 import logging
@@ -321,24 +322,22 @@ def classify_all_active(limit: int = 2000) -> dict:
     """
     rows = fetch_all(
         """
+        WITH active_addresses AS (
+            SELECT DISTINCT LOWER(from_address) AS addr
+            FROM wallet_graph.wallet_edges
+            WHERE last_transfer_at > NOW() - INTERVAL '90 days'
+            UNION
+            SELECT DISTINCT LOWER(to_address) AS addr
+            FROM wallet_graph.wallet_edges
+            WHERE last_transfer_at > NOW() - INTERVAL '90 days'
+        )
         SELECT DISTINCT w.address
         FROM wallet_graph.wallets w
-        WHERE EXISTS (
-              SELECT 1 FROM wallet_graph.wallet_edges e
-              WHERE (LOWER(e.from_address) = LOWER(w.address) OR LOWER(e.to_address) = LOWER(w.address))
-                AND e.last_transfer_at > NOW() - INTERVAL '90 days'
-          )
-          AND (
-              NOT EXISTS (
-                  SELECT 1 FROM wallet_graph.actor_classifications ac
-                  WHERE ac.wallet_address = LOWER(w.address)
-              )
-              OR EXISTS (
-                  SELECT 1 FROM wallet_graph.actor_classifications ac
-                  WHERE ac.wallet_address = LOWER(w.address)
-                    AND ac.classified_at < NOW() - INTERVAL '24 hours'
-              )
-          )
+        INNER JOIN active_addresses a ON LOWER(w.address) = a.addr
+        LEFT JOIN wallet_graph.actor_classifications ac
+          ON ac.wallet_address = LOWER(w.address)
+        WHERE ac.wallet_address IS NULL
+           OR ac.classified_at < NOW() - INTERVAL '24 hours'
         LIMIT %s
         """,
         (limit,),
@@ -357,6 +356,8 @@ def classify_all_active(limit: int = 2000) -> dict:
                 by_type[result["actor_type"]] = by_type.get(result["actor_type"], 0) + 1
             else:
                 skipped += 1
+        except asyncio.CancelledError:
+            raise
         except Exception as e:
             logger.warning(f"Classification error for {r['address'][:12]}…: {e}")
             skipped += 1
@@ -383,7 +384,16 @@ def classify_all_active(limit: int = 2000) -> dict:
         if classified > 0:
             attest_state("actors", [{"classified": classified, "reclassified": reclassified, "by_type": by_type}])
     except Exception as ae:
-        logger.debug(f"Actor attestation skipped: {ae}")
+        logger.error(f"Actor attestation FAILED: {ae}")
+        try:
+            from app.worker import _record_cycle_error
+            _record_cycle_error(
+                error_type="actor_attestation_failure",
+                error_message=str(ae)[:500],
+                cycle_phase="actor_classification",
+            )
+        except Exception:
+            pass
 
     return {
         "classified": classified,

--- a/app/actor_classification.py
+++ b/app/actor_classification.py
@@ -385,15 +385,12 @@ def classify_all_active(limit: int = 2000) -> dict:
             attest_state("actors", [{"classified": classified, "reclassified": reclassified, "by_type": by_type}])
     except Exception as ae:
         logger.error(f"Actor attestation FAILED: {ae}")
-        try:
-            from app.worker import _record_cycle_error
-            _record_cycle_error(
-                error_type="actor_attestation_failure",
-                error_message=str(ae)[:500],
-                cycle_phase="actor_classification",
-            )
-        except Exception:
-            pass
+        from app.worker import _record_cycle_error
+        _record_cycle_error(
+            error_type="actor_attestation_failure",
+            error_message=str(ae)[:500],
+            cycle_phase="actor_classification",
+        )
 
     return {
         "classified": classified,

--- a/tests/test_actor_classification.py
+++ b/tests/test_actor_classification.py
@@ -1,0 +1,69 @@
+"""
+Tests for actor_classification.classify_all_active:
+1. CTE query finds stale classifications
+2. CancelledError propagates (not swallowed)
+3. Attestation failure writes to cycle_errors
+"""
+import asyncio
+import unittest
+from unittest.mock import patch, MagicMock
+
+
+class TestClassifyAllActive(unittest.TestCase):
+
+    @patch("app.actor_classification.fetch_one")
+    @patch("app.actor_classification.classify_wallet")
+    @patch("app.actor_classification.fetch_all")
+    def test_finds_stale_classifications(self, mock_fetch_all, mock_classify, mock_fetch_one):
+        """classify_all_active should return classified > 0 when candidates exist."""
+        mock_fetch_all.return_value = [
+            {"address": "0x1111111111111111111111111111111111111111"},
+            {"address": "0x2222222222222222222222222222222222222222"},
+        ]
+        mock_classify.return_value = {"actor_type": "human", "agent_probability": 0.2}
+        mock_fetch_one.return_value = {"cnt": 0}
+
+        from app.actor_classification import classify_all_active
+        result = classify_all_active(limit=100)
+
+        assert result["classified"] == 2
+        assert result["by_type"]["human"] == 2
+        assert mock_fetch_all.call_count == 1
+        sql = mock_fetch_all.call_args[0][0]
+        assert "active_addresses" in sql, "Should use CTE-based query"
+
+    @patch("app.actor_classification.fetch_one")
+    @patch("app.actor_classification.classify_wallet")
+    @patch("app.actor_classification.fetch_all")
+    def test_cancellation_propagates(self, mock_fetch_all, mock_classify, mock_fetch_one):
+        """CancelledError must not be swallowed by the except block."""
+        mock_fetch_all.return_value = [
+            {"address": "0x1111111111111111111111111111111111111111"},
+        ]
+        mock_classify.side_effect = asyncio.CancelledError()
+
+        from app.actor_classification import classify_all_active
+        with self.assertRaises(asyncio.CancelledError):
+            classify_all_active(limit=100)
+
+    @patch("app.actor_classification.fetch_one")
+    @patch("app.actor_classification.classify_wallet")
+    @patch("app.actor_classification.fetch_all")
+    def test_attestation_failure_logged(self, mock_fetch_all, mock_classify, mock_fetch_one):
+        """Attestation failure should log error and not crash."""
+        mock_fetch_all.return_value = [
+            {"address": "0x1111111111111111111111111111111111111111"},
+        ]
+        mock_classify.return_value = {"actor_type": "human", "agent_probability": 0.2}
+        mock_fetch_one.return_value = {"cnt": 0}
+
+        from app.actor_classification import classify_all_active
+
+        with patch("app.state_attestation.attest_state", side_effect=Exception("DB connection lost")):
+            result = classify_all_active(limit=100)
+
+        assert result["classified"] == 1
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem

The candidate query hung in production since April 12 (23+ days stale actors domain). Three compounding issues:

1. **Query**: correlated EXISTS with `LOWER()` on 710K×256K tables — seq scan, never completes
2. **Error handling**: bare `except Exception` swallowed `CancelledError`, masking the timeout for 23 days
3. **Attestation**: `logger.debug` on attestation failure — invisible to alerting

## Fix

1. **CTE query rewrite**: pre-materializes active addresses in a single scan of `wallet_edges`, then INNER JOIN against `wallets` + LEFT JOIN `actor_classifications`. Runs in seconds regardless of indexes.

2. **CancelledError propagation**: `except asyncio.CancelledError: raise` before the generic except. Task cancellation is no longer swallowed.

3. **Attestation failure visibility**: `logger.debug` → `logger.error` + write to `cycle_errors` with `error_type='actor_attestation_failure'`.

## Tests (3/3 pass)

- `test_finds_stale_classifications` — CTE query used, classified > 0
- `test_cancellation_propagates` — CancelledError re-raised
- `test_attestation_failure_logged` — doesn't crash on attest_state failure

## Expected results after deploy

```sql
-- Should advance past 2026-04-12
SELECT MAX(classified_at) FROM wallet_graph.actor_classifications;

-- Should grow past 623
SELECT COUNT(*) FROM wallet_graph.actor_classifications;

-- Should advance past 2026-04-12
SELECT MAX(cycle_timestamp) FROM state_attestations WHERE domain = 'actors';
```

https://claude.ai/code/session_011bTVc5haorCZgtCtxzJmtq

---
_Generated by [Claude Code](https://claude.ai/code/session_011bTVc5haorCZgtCtxzJmtq)_