### PR TITLE
fix(enrichment): register 10 orphaned slow-cycle tasks + close 11 always-attest gaps

### DIFF
--- a/app/actor_classification.py
+++ b/app/actor_classification.py
@@ -389,6 +389,8 @@ def classify_all_active(limit: int = 2000) -> dict:
         from app.state_attestation import attest_state
         if classified > 0:
             attest_state("actors", [{"classified": classified, "reclassified": reclassified, "by_type": by_type}])
+        else:
+            attest_state("actors", [{"status": "ran_no_results", "results_count": 0}])
     except Exception as ae:
         logger.error(f"Actor attestation FAILED: {ae}")
         from app.worker import _record_cycle_error

--- a/app/collectors/bridge_collector.py
+++ b/app/collectors/bridge_collector.py
@@ -592,7 +592,18 @@ def run_bri_scoring() -> list[dict]:
                 {"slug": r["entity_slug"], "score": r["overall_score"]}
                 for r in results
             ])
-    except Exception as e:
-        logger.warning(f"BRI attestation failed: {e}")
+        else:
+            attest_state("bri_components", [{"status": "ran_no_results", "results_count": 0}])
+    except Exception as ae:
+        logger.error(f"bri_components attestation failed: {ae}")
+        try:
+            from app.worker import _record_cycle_error
+            _record_cycle_error(
+                error_type="bri_components_attestation_failure",
+                error_message=str(ae)[:500],
+                cycle_phase="bri_components",
+            )
+        except Exception:
+            pass
 
     return results

--- a/app/collectors/cex_collector.py
+++ b/app/collectors/cex_collector.py
@@ -444,7 +444,18 @@ def run_cxri_scoring() -> list[dict]:
                 {"slug": r["entity_slug"], "score": r["overall_score"]}
                 for r in results
             ])
-    except Exception as e:
-        logger.warning(f"CXRI attestation failed: {e}")
+        else:
+            attest_state("cxri_components", [{"status": "ran_no_results", "results_count": 0}])
+    except Exception as ae:
+        logger.error(f"cxri_components attestation failed: {ae}")
+        try:
+            from app.worker import _record_cycle_error
+            _record_cycle_error(
+                error_type="cxri_components_attestation_failure",
+                error_message=str(ae)[:500],
+                cycle_phase="cxri_components",
+            )
+        except Exception:
+            pass
 
     return results

--- a/app/collectors/dao_collector.py
+++ b/app/collectors/dao_collector.py
@@ -906,7 +906,18 @@ def run_dohi_scoring() -> list[dict]:
                 {"slug": r["entity_slug"], "score": r["overall_score"]}
                 for r in results
             ])
-    except Exception as e:
-        logger.warning(f"DOHI attestation failed: {e}")
+        else:
+            attest_state("dohi_components", [{"status": "ran_no_results", "results_count": 0}])
+    except Exception as ae:
+        logger.error(f"dohi_components attestation failed: {ae}")
+        try:
+            from app.worker import _record_cycle_error
+            _record_cycle_error(
+                error_type="dohi_components_attestation_failure",
+                error_message=str(ae)[:500],
+                cycle_phase="dohi_components",
+            )
+        except Exception:
+            pass
 
     return results

--- a/app/collectors/dex_pools.py
+++ b/app/collectors/dex_pools.py
@@ -373,7 +373,18 @@ def run_dex_pool_collection() -> list[dict]:
                 {"slug": r.get("protocol_slug"), "component": r.get("component"), "score": r.get("score")}
                 for r in results if "score" in r
             ])
-    except Exception:
-        pass
+        else:
+            attest_state("dex_pool_data", [{"status": "ran_no_results", "results_count": 0}])
+    except Exception as ae:
+        logger.error(f"dex_pool_data attestation failed: {ae}")
+        try:
+            from app.worker import _record_cycle_error
+            _record_cycle_error(
+                error_type="dex_pool_data_attestation_failure",
+                error_message=str(ae)[:500],
+                cycle_phase="dex_pool_data",
+            )
+        except Exception:
+            pass
 
     return results

--- a/app/collectors/lst_collector.py
+++ b/app/collectors/lst_collector.py
@@ -627,7 +627,18 @@ def run_lsti_scoring() -> list[dict]:
                 {"slug": r["entity_slug"], "score": r["overall_score"]}
                 for r in results
             ])
-    except Exception as e:
-        logger.warning(f"LSTI attestation failed: {e}")
+        else:
+            attest_state("lsti_components", [{"status": "ran_no_results", "results_count": 0}])
+    except Exception as ae:
+        logger.error(f"lsti_components attestation failed: {ae}")
+        try:
+            from app.worker import _record_cycle_error
+            _record_cycle_error(
+                error_type="lsti_components_attestation_failure",
+                error_message=str(ae)[:500],
+                cycle_phase="lsti_components",
+            )
+        except Exception:
+            pass
 
     return results

