### PR TITLE
fix(collectors): flows distinguishes API failure from genuine zero, writes cycle_errors

### DIFF
--- a/app/collectors/flows.py
+++ b/app/collectors/flows.py
@@ -17,7 +17,9 @@ import os
 import math
 import asyncio
 import logging
+from dataclasses import dataclass
 from datetime import datetime, timezone, timedelta
+from typing import Optional
 
 import httpx
 
@@ -29,6 +31,29 @@ logger = logging.getLogger(__name__)
 ETHERSCAN_V2_BASE = "https://api.etherscan.io/v2/api"
 RATE_LIMIT_DELAY = 0.15  # slightly conservative to avoid contention with holder queries
 ZERO_ADDRESS = "0x0000000000000000000000000000000000000000"
+
+
+def _write_cycle_error(error_type: str, error_message: str) -> None:
+    """Persist a flows-collection error to cycle_errors. Never raises."""
+    try:
+        from app.worker import _record_cycle_error
+        _record_cycle_error(
+            error_type=error_type,
+            error_message=error_message,
+            cycle_phase="flows_collection",
+        )
+    except Exception:
+        pass
+
+
+@dataclass
+class _FlowsFetchResult:
+    """Structured result from _fetch_recent_transfers so callers can
+    distinguish API failure from genuine zero transfers."""
+    success: bool
+    transfers: list
+    error_type: Optional[str] = None
+    error_message: Optional[str] = None
 
 
 def _get_stablecoin_config(stablecoin_id: str) -> dict | None:
