### PR TITLE
fix(enrichment): bump provenance timeout to 300s + orchestrator-level cycle_errors writes

### DIFF
--- a/app/enrichment_worker.py
+++ b/app/enrichment_worker.py
@@ -104,6 +104,15 @@ class EnrichmentPipeline:
                 logger.error(
                     f"[enrichment] [{task.name}] TIMEOUT after {task.timeout_seconds}s"
                 )
+                try:
+                    from app.worker import _record_cycle_error
+                    _record_cycle_error(
+                        error_type="enrichment_task_timeout",
+                        error_message=f"task {task.name} exceeded {task.timeout_seconds}s budget",
+                        cycle_phase=f"enrichment_{task.name}",
+                    )
+                except Exception:
+                    pass
                 return TaskResult(
                     name=task.name,
                     success=False,
@@ -113,6 +122,15 @@ class EnrichmentPipeline:
             except Exception as e:
                 elapsed = time.time() - start
                 logger.error(f"Enrichment [{task.name}] failed after {elapsed:.1f}s: {e}")
+                try:
+                    from app.worker import _record_cycle_error
+                    _record_cycle_error(
+                        error_type="enrichment_task_failure",
+                        error_message=f"task {task.name}: {str(e)[:400]}",
+                        cycle_phase=f"enrichment_{task.name}",
+                    )
+                except Exception:
+                    pass
                 return TaskResult(
                     name=task.name,
                     success=False,
@@ -1151,7 +1169,7 @@ async def run_enrichment_pipeline() -> dict:
 
     pipeline.add(EnrichmentTask(
         name="provenance_update", func=_run_provenance_update,
-        timeout_seconds=60, group="housekeeping", priority=10,
+        timeout_seconds=300, group="housekeeping", priority=10,
     ))
 
     # ---- Data catalog update (end of pipeline) ----


### PR DESCRIPTION
**Merge order: 1 of 7** (Wave A/B/C tonight). Merge serially. Verify before proceeding to PR 2.

## Why

`provenance_update` was timing out at 60s before reaching its attestation/except block. `_execute_task` caught `asyncio.TimeoutError` at the `wait_for` boundary and returned a `TaskResult` without writing to `cycle_errors`, so the failure was invisible. Result: `state_attestations.domain='provenance'` stayed 23 days stale with zero rows in `cycle_errors` for `cycle_phase='enrichment_provenance_update'`.

## Changes

- Raise `provenance_update` timeout from 60s → 300s (5x headroom; other housekeeping tasks already have 600s+ budgets).
- `_execute_task` now writes to `cycle_errors` on both `TimeoutError` and generic `Exception` paths, tagged `cycle_phase=f"enrichment_{task.name}"`, types `enrichment_task_timeout` / `enrichment_task_failure`. Inner try/except guards the logging call so it can't break the orchestrator.

V9.11 Layer 2 propagation into the orchestrator itself, not just individual tasks. Every caught failure now writes to `cycle_errors` with the task name in `cycle_phase`, making "which task is silently failing?" instantly queryable.

## Verification (after Railway redeploys Scoring-Worker, wait ~5 min)

```bash
PAGER=cat psql "$DATABASE_URL" -c "SELECT MAX(cycle_timestamp), NOW() - MAX(cycle_timestamp) AS staleness FROM state_attestations WHERE domain='provenance';"
```

**Pass:** staleness < 60 min, OR still stale (provenance task hasn't run yet — that's fine, will fire next cycle).
**Fail:** any error in worker logs about `provenance_update` failing differently than before.

If fail: STOP, do not proceed to PR 2.

https://claude.ai/code/session_01XuHuGXV2AyY8q7H4ECEFjk

---
_Generated by [Claude Code](https://claude.ai/code/session_01XuHuGXV2AyY8q7H4ECEFjk)_