### PR TITLE
fix(enrichment): register actor_classification as enrichment task (#87)

### DIFF
--- a/app/enrichment_worker.py
+++ b/app/enrichment_worker.py
@@ -415,6 +415,17 @@ async def run_enrichment_pipeline() -> dict:
         timeout_seconds=900, group="wallet", priority=3,
     ))
 
+    # ---- Actor classification ----
+
+    async def _run_actor_classification():
+        from app.actor_classification import classify_all_active
+        return await asyncio.to_thread(classify_all_active)
+
+    pipeline.add(EnrichmentTask(
+        name="actor_classification", func=_run_actor_classification,
+        timeout_seconds=600, group="wallet", priority=2,
+    ))
+
     # ---- Wallet expansion + profiles ----
 
     async def _run_wallet_expansion():

--- a/tests/test_actor_enrichment_registration.py
+++ b/tests/test_actor_enrichment_registration.py
@@ -1,0 +1,43 @@
+"""
+Test: actor_classification is registered in the enrichment pipeline.
+"""
+import unittest
+from unittest.mock import patch, MagicMock
+
+
+class TestActorClassificationRegistered(unittest.TestCase):
+
+    @patch("app.enrichment_worker.make_db_gate", return_value=lambda: True)
+    def test_actor_classification_in_pipeline(self, mock_gate):
+        from app.enrichment_worker import run_enrichment_pipeline, EnrichmentPipeline
+
+        # Build the pipeline by inspecting what run_enrichment_pipeline registers.
+        # The pipeline is built inside run_enrichment_pipeline, so we need to
+        # intercept the EnrichmentPipeline.add calls.
+        added_tasks = []
+        original_add = EnrichmentPipeline.add
+
+        def capture_add(self, task):
+            added_tasks.append(task)
+            return original_add(self, task)
+
+        with patch.object(EnrichmentPipeline, "add", capture_add):
+            with patch.object(EnrichmentPipeline, "run", return_value=[]):
+                import asyncio
+                try:
+                    asyncio.run(run_enrichment_pipeline())
+                except Exception:
+                    pass
+
+        task_names = [t.name for t in added_tasks]
+        assert "actor_classification" in task_names, \
+            f"actor_classification not found in pipeline tasks: {task_names}"
+
+        actor_task = next(t for t in added_tasks if t.name == "actor_classification")
+        assert actor_task.group == "wallet"
+        assert actor_task.timeout_seconds == 600
+        assert actor_task.priority == 2
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem

`classify_all_active` was orphaned from the enrichment pipeline when `run_slow_cycle_parallel` replaced sequential `run_slow_cycle` in commit 80cc170 (2026-04-13). The function existed but was never called — `actor_classifications` frozen at 623 rows / 2026-04-12 for 23 days.

## Fix

Register `actor_classification` as an `EnrichmentTask` in `app/enrichment_worker.py`:

- **group**: `wallet` (same as `wallet_reindex`)
- **priority**: 2 (runs after `wallet_expansion` which feeds it new wallets)
- **timeout**: 600s (generous — per-wallet feature extraction can be slow even with new indexes from migration 105)
- Wrapped in `asyncio.to_thread` since `classify_all_active` is sync

## Test

`test_actor_classification_in_pipeline` — confirms task appears in pipeline with correct name, group, timeout, priority.

## Verification after deploy

```sql
-- After 10-15 min for next cycle:
SELECT MAX(classified_at) AS last_classified, COUNT(*) AS total FROM wallet_graph.actor_classifications;
-- Expect: last_classified = today, total > 623

SELECT MAX(cycle_timestamp) FROM state_attestations WHERE domain = 'actors';
-- Expect: today's timestamp
```

Also check worker logs for `[enrichment] [actor_classification] starting...` and `[enrichment] [actor_classification] complete in Ns`.

https://claude.ai/code/session_011bTVc5haorCZgtCtxzJmtq

---
_Generated by [Claude Code](https://claude.ai/code/session_011bTVc5haorCZgtCtxzJmtq)_