### PR TITLE
fix(actors): reduce batch size to 300 to fit enrichment timeout

### DIFF
--- a/app/enrichment_worker.py
+++ b/app/enrichment_worker.py
@@ -419,7 +419,8 @@ async def run_enrichment_pipeline() -> dict:
 
     async def _run_actor_classification():
         from app.actor_classification import classify_all_active
-        return await asyncio.to_thread(classify_all_active)
+        # 300 wallets × ~1.5s feature extraction ≈ 7.5 min, fits in 600s timeout.
+        return await asyncio.to_thread(classify_all_active, limit=300)
 
     pipeline.add(EnrichmentTask(
         name="actor_classification", func=_run_actor_classification,


### PR DESCRIPTION
Pass `limit=300` to `classify_all_active` from the enrichment wrapper. Default limit=2000 takes ~33 min; timeout is 600s. Function gets cancelled, `attest_state` never reached.\n\n300 wallets × ~1.5s feature extraction ≈ 7.5 min, fits in 600s with headroom.\n\nhttps://claude.ai/code/session_011bTVc5haorCZgtCtxzJmtq

---
_Generated by [Claude Code](https://claude.ai/code/session_011bTVc5haorCZgtCtxzJmtq)_