--- a/app/collectors/tti_collector.py
+++ b/app/collectors/tti_collector.py
@@ -654,7 +654,18 @@ def run_tti_scoring() -> list[dict]:
                 {"slug": r["entity_slug"], "score": r["overall_score"]}
                 for r in results
             ])
-    except Exception as e:
-        logger.warning(f"TTI attestation failed: {e}")
+        else:
+            attest_state("tti_components", [{"status": "ran_no_results", "results_count": 0}])
+    except Exception as ae:
+        logger.error(f"tti_components attestation failed: {ae}")
+        try:
+            from app.worker import _record_cycle_error
+            _record_cycle_error(
+                error_type="tti_components_attestation_failure",
+                error_message=str(ae)[:500],
+                cycle_phase="tti_components",
+            )
+        except Exception:
+            pass
 
     return results

--- a/app/composition.py
+++ b/app/composition.py
@@ -5,9 +5,12 @@ Composes indices (SII, PSI) into composite risk views (CQI).
 All scores computed on-demand — no storage.
 """
 
+import logging
 import math
 
 from app.database import fetch_all, fetch_one
+
+logger = logging.getLogger(__name__)
 
 
 def compose_geometric_mean(scores):
@@ -386,8 +389,19 @@ def compute_rqs_all() -> dict:
                 {"protocol": r["protocol_slug"], "rqs_score": round(r["rqs_score"], 2)}
                 for r in results if r.get("rqs_score") is not None
             ])
-    except Exception:
-        pass
+        else:
+            attest_state("rqs_compositions", [{"status": "ran_no_results", "results_count": 0}])
+    except Exception as ae:
+        logger.error(f"rqs_compositions attestation failed: {ae}")
+        try:
+            from app.worker import _record_cycle_error
+            _record_cycle_error(
+                error_type="rqs_compositions_attestation_failure",
+                error_message=str(ae)[:500],
+                cycle_phase="rqs_compositions",
+            )
+        except Exception:
+            pass
 
     return {
         "protocols": results,
@@ -444,8 +458,19 @@ def compute_cqi_matrix():
         from app.state_attestation import attest_state
         if matrix:
             attest_state("cqi_compositions", [{"asset": r["asset"], "protocol": r["protocol_slug"], "cqi_score": round(r["cqi_score"], 2)} for r in matrix])
-    except Exception:
-        pass  # attestation is non-critical
+        else:
+            attest_state("cqi_compositions", [{"status": "ran_no_results", "results_count": 0}])
+    except Exception as ae:
+        logger.error(f"cqi_compositions attestation failed: {ae}")
+        try:
+            from app.worker import _record_cycle_error
+            _record_cycle_error(
+                error_type="cqi_compositions_attestation_failure",
+                error_message=str(ae)[:500],
+                cycle_phase="cqi_compositions",
+            )
+        except Exception:
+            pass
 
     return {"matrix": matrix, "count": len(matrix)}
 

--- a/app/discovery.py
+++ b/app/discovery.py
@@ -227,7 +227,18 @@ def run_discovery_cycle():
         from app.state_attestation import attest_state
         if all_signals:
             attest_state("discovery_signals", [{"type": s.get("signal_type"), "novelty": s.get("novelty_score")} for s in all_signals])
+        else:
+            attest_state("discovery_signals", [{"status": "ran_no_results", "results_count": 0}])
     except Exception as ae:
-        logger.debug(f"Discovery attestation skipped: {ae}")
+        logger.error(f"discovery_signals attestation failed: {ae}")
+        try:
+            from app.worker import _record_cycle_error
+            _record_cycle_error(
+                error_type="discovery_signals_attestation_failure",
+                error_message=str(ae)[:500],
+                cycle_phase="discovery_signals",
+            )
+        except Exception:
+            pass
 
     return all_signals

--- a/app/enrichment_worker.py
+++ b/app/enrichment_worker.py
@@ -347,6 +347,21 @@ async def run_enrichment_pipeline() -> dict:
         ),
     ))
 
+    # ---- Validator performance (Rated.network) ----
+
+    async def _run_validator_performance():
+        from app.collectors.rated_validators import collect_validator_performance
+        return await asyncio.to_thread(collect_validator_performance)
+
+    pipeline.add(EnrichmentTask(
+        name="validator_performance", func=_run_validator_performance,
+        timeout_seconds=600, group="lst_data", priority=3,
+        gate_check=_db_gate(
+            "SELECT MAX(collected_at) AS latest FROM validator_performance",
+            min_hours=20,
+        ),
+    ))
+
     # ---- RPI pipeline ----
 
     async def _run_rpi():
@@ -411,6 +426,21 @@ async def run_enrichment_pipeline() -> dict:
         ),
     ))
 
+    # ---- RPI expansion pipeline (weekly auto-discovery) ----
+
+    async def _run_rpi_expansion():
+        from app.rpi.expansion import run_expansion_pipeline
+        return await asyncio.to_thread(run_expansion_pipeline)
+
+    pipeline.add(EnrichmentTask(
+        name="rpi_expansion", func=_run_rpi_expansion,
+        timeout_seconds=900, group="rpi", priority=4,
+        gate_check=_db_gate(
+            "SELECT MAX(created_at) AS latest FROM rpi_protocol_config WHERE discovery_source != 'manual'",
+            min_hours=168,
+        ),
+    ))
+
     # ---- DEX pool collection ----
 
     async def _run_dex_pools():
@@ -423,6 +453,21 @@ async def run_enrichment_pipeline() -> dict:
         gate_check=_db_gate(
             "SELECT MAX(computed_at) AS latest FROM generic_index_scores WHERE index_id = 'dex_pool_data'",
             min_hours=3,
+        ),
+    ))
+
+    # ---- Pool wallet collection (protocol composition) ----
+
+    async def _run_pool_wallet_collection():
+        from app.collectors.pool_wallet_collector import run_pool_wallet_collection
+        return await run_pool_wallet_collection()
+
+    pipeline.add(EnrichmentTask(
+        name="pool_wallet_collection", func=_run_pool_wallet_collection,
+        timeout_seconds=900, group="composition", priority=3,
+        gate_check=_db_gate(
+            "SELECT MAX(discovered_at) AS latest FROM protocol_pool_wallets",
+            min_hours=20,
         ),
     ))
 
@@ -466,6 +511,36 @@ async def run_enrichment_pipeline() -> dict:
         gate_check=_db_gate(
             "SELECT MAX(created_at) AS latest FROM governance_events WHERE created_at > NOW() - INTERVAL '48 hours'",
             min_hours=24,
+        ),
+    ))
+
+    # ---- Governance proposal corpus ----
+
+    async def _run_governance_proposals():
+        from app.collectors.governance_proposals import collect_governance_proposals
+        return await collect_governance_proposals()
+
+    pipeline.add(EnrichmentTask(
+        name="governance_proposals", func=_run_governance_proposals,
+        timeout_seconds=900, group="governance", priority=3,
+        gate_check=_db_gate(
+            "SELECT MAX(captured_at) AS latest FROM governance_proposals",
+            min_hours=20,
+        ),
+    ))
+
+    # ---- Parameter history (protocol snapshots) ----
+
+    async def _run_parameter_history():
+        from app.collectors.parameter_history import collect_parameter_history
+        return await collect_parameter_history()
+
+    pipeline.add(EnrichmentTask(
+        name="parameter_history", func=_run_parameter_history,
+        timeout_seconds=600, group="protocol_data", priority=3,
+        gate_check=_db_gate(
+            "SELECT MAX(snapshot_date) AS latest FROM protocol_parameter_snapshots",
+            min_hours=20,
         ),
     ))
 
@@ -855,6 +930,66 @@ async def run_enrichment_pipeline() -> dict:
         ),
     ))
 
+    # ---- Contract dependency graph ----
+
+    async def _run_contract_dependencies():
+        from app.collectors.contract_dependencies import collect_contract_dependencies
+        return await collect_contract_dependencies()
+
+    pipeline.add(EnrichmentTask(
+        name="contract_dependencies", func=_run_contract_dependencies,
+        timeout_seconds=600, group="security", priority=5,
+        gate_check=_db_gate(
+            "SELECT MAX(scanned_at) AS latest FROM contract_dependency_graph",
+            min_hours=20,
+        ),
+    ))
+
+    # ---- Sanctions screening ----
+
+    async def _run_sanctions_screening():
+        from app.collectors.sanctions_screening import run_sanctions_screening
+        return await asyncio.to_thread(run_sanctions_screening)
+
+    pipeline.add(EnrichmentTask(
+        name="sanctions_screening", func=_run_sanctions_screening,
+        timeout_seconds=600, group="compliance", priority=5,
+        gate_check=_db_gate(
+            "SELECT MAX(screened_at) AS latest FROM sanctions_screening_results",
+            min_hours=20,
+        ),
+    ))
+
+    # ---- Enforcement records (weekly) ----
+
+    async def _run_enforcement_records():
+        from app.collectors.enforcement_history import collect_enforcement_records
+        return await asyncio.to_thread(collect_enforcement_records)
+
+    pipeline.add(EnrichmentTask(
+        name="enforcement_records", func=_run_enforcement_records,
+        timeout_seconds=600, group="compliance", priority=5,
+        gate_check=_db_gate(
+            "SELECT MAX(collected_at) AS latest FROM enforcement_records",
+            min_hours=168,
+        ),
+    ))
+
+    # ---- Parent company financials (weekly) ----
+
+    async def _run_parent_financials():
+        from app.collectors.parent_company_financials import collect_parent_financials
+        return await asyncio.to_thread(collect_parent_financials)
+
+    pipeline.add(EnrichmentTask(
+        name="parent_financials", func=_run_parent_financials,
+        timeout_seconds=600, group="compliance", priority=5,
+        gate_check=_db_gate(
+            "SELECT MAX(collected_at) AS latest FROM parent_company_financials",
+            min_hours=168,
+        ),
+    ))
+
     # ---- Hourly entity snapshots ----
 
     async def _run_entity_snapshots():
@@ -966,6 +1101,21 @@ async def run_enrichment_pipeline() -> dict:
     pipeline.add(EnrichmentTask(
         name="materialized_compositions", func=_run_materialized,
         timeout_seconds=120, group="computed", priority=4,
+    ))
+
+    # ---- Daily pulse generation ----
+
+    async def _run_daily_pulse():
+        from app.pulse_generator import run_daily_pulse
+        return await run_daily_pulse()
+
+    pipeline.add(EnrichmentTask(
+        name="daily_pulse", func=_run_daily_pulse,
+        timeout_seconds=300, group="pulse", priority=4,
+        gate_check=_db_gate(
+            "SELECT MAX(created_at) AS latest FROM daily_pulses",
+            min_hours=22,
+        ),
     ))
 
     # ---- Provenance linking + catalog update ----

--- a/app/indexer/profiles.py
+++ b/app/indexer/profiles.py
@@ -192,7 +192,18 @@ def rebuild_all_profiles(limit: int = 0) -> dict:
         from app.state_attestation import attest_state
         if built > 0:
             attest_state("wallet_profiles", [{"built": built, "total": len(addresses)}])
+        else:
+            attest_state("wallet_profiles", [{"status": "ran_no_results", "profiles_built": 0}])
     except Exception as ae:
-        logger.debug(f"Wallet profile attestation skipped: {ae}")
+        logger.error(f"wallet_profiles attestation failed: {ae}")
+        try:
+            from app.worker import _record_cycle_error
+            _record_cycle_error(
+                error_type="wallet_profiles_attestation_failure",
+                error_message=str(ae)[:500],
+                cycle_phase="wallet_profiles",
+            )
+        except Exception:
+            pass
 
     return {"total": len(addresses), "built": built, "errors": errors}


### PR DESCRIPTION
## Summary

Completes the `run_slow_cycle` migration begun April 13 (commit 80cc170). Closes the orphan-task bug class (PRs #87-91, #98-99).

## Part 1 — 10 orphan task registrations

| Task | Group | Cadence | Sync/Async |
|------|-------|---------|------------|
| pool_wallet_collection | composition | daily | async |
| validator_performance | lst_data | daily | sync→to_thread |
| daily_pulse | pulse | daily | async |
| parameter_history | protocol_data | daily | async |
| contract_dependencies | security | daily | async |
| governance_proposals | governance | daily | async |
| sanctions_screening | compliance | daily | sync→to_thread |
| enforcement_records | compliance | weekly | sync→to_thread |
| parent_financials | compliance | weekly | sync→to_thread |
| rpi_expansion | rpi | weekly | sync→to_thread |

## Part 2 — 11 always-attest gaps closed

Each site now attests on empty runs with `{"status": "ran_no_results"}` and logs failures via `logger.error` + `_record_cycle_error`.

| File | Domain |
|------|--------|
| lst_collector | lsti_components |
| bridge_collector | bri_components |
| cex_collector | cxri_components |
| tti_collector | tti_components |
| dao_collector | dohi_components |
| dex_pools | dex_pool_data |
| actor_classification | actors (else branch only) |
| discovery | discovery_signals |
| composition | rqs_compositions + cqi_compositions |
| profiles | wallet_profiles |

## Stats

11 files, 283 insertions, 18 deletions. All compile clean.

## Expected production impact (within 24h of merge)

- daily_pulses: +1 row/day
- protocol_parameter_changes/snapshots: first rows
- governance_proposals: new rows
- state_attestations: fresh rows for all 11 domains on every cycle

## Note

This PR does NOT delete `run_slow_cycle` from worker.py. That cleanup is a separate hygiene PR after these orphans prove out in ≥3 production cycles.

https://claude.ai/code/session_011bTVc5haorCZgtCtxzJmtq

---
_Generated by [Claude Code](https://claude.ai/code/session_011bTVc5haorCZgtCtxzJmtq)_