### PR TITLE
fix(rpi): relocate rpi_components attestation into enrichment task

### DIFF
--- a/app/enrichment_worker.py
+++ b/app/enrichment_worker.py
@@ -335,7 +335,30 @@ async def run_enrichment_pipeline() -> dict:
             logger.warning(f"RPI incident detection failed: {e}")
 
         from app.rpi.scorer import run_rpi_scoring
-        return await asyncio.to_thread(run_rpi_scoring)
+        result = await asyncio.to_thread(run_rpi_scoring)
+
+        # Attest RPI component scores
+        try:
+            from app.state_attestation import attest_state
+            if result:
+                records = [
+                    {"slug": r.get("protocol_slug", ""), "score": r.get("overall_score")}
+                    for r in result if isinstance(r, dict)
+                ]
+                await asyncio.to_thread(attest_state, "rpi_components", records)
+        except Exception as ae:
+            logger.error(f"RPI components attestation failed: {ae}")
+            try:
+                from app.worker import _record_cycle_error
+                _record_cycle_error(
+                    error_type="rpi_components_attestation_failure",
+                    error_message=str(ae),
+                    cycle_phase="enrichment",
+                )
+            except Exception:
+                pass
+
+        return result
 
     pipeline.add(EnrichmentTask(
         name="rpi_scoring", func=_run_rpi,

--- a/app/worker.py
+++ b/app/worker.py
@@ -1755,18 +1755,6 @@ async def run_slow_cycle():
             from app.rpi.scorer import run_rpi_scoring
             rpi_results = await asyncio.to_thread(run_rpi_scoring)
             logger.info(f"RPI scoring complete: {len(rpi_results)} protocols scored")
-
-            # Attest RPI scores (14th domain)
-            try:
-                from app.state_attestation import attest_state
-                if rpi_results:
-                    _loop = asyncio.get_event_loop()
-                    await _loop.run_in_executor(None, attest_state, "rpi_components", [
-                        {"slug": r.get("protocol_slug", ""), "score": r.get("overall_score")}
-                        for r in rpi_results if isinstance(r, dict)
-                    ])
-            except Exception as ae:
-                logger.debug(f"RPI attestation skipped: {ae}")
         else:
             logger.info(f"RPI scoring skipped — last ran {rpi_age_hours:.0f}h ago")
     except Exception as e:

--- a/tests/test_rpi_attestation.py
+++ b/tests/test_rpi_attestation.py
@@ -1,0 +1,44 @@
+"""Verify that _run_rpi() in enrichment_worker calls attest_state for rpi_components."""
+
+import asyncio
+from unittest.mock import patch, MagicMock, AsyncMock
+
+
+def test_run_rpi_calls_attest_state():
+    """The rpi_scoring enrichment task must attest rpi_components after scoring."""
+    fake_results = [{"protocol_slug": "aave", "overall_score": 75.5}]
+
+    with (
+        patch("app.rpi.snapshot_collector.collect_snapshot_proposals"),
+        patch("app.rpi.tally_collector.collect_tally_proposals"),
+        patch("app.rpi.parameter_collector.collect_parameter_changes"),
+        patch("app.rpi.forum_scraper.scrape_all_forums"),
+        patch("app.rpi.forum_scraper.update_vendor_diversity_lens"),
+        patch("app.rpi.docs_scorer.score_all_docs"),
+        patch("app.rpi.incident_detector.run_incident_detection"),
+        patch("app.rpi.scorer.run_rpi_scoring", return_value=fake_results),
+        patch("app.state_attestation.attest_state") as mock_attest,
+    ):
+        from app.enrichment_worker import run_enrichment_pipeline, EnrichmentPipeline
+
+        # Patch the pipeline so we only run the rpi_scoring task
+        original_add = EnrichmentPipeline.add
+
+        captured_rpi_func = None
+
+        def selective_add(self, task):
+            nonlocal captured_rpi_func
+            if task.name == "rpi_scoring":
+                captured_rpi_func = task.func
+                # Remove the gate so it always runs
+                task.gate_check = None
+                original_add(self, task)
+            # Skip all other tasks
+
+        with patch.object(EnrichmentPipeline, "add", selective_add):
+            asyncio.run(run_enrichment_pipeline())
+
+        mock_attest.assert_called_once()
+        call_args = mock_attest.call_args
+        assert call_args[0][0] == "rpi_components"
+        assert call_args[0][1] == [{"slug": "aave", "score": 75.5}]


### PR DESCRIPTION
Relocate `attest_state("rpi_components", ...)` from orphaned `worker.py:1764` into `enrichment_worker.py:_run_rpi()`. Delete dead block from worker.py. Test verifies attestation fires with correct domain and records shape.\n\nhttps://claude.ai/code/session_011bTVc5haorCZgtCtxzJmtq

---
_Generated by [Claude Code](https://claude.ai/code/session_011bTVc5haorCZgtCtxzJmtq)_