@@ -50,8 +75,12 @@ def _get_stablecoin_config(stablecoin_id: str) -> dict | None:
 
 async def _fetch_recent_transfers(
     client: httpx.AsyncClient, contract: str, api_key: str
-) -> list[dict]:
-    """Fetch the most recent 200 token transfers for a contract."""
+) -> _FlowsFetchResult:
+    """Fetch the most recent 200 token transfers for a contract.
+
+    Returns a _FlowsFetchResult so callers can distinguish API failure
+    (rate-limit, timeout, transport error) from a genuine empty result set.
+    """
     params = {
         "chainid": 1,
         "module": "account",
@@ -65,15 +94,58 @@ async def _fetch_recent_transfers(
     try:
         resp = await client.get(ETHERSCAN_V2_BASE, params=params, timeout=20)
         data = resp.json()
-        if data.get("status") == "1" and data.get("result"):
-            return data["result"]
-        if "Max rate limit" in str(data.get("result", "")):
+
+        # Rate limit surfaced inside the JSON body (status "0")
+        result_str = str(data.get("result", ""))
+        if "Max rate limit" in result_str:
             logger.warning("Etherscan rate limit hit in flows collector")
             await asyncio.sleep(1.0)
-        return []
+            return _FlowsFetchResult(
+                success=False,
+                transfers=[],
+                error_type="rate_limit",
+                error_message=result_str[:500],
+            )
+
+        # Etherscan returned a non-success status (e.g. invalid key, bad params)
+        if data.get("status") != "1":
+            return _FlowsFetchResult(
+                success=False,
+                transfers=[],
+                error_type="api_error",
+                error_message=result_str[:500],
+            )
+
+        # Success
+        return _FlowsFetchResult(
+            success=True,
+            transfers=data.get("result") or [],
+        )
+
+    except httpx.TimeoutException as e:
+        logger.error(f"Etherscan tokentx timeout for {contract}: {e}")
+        return _FlowsFetchResult(
+            success=False,
+            transfers=[],
+            error_type="timeout",
+            error_message=str(e)[:500],
+        )
+    except httpx.HTTPError as e:
+        logger.error(f"Etherscan tokentx transport error for {contract}: {e}")
+        return _FlowsFetchResult(
+            success=False,
+            transfers=[],
+            error_type="transport",
+            error_message=str(e)[:500],
+        )
     except Exception as e:
         logger.error(f"Etherscan tokentx error for {contract}: {e}")
-        return []
+        return _FlowsFetchResult(
+            success=False,
+            transfers=[],
+            error_type="transport",
+            error_message=str(e)[:500],
+        )
 
 
 def _parse_mint_burn(transfers: list[dict], decimals: int, price: float) -> dict:
@@ -268,11 +340,21 @@ async def collect_flows_components(
     market_cap = await _fl.run_in_executor(None, _get_market_cap, stablecoin_id)
 
     # Fetch recent transfers
-    transfers = await _fetch_recent_transfers(client, contract, api_key)
+    fetch_result = await _fetch_recent_transfers(client, contract, api_key)
     await asyncio.sleep(RATE_LIMIT_DELAY)
 
+    if not fetch_result.success:
+        # API failure — record to cycle_errors so it's distinguishable from
+        # genuine zero-transfer periods.
+        _write_cycle_error(
+            error_type=f"flows_{fetch_result.error_type}",
+            error_message=f"{stablecoin_id}: {fetch_result.error_message}",
+        )
+        return []
+
+    transfers = fetch_result.transfers
     if not transfers:
-        logger.debug(f"No transfers found for {stablecoin_id}")
+        logger.info(f"No transfers found for {stablecoin_id} (genuine zero)")
         return []
 
     # Parse mint/burn volumes

--- a/tests/test_flows_collector.py
+++ b/tests/test_flows_collector.py
@@ -1,0 +1,141 @@
+"""
+Tests for flows collector: structured _FlowsFetchResult and cycle_errors recording.
+"""
+import asyncio
+import unittest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+
+
+class TestFetchReturnsStructuredResult(unittest.TestCase):
+    """_fetch_recent_transfers must return _FlowsFetchResult, not bare list."""
+
+    def _run(self, coro):
+        return asyncio.run(coro)
+
+    def _make_client(self, side_effect=None, response=None):
+        client = AsyncMock(spec=httpx.AsyncClient)
+        if side_effect:
+            client.get.side_effect = side_effect
+        elif response:
+            client.get.return_value = response
+        return client
+
+    def _make_response(self, json_data):
+        resp = MagicMock()
+        resp.json.return_value = json_data
+        return resp
+
+    def test_fetch_returns_structured_result_on_rate_limit(self):
+        """Rate-limit in body -> success=False, error_type='rate_limit'."""
+        from app.collectors.flows import _fetch_recent_transfers, _FlowsFetchResult
+
+        json_data = {"status": "0", "result": "Max rate limit reached"}
+        client = self._make_client(response=self._make_response(json_data))
+
+        result = self._run(_fetch_recent_transfers(client, "0xABC", "key"))
+
+        self.assertIsInstance(result, _FlowsFetchResult)
+        self.assertFalse(result.success)
+        self.assertEqual(result.error_type, "rate_limit")
+        self.assertEqual(result.transfers, [])
+        self.assertIn("Max rate limit", result.error_message)
+
+    def test_fetch_returns_structured_result_on_timeout(self):
+        """httpx.TimeoutException -> success=False, error_type='timeout'."""
+        from app.collectors.flows import _fetch_recent_transfers, _FlowsFetchResult
+
+        client = self._make_client(side_effect=httpx.TimeoutException("timed out"))
+
+        result = self._run(_fetch_recent_transfers(client, "0xABC", "key"))
+
+        self.assertIsInstance(result, _FlowsFetchResult)
+        self.assertFalse(result.success)
+        self.assertEqual(result.error_type, "timeout")
+        self.assertEqual(result.transfers, [])
+
+    def test_fetch_returns_structured_result_on_transport_error(self):
+        """httpx.HTTPError -> success=False, error_type='transport'."""
+        from app.collectors.flows import _fetch_recent_transfers, _FlowsFetchResult
+
+        client = self._make_client(side_effect=httpx.NetworkError("conn refused"))
+
+        result = self._run(_fetch_recent_transfers(client, "0xABC", "key"))
+
+        self.assertIsInstance(result, _FlowsFetchResult)
+        self.assertFalse(result.success)
+        self.assertEqual(result.error_type, "transport")
+
+    def test_fetch_returns_structured_result_on_api_error(self):
+        """status != '1' (non-rate-limit) -> success=False, error_type='api_error'."""
+        from app.collectors.flows import _fetch_recent_transfers, _FlowsFetchResult
+
+        json_data = {"status": "0", "result": "Invalid API Key"}
+        client = self._make_client(response=self._make_response(json_data))
+
+        result = self._run(_fetch_recent_transfers(client, "0xABC", "key"))
+
+        self.assertIsInstance(result, _FlowsFetchResult)
+        self.assertFalse(result.success)
+        self.assertEqual(result.error_type, "api_error")
+
+    def test_fetch_returns_structured_result_on_success(self):
+        """Normal 200 with status '1' -> success=True, transfers populated."""
+        from app.collectors.flows import _fetch_recent_transfers, _FlowsFetchResult
+
+        transfers = [{"hash": "0x1", "from": "0xa", "to": "0xb", "value": "1000"}]
+        json_data = {"status": "1", "result": transfers}
+        client = self._make_client(response=self._make_response(json_data))
+
+        result = self._run(_fetch_recent_transfers(client, "0xABC", "key"))
+
+        self.assertIsInstance(result, _FlowsFetchResult)
+        self.assertTrue(result.success)
+        self.assertEqual(result.transfers, transfers)
+        self.assertIsNone(result.error_type)
+
+
+class TestCollectFlowsWritesCycleError(unittest.TestCase):
+    """collect_flows_components must write cycle_errors on API failure."""
+
+    def _run(self, coro):
+        return asyncio.run(coro)
+
+    @patch("app.collectors.flows._fetch_recent_transfers")
+    @patch("app.collectors.flows._get_market_cap", return_value=1_000_000)
+    @patch("app.collectors.flows._get_current_price", return_value=1.0)
+    @patch("app.collectors.flows._get_stablecoin_config", return_value={
+        "id": "usdc", "symbol": "USDC", "contract": "0xA0b8",
+        "decimals": 6, "coingecko_id": "usd-coin",
+    })
+    @patch.dict("os.environ", {"ETHERSCAN_API_KEY": "fake_key"})
+    def test_collect_flows_writes_cycle_error_on_failure(
+        self, _cfg, _price, _mcap, mock_fetch
+    ):
+        """When _fetch_recent_transfers returns failure, cycle_errors gets a row."""
+        from app.collectors.flows import collect_flows_components, _FlowsFetchResult
+
+        mock_fetch.return_value = _FlowsFetchResult(
+            success=False,
+            transfers=[],
+            error_type="rate_limit",
+            error_message="Max rate limit reached",
+        )
+
+        with patch("app.collectors.flows._write_cycle_error") as mock_write:
+            result = self._run(collect_flows_components(
+                AsyncMock(spec=httpx.AsyncClient), "usdc"
+            ))
+
+            self.assertEqual(result, [])
+            mock_write.assert_called_once()
+            call_kwargs = mock_write.call_args
+            # Check error_type includes the flows_ prefix and the error class
+            self.assertIn("flows_rate_limit", str(call_kwargs))
+            # Check error_message includes the stablecoin_id
+            self.assertIn("usdc", str(call_kwargs))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
`_fetch_recent_transfers` returned `[]` on rate limit, timeout, and transport error — indistinguishable from genuine zero transfers. No `cycle_errors` row written.\n\nAdds `_FlowsFetchResult` dataclass with `success`, `error_type`, `error_message`. Rewrites `_fetch_recent_transfers` to classify errors (timeout, transport, rate_limit, api_error). `collect_flows_components` now writes `cycle_errors` on failure via `_write_cycle_error()` helper.\n\n6 tests pass.\n\nhttps://claude.ai/code/session_011bTVc5haorCZgtCtxzJmtq

---
_Generated by [Claude Code](https://claude.ai/code/session_011bTVc5haorCZgtCtxzJmtq)_