### PR TITLE
fix(collectors): exchange_trust_ratio handles modern CoinGecko trust_score_rank format

### DIFF
--- a/app/collectors/coingecko.py
+++ b/app/collectors/coingecko.py
@@ -31,6 +31,21 @@ def _headers() -> dict:
     return h
 
 
+def _is_high_trust(ticker: dict) -> bool:
+    """Check if a ticker is from a high-trust exchange.
+
+    CoinGecko historically returned trust_score as a string ("green", "yellow",
+    "red").  Modern responses may return ``null`` for that field and instead
+    provide a numeric ``trust_score_rank``.  We accept either signal.
+    """
+    if ticker.get("trust_score") == "green":
+        return True
+    rank = ticker.get("trust_score_rank")
+    if isinstance(rank, (int, float)) and rank <= 10:
+        return True
+    return False
+
+
 async def fetch_current(client: httpx.AsyncClient, coingecko_id: str) -> dict:
     """Get current coin data including tickers."""
     url = f"{BASE_URL}/coins/{coingecko_id}"
@@ -197,6 +212,7 @@ async def collect_peg_components(
         t.get("converted_last", {}).get("usd", 1.0)
         for t in tickers[:20]
         if t.get("trust_score") in ("green", "yellow")
+        or _is_high_trust(t)
     ]
     if len(ticker_prices) >= 3:
         variance = statistics.stdev(ticker_prices)
@@ -460,8 +476,8 @@ async def collect_market_activity_components(
     
     # Trust Score Ratio
     if tickers:
-        green = sum(1 for t in tickers if t.get("trust_score") == "green")
-        trust_ratio = green / len(tickers)
+        high_trust = sum(1 for t in tickers if _is_high_trust(t))
+        trust_ratio = high_trust / len(tickers)
         components.append({
             "component_id": "exchange_trust_ratio",
             "category": "market_activity",

--- a/tests/test_coingecko_collector.py
+++ b/tests/test_coingecko_collector.py
@@ -1,0 +1,78 @@
+"""Tests for CoinGecko collector trust-score parsing."""
+
+from app.collectors.coingecko import _is_high_trust
+
+
+def _make_tickers(specs):
+    """Build minimal ticker dicts from a list of (trust_score, trust_score_rank) tuples."""
+    tickers = []
+    for trust_score, trust_score_rank in specs:
+        t = {}
+        if trust_score is not None:
+            t["trust_score"] = trust_score
+        if trust_score_rank is not None:
+            t["trust_score_rank"] = trust_score_rank
+        tickers.append(t)
+    return tickers
+
+
+def _compute_trust_ratio(tickers):
+    """Replicate the trust-ratio calculation from collect_market_activity_components."""
+    if not tickers:
+        return 0.0
+    high_trust = sum(1 for t in tickers if _is_high_trust(t))
+    return high_trust / len(tickers)
+
+
+# ---- test_exchange_trust_ratio_handles_string_trust_score ----
+def test_exchange_trust_ratio_handles_string_trust_score():
+    """Legacy format: trust_score is 'green'/'yellow'/'red'. Only green counts."""
+    tickers = _make_tickers([
+        ("green", None),   # high trust
+        ("green", None),   # high trust
+        ("red", None),     # not high trust
+    ])
+    ratio = _compute_trust_ratio(tickers)
+    assert ratio == 2 / 3, f"Expected 2/3, got {ratio}"
+
+
+# ---- test_exchange_trust_ratio_handles_numeric_rank ----
+def test_exchange_trust_ratio_handles_numeric_rank():
+    """Modern format: trust_score is null, trust_score_rank is numeric."""
+    tickers = _make_tickers([
+        (None, 3),    # rank <= 10 -> high trust
+        (None, 10),   # rank <= 10 -> high trust
+        (None, 11),   # rank > 10  -> not high trust
+        (None, 250),  # rank > 10  -> not high trust
+    ])
+    ratio = _compute_trust_ratio(tickers)
+    assert ratio == 2 / 4, f"Expected 2/4, got {ratio}"
+
+
+# ---- test_exchange_trust_ratio_mixed_formats ----
+def test_exchange_trust_ratio_mixed_formats():
+    """Mix of legacy string and modern numeric formats."""
+    tickers = _make_tickers([
+        ("green", None),  # high trust via string
+        (None, 5),        # high trust via rank
+        ("red", 50),      # neither qualifies
+    ])
+    ratio = _compute_trust_ratio(tickers)
+    assert ratio == 2 / 3, f"Expected 2/3, got {ratio}"
+
+
+# ---- edge cases ----
+def test_is_high_trust_empty_ticker():
+    """Empty ticker dict should not be high trust."""
+    assert not _is_high_trust({})
+
+
+def test_is_high_trust_yellow_not_high():
+    """Yellow trust_score is NOT high trust (only green is)."""
+    assert not _is_high_trust({"trust_score": "yellow"})
+
+
+def test_is_high_trust_rank_boundary():
+    """Rank exactly 10 is high trust; 11 is not."""
+    assert _is_high_trust({"trust_score_rank": 10})
+    assert not _is_high_trust({"trust_score_rank": 11})


### PR DESCRIPTION
CoinGecko stopped returning `trust_score` as "green"/"yellow"/"red". Modern responses use numeric `trust_score_rank`. Old filter matched zero tickers → ratio always 0 → ~1-2 SII points lost per cycle.\n\nAdds `_is_high_trust()` helper: returns True if `trust_score == "green"` (legacy) OR `trust_score_rank <= 10` (modern). Also fixes `cross_exchange_variance` filter which had the same vulnerability.\n\n6 tests pass.\n\nhttps://claude.ai/code/session_011bTVc5haorCZgtCtxzJmtq

---
_Generated by [Claude Code](https://claude.ai/code/session_011bTVc5haorCZgtCtxzJmtq)_