### PR TITLE
fix(db): increase pool max_conn from 10 to 50

### DIFF
--- a/app/database.py
+++ b/app/database.py
@@ -48,7 +48,7 @@ def _warn_if_async_context(helper_name: str) -> None:
 _pool: Optional[ThreadedConnectionPool] = None
 
 
-def init_pool(database_url: Optional[str] = None, min_conn: int = 2, max_conn: int = 10):
+def init_pool(database_url: Optional[str] = None, min_conn: int = 5, max_conn: int = 50):
     """Initialize the connection pool. Call once at startup."""
     global _pool
     url = database_url or os.environ.get("DATABASE_URL", "")

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -1,0 +1,25 @@
+"""
+Test: DB pool defaults are sized for enrichment pipeline concurrency.
+"""
+
+
+def test_pool_defaults_are_sized_for_enrichment_concurrency():
+    """Pool max_conn must be >= 3x enrichment max_concurrent (currently 15)."""
+    import inspect
+    from app.database import init_pool
+    sig = inspect.signature(init_pool)
+    assert sig.parameters["max_conn"].default >= 45, (
+        "Pool max_conn too low for enrichment pipeline; will cause "
+        "'connection pool exhausted' fast-fails at startup."
+    )
+
+
+def test_pool_min_conn_provides_baseline():
+    """Pool min_conn must be >= 5 for gate-check burst at cycle start."""
+    import inspect
+    from app.database import init_pool
+    sig = inspect.signature(init_pool)
+    assert sig.parameters["min_conn"].default >= 5, (
+        "Pool min_conn too low; gate checks at cycle start will exhaust "
+        "the pool before tasks even begin."
+    )


### PR DESCRIPTION
## Problem

Enrichment pipeline runs 39 tasks with `max_concurrent=15`. At cycle start, all tasks attempt gate-check DB queries simultaneously. Pool `max_conn=10` was the default from before the parallel pipeline shipped (April 13). Pool starves within milliseconds — confirmed in worker logs:

```
[ERROR] Enrichment [actor_classification] failed after 2.9s: connection pool exhausted
[ERROR] Enrichment [liquidity_depth] failed after 2.9s: connection pool exhausted
[ERROR] Enrichment [treasury_flows] failed after 2.9s: connection pool exhausted
```

This is the root cause of the 23-day attestation stale cluster. PRs #84-87 fixed real bugs that would have surfaced once the tasks ran, but the tasks couldn't run because the pool was exhausted.

## Fix

```
min_conn: 2 → 5  (baseline for gate-check burst)
max_conn: 10 → 50 (15 concurrent × ~3 connections each = 45 working set)
```

## Tests

- `test_pool_defaults_are_sized_for_enrichment_concurrency` — asserts max_conn >= 45
- `test_pool_min_conn_provides_baseline` — asserts min_conn >= 5

## Verification after deploy

```
psql "$DATABASE_URL" -c "SELECT MAX(classified_at), COUNT(*) FROM wallet_graph.actor_classifications;"
```

Search worker logs for `connection pool exhausted` — should drop to zero.

https://claude.ai/code/session_011bTVc5haorCZgtCtxzJmtq

---
_Generated by [Claude Code](https://claude.ai/code/session_011bTVc5haorCZgtCtxzJmtq)_