### PR TITLE
fix(actors): filter candidates by MIN_TX_COUNT at SQL level

### DIFF
--- a/app/actor_classification.py
+++ b/app/actor_classification.py
@@ -322,25 +322,31 @@ def classify_all_active(limit: int = 2000) -> dict:
     """
     rows = fetch_all(
         """
-        WITH active_addresses AS (
-            SELECT DISTINCT LOWER(from_address) AS addr
-            FROM wallet_graph.wallet_edges
-            WHERE last_transfer_at > NOW() - INTERVAL '90 days'
-            UNION
-            SELECT DISTINCT LOWER(to_address) AS addr
-            FROM wallet_graph.wallet_edges
-            WHERE last_transfer_at > NOW() - INTERVAL '90 days'
+        WITH addr_transfer_totals AS (
+            SELECT addr, SUM(transfer_count) AS total_transfers
+            FROM (
+                SELECT LOWER(from_address) AS addr, transfer_count
+                FROM wallet_graph.wallet_edges
+                WHERE last_transfer_at > NOW() - INTERVAL '90 days'
+                UNION ALL
+                SELECT LOWER(to_address) AS addr, transfer_count
+                FROM wallet_graph.wallet_edges
+                WHERE last_transfer_at > NOW() - INTERVAL '90 days'
+            ) edges_both_sides
+            GROUP BY addr
+            HAVING SUM(transfer_count) >= %s
         )
-        SELECT DISTINCT w.address
+        SELECT w.address
         FROM wallet_graph.wallets w
-        INNER JOIN active_addresses a ON LOWER(w.address) = a.addr
+        INNER JOIN addr_transfer_totals a ON LOWER(w.address) = a.addr
         LEFT JOIN wallet_graph.actor_classifications ac
           ON ac.wallet_address = LOWER(w.address)
         WHERE ac.wallet_address IS NULL
            OR ac.classified_at < NOW() - INTERVAL '24 hours'
+        ORDER BY ac.classified_at NULLS FIRST, a.total_transfers DESC
         LIMIT %s
         """,
-        (limit,),
+        (MIN_TX_COUNT, limit),
     )
 
     classified = 0

--- a/tests/test_actor_classification.py
+++ b/tests/test_actor_classification.py
@@ -30,7 +30,7 @@ class TestClassifyAllActive(unittest.TestCase):
         assert result["by_type"]["human"] == 2
         assert mock_fetch_all.call_count == 1
         sql = mock_fetch_all.call_args[0][0]
-        assert "active_addresses" in sql, "Should use CTE-based query"
+        assert "addr_transfer_totals" in sql, "Should use transfer-count CTE query"
 
     @patch("app.actor_classification.fetch_one")
     @patch("app.actor_classification.classify_wallet")


### PR DESCRIPTION
## Problem

Candidate query selected any address with any edge in 90 days. Most candidates had <20 transfers → `_extract_features` returned None → `classified=0` → `attest_state` never called → `state_attestations.domain='actors'` stale 23+ days.

Production confirmed: of 300 candidates per cycle, all 300 skipped. Zero classified.

## Fix

Replace CTE with transfer-count aggregation:
- `HAVING SUM(transfer_count) >= MIN_TX_COUNT` filters sparse wallets at SQL level
- `ORDER BY ac.classified_at NULLS FIRST, a.total_transfers DESC` prioritizes unclassified + most active
- Only wallets with enough history to actually produce features are fetched

## Verification after deploy

```sql
SELECT MAX(cycle_timestamp) AS last_attested, NOW() - MAX(cycle_timestamp) AS staleness
FROM state_attestations WHERE domain = 'actors';
```

Expect staleness < 30 min. Worker log should show `classified > 0`.

https://claude.ai/code/session_011bTVc5haorCZgtCtxzJmtq

---
_Generated by [Claude Code](https://claude.ai/code/session_011bTVc5haorCZgtCtxzJmtq)_