### PR TITLE
fix(psi): relocate psi_discoveries attestation into enrichment task

### DIFF
--- a/app/enrichment_worker.py
+++ b/app/enrichment_worker.py
@@ -241,6 +241,48 @@ def make_db_gate(query: str, min_hours: float = 24) -> Callable[[], bool]:
 # ``await asyncio.to_thread(task.gate_check)`` in _execute_task.
 _db_gate = make_db_gate
 
+
+async def _run_psi_expansion():
+    """PSI expansion: sync collateral, discover, enrich, promote protocols."""
+    from app.collectors.psi_collector import (
+        collect_collateral_exposure,
+        sync_collateral_to_backlog,
+        discover_protocols,
+        enrich_protocol_backlog,
+        promote_eligible_protocols,
+    )
+    await asyncio.to_thread(collect_collateral_exposure)
+    synced = await asyncio.to_thread(sync_collateral_to_backlog)
+    discovered = await asyncio.to_thread(discover_protocols)
+    enriched = await asyncio.to_thread(enrich_protocol_backlog)
+    promoted = await asyncio.to_thread(promote_eligible_protocols)
+    result = {
+        "synced": synced, "discovered": discovered,
+        "enriched": enriched, "promoted": promoted,
+    }
+    # Attest PSI discovery state when new protocols discovered or promoted
+    if discovered or promoted:
+        try:
+            from app.state_attestation import attest_state
+            await asyncio.to_thread(
+                attest_state,
+                "psi_discoveries",
+                [{"synced": synced, "discovered": discovered, "enriched": enriched, "promoted": promoted}],
+            )
+        except Exception as ae:
+            logger.error(f"[enrichment] psi_discoveries attestation failed: {ae}")
+            try:
+                from app.worker import _record_cycle_error
+                _record_cycle_error(
+                    error_type="psi_discoveries_attestation_failure",
+                    error_message=str(ae),
+                    cycle_phase="psi_expansion",
+                )
+            except Exception:
+                pass
+    return result
+
+
 async def run_enrichment_pipeline() -> dict:
     """
     Build and run the full enrichment pipeline.
@@ -566,24 +608,6 @@ async def run_enrichment_pipeline() -> dict:
     ))
 
     # ---- PSI expansion pipeline ----
-
-    async def _run_psi_expansion():
-        from app.collectors.psi_collector import (
-            collect_collateral_exposure,
-            sync_collateral_to_backlog,
-            discover_protocols,
-            enrich_protocol_backlog,
-            promote_eligible_protocols,
-        )
-        await asyncio.to_thread(collect_collateral_exposure)
-        synced = await asyncio.to_thread(sync_collateral_to_backlog)
-        discovered = await asyncio.to_thread(discover_protocols)
-        enriched = await asyncio.to_thread(enrich_protocol_backlog)
-        promoted = await asyncio.to_thread(promote_eligible_protocols)
-        return {
-            "synced": synced, "discovered": discovered,
-            "enriched": enriched, "promoted": promoted,
-        }
 
     pipeline.add(EnrichmentTask(
         name="psi_expansion", func=_run_psi_expansion,

--- a/app/worker.py
+++ b/app/worker.py
@@ -2392,13 +2392,6 @@ async def run_slow_cycle():
                 f"PSI expansion: {synced} stablecoins synced, {discovered} discovered, "
                 f"{enriched} enriched, {promoted} promoted"
             )
-            try:
-                from app.state_attestation import attest_state
-                if discovered or promoted:
-                    _loop = asyncio.get_event_loop()
-                    await _loop.run_in_executor(None, attest_state, "psi_discoveries", [{"synced": synced, "discovered": discovered, "enriched": enriched, "promoted": promoted}])
-            except Exception as ae:
-                logger.debug(f"PSI discovery attestation skipped: {ae}")
         else:
             logger.info(f"PSI expansion skipped — last ran {hours_since:.0f}h ago")
     except Exception as e:

--- a/tests/test_psi_discoveries_attestation.py
+++ b/tests/test_psi_discoveries_attestation.py
@@ -1,0 +1,50 @@
+"""Tests for psi_discoveries attestation in the enrichment pipeline."""
+
+import asyncio
+from unittest.mock import patch, MagicMock
+
+
+def test_psi_expansion_attests_when_discovered_or_promoted():
+    """When discover_protocols or promote_eligible_protocols return >0,
+    attest_state should be called with domain='psi_discoveries'."""
+    mock_attest = MagicMock()
+
+    with (
+        patch("app.collectors.psi_collector.collect_collateral_exposure"),
+        patch("app.collectors.psi_collector.sync_collateral_to_backlog", return_value=5),
+        patch("app.collectors.psi_collector.discover_protocols", return_value=3),
+        patch("app.collectors.psi_collector.enrich_protocol_backlog", return_value=2),
+        patch("app.collectors.psi_collector.promote_eligible_protocols", return_value=1),
+        patch("app.state_attestation.attest_state", mock_attest),
+    ):
+        from app.enrichment_worker import _run_psi_expansion
+
+        result = asyncio.run(_run_psi_expansion())
+
+        assert result == {"synced": 5, "discovered": 3, "enriched": 2, "promoted": 1}
+        mock_attest.assert_called_once()
+        call_args = mock_attest.call_args
+        assert call_args[0][0] == "psi_discoveries"
+        assert call_args[0][1] == [
+            {"synced": 5, "discovered": 3, "enriched": 2, "promoted": 1}
+        ]
+
+
+def test_psi_expansion_skips_attestation_when_nothing_discovered():
+    """When both discovered=0 and promoted=0, attest_state should NOT be called."""
+    mock_attest = MagicMock()
+
+    with (
+        patch("app.collectors.psi_collector.collect_collateral_exposure"),
+        patch("app.collectors.psi_collector.sync_collateral_to_backlog", return_value=2),
+        patch("app.collectors.psi_collector.discover_protocols", return_value=0),
+        patch("app.collectors.psi_collector.enrich_protocol_backlog", return_value=0),
+        patch("app.collectors.psi_collector.promote_eligible_protocols", return_value=0),
+        patch("app.state_attestation.attest_state", mock_attest),
+    ):
+        from app.enrichment_worker import _run_psi_expansion
+
+        result = asyncio.run(_run_psi_expansion())
+
+        assert result == {"synced": 2, "discovered": 0, "enriched": 0, "promoted": 0}
+        mock_attest.assert_not_called()


### PR DESCRIPTION
Relocate `attest_state("psi_discoveries", ...)` from orphaned `worker.py:2399` into `enrichment_worker.py:_run_psi_expansion()`. Only attests when `discovered or promoted` (matches original logic). Delete dead block from worker.py. 2 tests: attestation fires when discovered, skipped when nothing found.\n\nhttps://claude.ai/code/session_011bTVc5haorCZgtCtxzJmtq

---
_Generated by [Claude Code](https://claude.ai/code/session_011bTVc5haorCZgtCtxzJmtq)_