### PR TITLE
audit(services): convert 45 debug_only blocks to structured cycle_errors writes

### DIFF
--- a/app/services/cda_collector.py
+++ b/app/services/cda_collector.py
@@ -311,8 +311,17 @@ def _extract_reserve_data_from_markdown(markdown: str) -> dict | None:
             elif "million" in text_after:
                 num *= 1_000_000
             data["total_reserves_usd"] = num
-        except ValueError:
-            pass
+        except ValueError as e:
+            logger.warning(f"cda_collector: total_reserves_usd parse failed: {e}")
+            try:
+                from app.worker import _record_cycle_error
+                _record_cycle_error(
+                    error_type="services__extract_reserve_data_from_markdown_total_reserves_parse_failure",
+                    error_message=str(e)[:500],
+                    cycle_phase="cda_collector",
+                )
+            except Exception:
+                pass
 
     # Total supply patterns
     supply_match = re.search(
@@ -323,8 +332,17 @@ def _extract_reserve_data_from_markdown(markdown: str) -> dict | None:
         val = supply_match.group(1).replace(",", "")
         try:
             data["total_supply"] = float(val)
-        except ValueError:
-            pass
+        except ValueError as e:
+            logger.warning(f"cda_collector: total_supply parse failed: {e}")
+            try:
+                from app.worker import _record_cycle_error
+                _record_cycle_error(
+                    error_type="services__extract_reserve_data_from_markdown_total_supply_parse_failure",
+                    error_message=str(e)[:500],
+                    cycle_phase="cda_collector",
+                )
+            except Exception:
+                pass
 
     # Attestation date patterns
     date_match = re.search(
@@ -396,8 +414,19 @@ async def _try_reducto_pdf(symbol: str, pdf_url: str, prefix: str, disclosure_ty
             VALUES (%s, %s, %s)
             ON CONFLICT (asset_symbol, source_url) DO UPDATE SET discovered_at = NOW(), active = TRUE
         """, (symbol, _issuer_domain, pdf_url))
+    except asyncio.CancelledError:
+        raise
     except Exception as _ue:
-        logger.debug(f"{prefix} — cda_source_urls upsert skipped: {_ue}")
+        logger.warning(f"{prefix} — cda_source_urls upsert skipped: {_ue}")
+        try:
+            from app.worker import _record_cycle_error
+            _record_cycle_error(
+                error_type="services__try_reducto_pdf_cda_source_urls_upsert_failure",
+                error_message=str(_ue)[:500],
+                cycle_phase="cda_collector",
+            )
+        except Exception:
+            pass
 
     # Run validation
     try:
@@ -771,8 +800,17 @@ async def _step_parallel_task(issuer: dict, prefix: str) -> dict | None:
                 structured["total_reserves_usd"] = float(
                     str(total_reserves).replace(",", "").replace("$", "")
                 )
-            except ValueError:
-                pass
+            except ValueError as e:
+                logger.warning(f"cda_collector: _step_parallel_task total_reserves_usd parse failed: {e}")
+                try:
+                    from app.worker import _record_cycle_error
+                    _record_cycle_error(
+                        error_type="services__step_parallel_task_total_reserves_parse_failure",
+                        error_message=str(e)[:500],
+                        cycle_phase="cda_collector",
+                    )
+                except Exception:
+                    pass
 
         await asyncio.to_thread(
             _store_extraction,
@@ -1090,8 +1128,19 @@ async def _collect_api_source(symbol: str, url: str, prefix: str) -> dict | None
                     from urllib.parse import urlparse as _urlparse
                     _provider = _urlparse(url).netloc or "issuer"
                     track_api_call(provider=_provider, endpoint="GET", caller="services.cda_collector", status=_status, latency_ms=int((time.monotonic() - _t0) * 1000))
-                except Exception:
-                    pass
+                except asyncio.CancelledError:
+                    raise
+                except Exception as e:
+                    logger.warning(f"cda_collector: _collect_api_source track_api_call failed: {e}")
+                    try:
+                        from app.worker import _record_cycle_error
+                        _record_cycle_error(
+                            error_type="services__collect_api_source_track_api_call_failure",
+                            error_message=str(e)[:500],
+                            cycle_phase="cda_collector",
+                        )
+                    except Exception:
+                        pass
             resp.raise_for_status()
             data = resp.json()
 
@@ -1245,8 +1294,19 @@ async def run_collection():
         )
         if recent:
             await asyncio.to_thread(attest_state, "cda_extractions", [dict(r) for r in recent])
+    except asyncio.CancelledError:
+        raise
     except Exception as ae:
-        logger.debug(f"CDA attestation skipped: {ae}")
+        logger.warning(f"CDA attestation skipped: {ae}")
+        try:
+            from app.worker import _record_cycle_error
+            _record_cycle_error(
+                error_type="services_run_collection_cda_attestation_failure",
+                error_message=str(ae)[:500],
+                cycle_phase="cda_collector",
+            )
+        except Exception:
+            pass
 
 
 async def collect_single_issuer(asset_symbol: str):

--- a/app/services/cda_scores.py
+++ b/app/services/cda_scores.py
@@ -7,6 +7,7 @@ Called by the offline collector for each stablecoin.
 If no CDA data exists, returns empty list — scoring continues with existing data.
 """
 
+import asyncio
 import logging
 from datetime import datetime, timezone
 
@@ -106,8 +107,19 @@ async def get_cda_components(stablecoin_id: str) -> list[dict]:
                 "normalized_score": round(freshness_score, 2),
                 "data_source": source,
             })
-        except (ValueError, TypeError):
-            pass
+        except asyncio.CancelledError:
+            raise
+        except (ValueError, TypeError) as e:
+            logger.warning(f"cda_scores: get_cda_components attestation_freshness parse failed: {e}")
+            try:
+                from app.worker import _record_cycle_error
+                _record_cycle_error(
+                    error_type="services_get_cda_components_attestation_freshness_parse_failure",
+                    error_message=str(e)[:500],
+                    cycle_phase="cda_scores",
+                )
+            except Exception:
+                pass
 
     # 2. Reserve-to-Supply Ratio (category: transparency)
     reserves = data.get("total_reserves_usd")
@@ -226,8 +238,19 @@ async def get_cda_components_typed(stablecoin_id: str, disclosure_type: str = No
                 "normalized_score": round(freshness_score, 2),
                 "data_source": source,
             })
-        except (ValueError, TypeError):
-            pass
+        except asyncio.CancelledError:
+            raise
+        except (ValueError, TypeError) as e:
+            logger.warning(f"cda_scores: get_cda_components_typed attestation_freshness parse failed: {e}")
+            try:
+                from app.worker import _record_cycle_error
+                _record_cycle_error(
+                    error_type="services_get_cda_components_typed_attestation_freshness_parse_failure",
+                    error_message=str(e)[:500],
+                    cycle_phase="cda_scores",
+                )
+            except Exception:
+                pass
 
     if components:
         logger.info(

--- a/app/services/cda_validator.py
+++ b/app/services/cda_validator.py
@@ -85,8 +85,17 @@ def _run_rule(rule_name: str, data: dict, disclosure_type: str) -> dict:
             if total_backing and supply:
                 try:
                     cr = float(total_backing) / float(supply)
-                except (ValueError, TypeError, ZeroDivisionError):
-                    pass
+                except (ValueError, TypeError, ZeroDivisionError) as e:
+                    logger.warning(f"cda_validator: _run_rule collateral_ratio compute failed: {e}")
+                    try:
+                        from app.worker import _record_cycle_error
+                        _record_cycle_error(
+                            error_type="services__run_rule_collateral_ratio_compute_failure",
+                            error_message=str(e)[:500],
+                            cycle_phase="cda_validator",
+                        )
+                    except Exception:
+                        pass
         if cr is None:
             return {"passed": False, "applicable": False, "message": "No collateral ratio data"}
         try:

--- a/app/services/chain_spec_generator.py
+++ b/app/services/chain_spec_generator.py
@@ -77,8 +77,17 @@ def _get_stablecoin_addresses_on_chain(chain_name: str) -> list:
             finally:
                 try:
                     track_api_call(provider="coingecko", endpoint=f"/coins/{stable['coingecko_id']}", caller="services.chain_spec_generator", status=_status, latency_ms=int((time.monotonic() - _t0) * 1000))
-                except Exception:
-                    pass
+                except Exception as e:
+                    logger.warning(f"chain_spec_generator: _get_stablecoin_addresses_on_chain track_api_call failed: {e}")
+                    try:
+                        from app.worker import _record_cycle_error
+                        _record_cycle_error(
+                            error_type="services__get_stablecoin_addresses_on_chain_track_api_call_failure",
+                            error_message=str(e)[:500],
+                            cycle_phase="chain_spec_generator",
+                        )
+                    except Exception:
+                        pass
             if resp.status_code != 200:
                 continue
 
@@ -93,7 +102,16 @@ def _get_stablecoin_addresses_on_chain(chain_name: str) -> list:
                     "platform_id": platform_id,
                 })
         except Exception as e:
-            logger.debug(f"CoinGecko lookup failed for {stable['symbol']} on {chain_name}: {e}")
+            logger.warning(f"CoinGecko lookup failed for {stable['symbol']} on {chain_name}: {e}")
+            try:
+                from app.worker import _record_cycle_error
+                _record_cycle_error(
+                    error_type="services__get_stablecoin_addresses_on_chain_coingecko_lookup_failure",
+                    error_message=str(e)[:500],
+                    cycle_phase="chain_spec_generator",
+                )
+            except Exception:
+                pass
 
     return results
 

--- a/app/services/contagion_archive.py
+++ b/app/services/contagion_archive.py
@@ -165,8 +165,19 @@ async def _run_contagion_traversal(
                 ORDER BY wallet_address, computed_at DESC
             """, (connected_addrs,))
             risk_map = {r["wallet_address"]: r for r in (risk_rows or [])}
-    except Exception:
-        pass
+    except asyncio.CancelledError:
+        raise
+    except Exception as e:
+        logger.warning(f"contagion_archive: _run_contagion_traversal risk score lookup failed: {e}")
+        try:
+            from app.worker import _record_cycle_error
+            _record_cycle_error(
+                error_type="services__run_contagion_traversal_risk_lookup_failure",
+                error_message=str(e)[:500],
+                cycle_phase="contagion_archive",
+            )
+        except Exception:
+            pass
 
     affected = []
     for r in contagion_rows:
@@ -273,8 +284,19 @@ async def archive_contagion_event(
                 "trigger_after": trigger_after,
                 "detected_at": now.isoformat(),
             }], str(source_entity_id))
+        except asyncio.CancelledError:
+            raise
         except Exception as ae:
-            logger.debug(f"Contagion event attestation failed: {ae}")
+            logger.warning(f"Contagion event attestation failed: {ae}")
+            try:
+                from app.worker import _record_cycle_error
+                _record_cycle_error(
+                    error_type="services_archive_contagion_event_attestation_failure",
+                    error_message=str(ae)[:500],
+                    cycle_phase="contagion_archive",
+                )
+            except Exception:
+                pass
 
         depth2_wallets = propagation_summary.get("total_affected_wallets", 0)
         exposure = propagation_summary.get("estimated_exposure_usd", 0)
@@ -349,5 +371,16 @@ async def archive_divergence_signals(signals: list):
                 trigger_after=trigger_after,
                 severity=severity,
             )
+        except asyncio.CancelledError:
+            raise
         except Exception as e:
-            logger.debug(f"Failed to archive contagion for signal: {e}")
+            logger.warning(f"Failed to archive contagion for signal: {e}")
+            try:
+                from app.worker import _record_cycle_error
+                _record_cycle_error(
+                    error_type="services_archive_divergence_signals_archive_failure",
+                    error_message=str(e)[:500],
+                    cycle_phase="contagion_archive",
+                )
+            except Exception:
+                pass

--- a/app/services/firecrawl_client.py
+++ b/app/services/firecrawl_client.py
@@ -111,8 +111,17 @@ def discover_framer_pdfs(page_url: str) -> list[str]:
             finally:
                 try:
                     track_api_call(provider="firecrawl", endpoint="framer_module", caller="services.firecrawl_client", status=_status, latency_ms=int((time.monotonic() - _t0) * 1000))
-                except Exception:
-                    pass
+                except Exception as e:
+                    logger.warning(f"firecrawl_client: discover_framer_pdfs track_api_call failed: {e}")
+                    try:
+                        from app.worker import _record_cycle_error
+                        _record_cycle_error(
+                            error_type="services_discover_framer_pdfs_track_api_call_failure",
+                            error_message=str(e)[:500],
+                            cycle_phase="firecrawl_client",
+                        )
+                    except Exception:
+                        pass
             pdf_urls = re.findall(
                 r'https://framerusercontent\.com/assets/[A-Za-z0-9_]+\.pdf',
                 resp.text,
@@ -170,8 +179,17 @@ def identify_most_recent_attestation(pdf_urls: list[str]) -> str | None:
             finally:
                 try:
                     track_api_call(provider="firecrawl", endpoint="pdf_probe", caller="services.firecrawl_client", status=_status, latency_ms=int((time.monotonic() - _t0) * 1000))
-                except Exception:
-                    pass
+                except Exception as e:
+                    logger.warning(f"firecrawl_client: identify_most_recent_attestation track_api_call failed: {e}")
+                    try:
+                        from app.worker import _record_cycle_error
+                        _record_cycle_error(
+                            error_type="services_identify_most_recent_attestation_track_api_call_failure",
+                            error_message=str(e)[:500],
+                            cycle_phase="firecrawl_client",
+                        )
+                    except Exception:
+                        pass
             if len(resp.content) < 100_000:
                 continue  # Too small for an attestation report
 
@@ -197,8 +215,17 @@ def identify_most_recent_attestation(pdf_urls: list[str]) -> str | None:
                     if best_date is None or d > best_date:
                         best_date = d
                         best_url = url
-                except ValueError:
-                    pass
+                except ValueError as e:
+                    logger.warning(f"firecrawl_client: identify_most_recent_attestation date parse failed: {e}")
+                    try:
+                        from app.worker import _record_cycle_error
+                        _record_cycle_error(
+                            error_type="services_identify_most_recent_attestation_date_parse_failure",
+                            error_message=str(e)[:500],
+                            cycle_phase="firecrawl_client",
+                        )
+                    except Exception:
+                        pass
 
         except Exception as e:
             logger.warning(f"Firecrawl: Error checking PDF {url}: {e}")

--- a/app/services/historical_backfill.py
+++ b/app/services/historical_backfill.py
@@ -152,8 +152,17 @@ def backfill_coin_sync(
                     finally:
                         try:
                             track_api_call(provider="coingecko", endpoint=f"/coins/{coingecko_id}/market_chart/range", caller="services.historical_backfill", status=_status, latency_ms=int((time.monotonic() - _t0) * 1000))
-                        except Exception:
-                            pass
+                        except Exception as e:
+                            logger.warning(f"historical_backfill: backfill_coin_sync track_api_call failed: {e}")
+                            try:
+                                from app.worker import _record_cycle_error
+                                _record_cycle_error(
+                                    error_type="services_backfill_coin_sync_track_api_call_failure",
+                                    error_message=str(e)[:500],
+                                    cycle_phase="historical_backfill",
+                                )
+                            except Exception:
+                                pass
                     resp.raise_for_status()
                     data = resp.json()
                     break
@@ -197,8 +206,17 @@ def backfill_all_sync(from_date: str = "2020-01-01", to_date: str = None) -> dic
             "INSERT INTO backfill_status (coins_total, status) VALUES (%s, 'running')",
             (len(STABLECOIN_REGISTRY),)
         )
-    except Exception:
-        pass
+    except Exception as e:
+        logger.warning(f"historical_backfill: backfill_all_sync status row insert failed: {e}")
+        try:
+            from app.worker import _record_cycle_error
+            _record_cycle_error(
+                error_type="services_backfill_all_sync_status_insert_failure",
+                error_message=str(e)[:500],
+                cycle_phase="historical_backfill",
+            )
+        except Exception:
+            pass
 
     results = {}
     total = 0
@@ -216,8 +234,17 @@ def backfill_all_sync(from_date: str = "2020-01-01", to_date: str = None) -> dic
                    WHERE id = (SELECT MAX(id) FROM backfill_status)""",
                 (gecko_id, completed, total)
             )
-        except Exception:
-            pass
+        except Exception as e:
+            logger.warning(f"historical_backfill: backfill_all_sync status update failed: {e}")
+            try:
+                from app.worker import _record_cycle_error
+                _record_cycle_error(
+                    error_type="services_backfill_all_sync_status_update_failure",
+                    error_message=str(e)[:500],
+                    cycle_phase="historical_backfill",
+                )
+            except Exception:
+                pass
 
         logger.info(f"Backfilling {cfg['symbol']} ({gecko_id})...")
         count = backfill_coin_sync(gecko_id, from_date, to_date)
@@ -239,15 +266,33 @@ def backfill_all_sync(from_date: str = "2020-01-01", to_date: str = None) -> dic
                            WHERE id = (SELECT MAX(id) FROM backfill_status)""",
                         (gecko_id,)
                     )
-                except Exception:
-                    pass
+                except Exception as e:
+                    logger.warning(f"historical_backfill: backfill_all_sync promoted coin status update failed: {e}")
+                    try:
+                        from app.worker import _record_cycle_error
+                        _record_cycle_error(
+                            error_type="services_backfill_all_sync_promoted_status_update_failure",
+                            error_message=str(e)[:500],
+                            cycle_phase="historical_backfill",
+                        )
+                    except Exception:
+                        pass
                 logger.info(f"Backfilling promoted coin {gecko_id}...")
                 count = backfill_coin_sync(gecko_id, from_date, to_date)
                 results[gecko_id] = count
                 total += count
                 completed += 1
     except Exception as e:
-        logger.debug(f"Could not fetch promoted stablecoins: {e}")
+        logger.warning(f"Could not fetch promoted stablecoins: {e}")
+        try:
+            from app.worker import _record_cycle_error
+            _record_cycle_error(
+                error_type="services_backfill_all_sync_promoted_fetch_failure",
+                error_message=str(e)[:500],
+                cycle_phase="historical_backfill",
+            )
+        except Exception:
+            pass
 
     # Mark complete
     try:
@@ -257,8 +302,17 @@ def backfill_all_sync(from_date: str = "2020-01-01", to_date: str = None) -> dic
                WHERE id = (SELECT MAX(id) FROM backfill_status)""",
             (completed, total, _json.dumps(results))
         )
-    except Exception:
-        pass
+    except Exception as e:
+        logger.warning(f"historical_backfill: backfill_all_sync mark complete failed: {e}")
+        try:
+            from app.worker import _record_cycle_error
+            _record_cycle_error(
+                error_type="services_backfill_all_sync_mark_complete_failure",
+                error_message=str(e)[:500],
+                cycle_phase="historical_backfill",
+            )
+        except Exception:
+            pass
 
     logger.info(f"Backfill complete: {len(results)} coins, {total} total records")
     return {"coins": results, "total": total}

--- a/app/services/parallel_client.py
+++ b/app/services/parallel_client.py
@@ -70,8 +70,19 @@ async def extract(url: str, objective: str = None, full_content: bool = True) ->
             finally:
                 try:
                     track_api_call(provider="parallel", endpoint="/v1beta/extract", caller="services.parallel_client", status=_status, latency_ms=int((time.monotonic() - _t0) * 1000))
-                except Exception:
-                    pass
+                except asyncio.CancelledError:
+                    raise
+                except Exception as _track_err:
+                    logger.warning(f"parallel_client: extract track_api_call failed: {_track_err}")
+                    try:
+                        from app.worker import _record_cycle_error
+                        _record_cycle_error(
+                            error_type="services_extract_track_api_call_failure",
+                            error_message=str(_track_err)[:500],
+                            cycle_phase="parallel_client",
+                        )
+                    except Exception:
+                        pass
             resp.raise_for_status()
             return resp.json()
         except Exception as e:
@@ -111,8 +122,19 @@ async def extract_batch(urls: List[str], objective: str = None, full_content: bo
             finally:
                 try:
                     track_api_call(provider="parallel", endpoint="/v1beta/extract_batch", caller="services.parallel_client", status=_status, latency_ms=int((time.monotonic() - _t0) * 1000))
-                except Exception:
-                    pass
+                except asyncio.CancelledError:
+                    raise
+                except Exception as _track_err:
+                    logger.warning(f"parallel_client: extract_batch track_api_call failed: {_track_err}")
+                    try:
+                        from app.worker import _record_cycle_error
+                        _record_cycle_error(
+                            error_type="services_extract_batch_track_api_call_failure",
+                            error_message=str(_track_err)[:500],
+                            cycle_phase="parallel_client",
+                        )
+                    except Exception:
+                        pass
             resp.raise_for_status()
             return resp.json()
         except Exception as e:
@@ -148,8 +170,19 @@ async def search(query: str, num_results: int = 10) -> dict:
             finally:
                 try:
                     track_api_call(provider="parallel", endpoint="/v1beta/search", caller="services.parallel_client", status=_status, latency_ms=int((time.monotonic() - _t0) * 1000))
-                except Exception:
-                    pass
+                except asyncio.CancelledError:
+                    raise
+                except Exception as _track_err:
+                    logger.warning(f"parallel_client: search track_api_call failed: {_track_err}")
+                    try:
+                        from app.worker import _record_cycle_error
+                        _record_cycle_error(
+                            error_type="services_search_track_api_call_failure",
+                            error_message=str(_track_err)[:500],
+                            cycle_phase="parallel_client",
+                        )
+                    except Exception:
+                        pass
             resp.raise_for_status()
             return resp.json()
         except Exception as e:
@@ -220,8 +253,19 @@ async def task(
             finally:
                 try:
                     track_api_call(provider="parallel", endpoint="/v1/tasks/runs", caller="services.parallel_client", status=_status, latency_ms=int((time.monotonic() - _t0) * 1000))
-                except Exception:
-                    pass
+                except asyncio.CancelledError:
+                    raise
+                except Exception as _track_err:
+                    logger.warning(f"parallel_client: task create track_api_call failed: {_track_err}")
+                    try:
+                        from app.worker import _record_cycle_error
+                        _record_cycle_error(
+                            error_type="services_task_create_track_api_call_failure",
+                            error_message=str(_track_err)[:500],
+                            cycle_phase="parallel_client",
+                        )
+                    except Exception:
+                        pass
             resp.raise_for_status()
             run_data = resp.json()
         except Exception as e:
@@ -252,8 +296,19 @@ async def task(
             finally:
                 try:
                     track_api_call(provider="parallel", endpoint="/v1/tasks/runs/result", caller="services.parallel_client", status=_status, latency_ms=int((time.monotonic() - _t0) * 1000))
-                except Exception:
-                    pass
+                except asyncio.CancelledError:
+                    raise
+                except Exception as _track_err:
+                    logger.warning(f"parallel_client: task result track_api_call failed: {_track_err}")
+                    try:
+                        from app.worker import _record_cycle_error
+                        _record_cycle_error(
+                            error_type="services_task_result_track_api_call_failure",
+                            error_message=str(_track_err)[:500],
+                            cycle_phase="parallel_client",
+                        )
+                    except Exception:
+                        pass
             resp.raise_for_status()
             result = resp.json()
         except httpx.HTTPStatusError as e:
@@ -326,8 +381,19 @@ async def monitor_create(
             finally:
                 try:
                     track_api_call(provider="parallel", endpoint="/v1alpha/monitors", caller="services.parallel_client", status=_status, latency_ms=int((time.monotonic() - _t0) * 1000))
-                except Exception:
-                    pass
+                except asyncio.CancelledError:
+                    raise
+                except Exception as _track_err:
+                    logger.warning(f"parallel_client: monitor_create track_api_call failed: {_track_err}")
+                    try:
+                        from app.worker import _record_cycle_error
+                        _record_cycle_error(
+                            error_type="services_monitor_create_track_api_call_failure",
+                            error_message=str(_track_err)[:500],
+                            cycle_phase="parallel_client",
+                        )
+                    except Exception:
+                        pass
             resp.raise_for_status()
             return resp.json()
         except httpx.HTTPStatusError as e:
@@ -360,8 +426,19 @@ async def monitor_list() -> dict:
             finally:
                 try:
                     track_api_call(provider="parallel", endpoint="/v1alpha/monitors", caller="services.parallel_client", status=_status, latency_ms=int((time.monotonic() - _t0) * 1000))
-                except Exception:
-                    pass
+                except asyncio.CancelledError:
+                    raise
+                except Exception as _track_err:
+                    logger.warning(f"parallel_client: monitor_list track_api_call failed: {_track_err}")
+                    try:
+                        from app.worker import _record_cycle_error
+                        _record_cycle_error(
+                            error_type="services_monitor_list_track_api_call_failure",
+                            error_message=str(_track_err)[:500],
+                            cycle_phase="parallel_client",
+                        )
+                    except Exception:
+                        pass
             resp.raise_for_status()
             return resp.json()
         except Exception as e:
@@ -390,8 +467,19 @@ async def monitor_delete(monitor_id: str) -> dict:
             finally:
                 try:
                     track_api_call(provider="parallel", endpoint=f"/v1alpha/monitors/{monitor_id}", caller="services.parallel_client", status=_status, latency_ms=int((time.monotonic() - _t0) * 1000))
-                except Exception:
-                    pass
+                except asyncio.CancelledError:
+                    raise
+                except Exception as _track_err:
+                    logger.warning(f"parallel_client: monitor_delete track_api_call failed: {_track_err}")
+                    try:
+                        from app.worker import _record_cycle_error
+                        _record_cycle_error(
+                            error_type="services_monitor_delete_track_api_call_failure",
+                            error_message=str(_track_err)[:500],
+                            cycle_phase="parallel_client",
+                        )
+                    except Exception:
+                        pass
             resp.raise_for_status()
             return resp.json()
         except Exception as e:
@@ -421,8 +509,19 @@ async def monitor_events(monitor_id: str, lookback: str = "10d") -> dict:
             finally:
                 try:
                     track_api_call(provider="parallel", endpoint=f"/v1alpha/monitors/{monitor_id}/events", caller="services.parallel_client", status=_status, latency_ms=int((time.monotonic() - _t0) * 1000))
-                except Exception:
-                    pass
+                except asyncio.CancelledError:
+                    raise
+                except Exception as _track_err:
+                    logger.warning(f"parallel_client: monitor_events track_api_call failed: {_track_err}")
+                    try:
+                        from app.worker import _record_cycle_error
+                        _record_cycle_error(
+                            error_type="services_monitor_events_track_api_call_failure",
+                            error_message=str(_track_err)[:500],
+                            cycle_phase="parallel_client",
+                        )
+                    except Exception:
+                        pass
             resp.raise_for_status()
             return resp.json()
         except Exception as e:

--- a/app/services/psi_backfill.py
+++ b/app/services/psi_backfill.py
@@ -77,8 +77,17 @@ def backfill_protocol_tvl(slug: str) -> int:
         finally:
             try:
                 track_api_call(provider="defillama", endpoint=f"/protocol/{slug}", caller="services.psi_backfill", status=_status, latency_ms=int((time.monotonic() - _t0) * 1000))
-            except Exception:
-                pass
+            except Exception as _track_err:
+                logger.warning(f"psi_backfill: backfill_protocol_tvl track_api_call failed: {_track_err}")
+                try:
+                    from app.worker import _record_cycle_error
+                    _record_cycle_error(
+                        error_type="services_backfill_protocol_tvl_track_api_call_failure",
+                        error_message=str(_track_err)[:500],
+                        cycle_phase="psi_backfill",
+                    )
+                except Exception:
+                    pass
         if resp.status_code != 200:
             logger.warning(f"DeFiLlama {slug} returned {resp.status_code}")
             return 0
@@ -119,7 +128,16 @@ def backfill_protocol_tvl(slug: str) -> int:
             """, (slug, record_date.isoformat(), tvl_val, chain_count))
             records += 1
         except Exception as e:
-            logger.debug(f"TVL insert error for {slug} @ {record_date}: {e}")
+            logger.warning(f"TVL insert error for {slug} @ {record_date}: {e}")
+            try:
+                from app.worker import _record_cycle_error
+                _record_cycle_error(
+                    error_type="services_backfill_protocol_tvl_insert_failure",
+                    error_message=str(e)[:500],
+                    cycle_phase="psi_backfill",
+                )
+            except Exception:
+                pass
 
     logger.info(f"Backfilled {records} TVL records for {slug}")
     return records
@@ -158,8 +176,17 @@ def backfill_protocol_token(slug: str, gecko_id: str, from_date: str = "2024-01-
             finally:
                 try:
                     track_api_call(provider="coingecko", endpoint=f"/coins/{gecko_id}/market_chart/range", caller="services.psi_backfill", status=_status, latency_ms=int((time.monotonic() - _t0) * 1000))
-                except Exception:
-                    pass
+                except Exception as _track_err:
+                    logger.warning(f"psi_backfill: backfill_protocol_token track_api_call failed: {_track_err}")
+                    try:
+                        from app.worker import _record_cycle_error
+                        _record_cycle_error(
+                            error_type="services_backfill_protocol_token_track_api_call_failure",
+                            error_message=str(_track_err)[:500],
+                            cycle_phase="psi_backfill",
+                        )
+                    except Exception:
+                        pass
             if resp.status_code == 429:
                 logger.warning("CoinGecko rate limit — sleeping 60s")
                 time.sleep(5)
@@ -202,8 +229,17 @@ def backfill_protocol_token(slug: str, gecko_id: str, from_date: str = "2024-01-
                         token_volume = COALESCE(EXCLUDED.token_volume, historical_protocol_data.token_volume)
                 """, (slug, d.isoformat(), price, mcap_map.get(d), vol_map.get(d)))
                 records += 1
-            except Exception:
-                pass
+            except Exception as e:
+                logger.warning(f"psi_backfill: backfill_protocol_token insert failed for {slug} @ {d}: {e}")
+                try:
+                    from app.worker import _record_cycle_error
+                    _record_cycle_error(
+                        error_type="services_backfill_protocol_token_insert_failure",
+                        error_message=str(e)[:500],
+                        cycle_phase="psi_backfill",
+                    )
+                except Exception:
+                    pass
 
         current = chunk_end
         time.sleep(0.2)

--- a/app/services/psi_temporal_engine.py
+++ b/app/services/psi_temporal_engine.py
@@ -152,8 +152,17 @@ def reconstruct_psi_score(slug: str, target_date: date) -> dict:
             if len(daily_returns) > 1:
                 raw_values["token_price_volatility_30d"] = statistics.stdev(daily_returns) * 100
                 sources["token_price_volatility_30d"] = "calculated_from_historical"
-        except Exception:
-            pass
+        except Exception as e:
+            logger.warning(f"psi_temporal_engine: reconstruct_psi_score volatility calc failed: {e}")
+            try:
+                from app.worker import _record_cycle_error
+                _record_cycle_error(
+                    error_type="services_reconstruct_psi_score_volatility_calc_failure",
+                    error_message=str(e)[:500],
+                    cycle_phase="psi_temporal_engine",
+                )
+            except Exception:
+                pass
 
     # 4. Carry-forward from latest live scoring (fees, utilization, audits)
     latest_raw = _get_latest_psi_raw(slug)

--- a/app/services/reducto_client.py
+++ b/app/services/reducto_client.py
@@ -4,6 +4,7 @@ PDF document parsing with schema-level extraction and confidence scoring.
 Used for attestation PDFs (Grant Thornton, BDO, Deloitte reports).
 Docs: https://docs.reducto.ai
 """
+import asyncio
 import os
 import time
 import httpx
@@ -301,8 +302,19 @@ async def parse_pdf(pdf_url: str, schema: dict = None, disclosure_type: str = No
             finally:
                 try:
                     track_api_call(provider="reducto", endpoint="/extract", caller="services.reducto_client", status=_status, latency_ms=int((time.monotonic() - _t0) * 1000))
-                except Exception:
-                    pass
+                except asyncio.CancelledError:
+                    raise
+                except Exception as _track_err:
+                    logger.warning(f"reducto_client: parse_pdf track_api_call failed: {_track_err}")
+                    try:
+                        from app.worker import _record_cycle_error
+                        _record_cycle_error(
+                            error_type="services_parse_pdf_track_api_call_failure",
+                            error_message=str(_track_err)[:500],
+                            cycle_phase="reducto_client",
+                        )
+                    except Exception:
+                        pass
             resp.raise_for_status()
             return resp.json()
         except Exception as e:
@@ -336,8 +348,19 @@ async def parse_to_markdown(pdf_url: str) -> dict:
             finally:
                 try:
                     track_api_call(provider="reducto", endpoint="/parse", caller="services.reducto_client", status=_status, latency_ms=int((time.monotonic() - _t0) * 1000))
-                except Exception:
-                    pass
+                except asyncio.CancelledError:
+                    raise
+                except Exception as _track_err:
+                    logger.warning(f"reducto_client: parse_to_markdown track_api_call failed: {_track_err}")
+                    try:
+                        from app.worker import _record_cycle_error
+                        _record_cycle_error(
+                            error_type="services_parse_to_markdown_track_api_call_failure",
+                            error_message=str(_track_err)[:500],
+                            cycle_phase="reducto_client",
+                        )
+                    except Exception:
+                        pass
             resp.raise_for_status()
             return resp.json()
         except Exception as e:

--- a/app/services/tti_disclosure_collector.py
+++ b/app/services/tti_disclosure_collector.py
@@ -121,8 +121,19 @@ async def _store_extraction(entity_slug: str, entity_name: str, source_url: str,
             CREATE UNIQUE INDEX IF NOT EXISTS idx_tti_disc_entity_source
             ON tti_disclosure_extractions(entity_slug, source_url)
         """)
-    except Exception:
-        pass
+    except asyncio.CancelledError:
+        raise
+    except Exception as e:
+        logger.warning(f"tti_disclosure_collector: _store_extraction index ensure failed: {e}")
+        try:
+            from app.worker import _record_cycle_error
+            _record_cycle_error(
+                error_type="services__store_extraction_index_ensure_failure",
+                error_message=str(e)[:500],
+                cycle_phase="tti_disclosure_collector",
+            )
+        except Exception:
+            pass
 
     await execute_async("""
         INSERT INTO tti_disclosure_extractions
@@ -309,7 +320,16 @@ def _try_scrape_page(url: str, entity_slug: str = "") -> str | None:
                     logger.info(f"TTI Parallel Extract OK for {entity_slug}: {len(content)} chars")
                     return content
     except Exception as e:
-        logger.debug(f"Parallel Extract failed for {url}: {e}")
+        logger.warning(f"Parallel Extract failed for {url}: {e}")
+        try:
+            from app.worker import _record_cycle_error
+            _record_cycle_error(
+                error_type="services__try_scrape_page_parallel_extract_failure",
+                error_message=str(e)[:500],
+                cycle_phase="tti_disclosure_collector",
+            )
+        except Exception:
+            pass
 
     # Fallback to Firecrawl (JS-rendered page scraping)
     try:
@@ -320,7 +340,16 @@ def _try_scrape_page(url: str, entity_slug: str = "") -> str | None:
         if isinstance(result, dict) and result.get("markdown"):
             return result["markdown"]
     except Exception as e:
-        logger.debug(f"Firecrawl scrape failed for {url}: {e}")
+        logger.warning(f"Firecrawl scrape failed for {url}: {e}")
+        try:
+            from app.worker import _record_cycle_error
+            _record_cycle_error(
+                error_type="services__try_scrape_page_firecrawl_scrape_failure",
+                error_message=str(e)[:500],
+                cycle_phase="tti_disclosure_collector",
+            )
+        except Exception:
+            pass
 
     # Last resort: plain requests
     try:
@@ -338,13 +367,31 @@ def _try_scrape_page(url: str, entity_slug: str = "") -> str | None:
                 from urllib.parse import urlparse as _urlparse
                 _provider = _urlparse(url).netloc or "unknown"
                 track_api_call(provider=_provider, endpoint="GET", caller="services.tti_disclosure_collector", status=_status, latency_ms=int((time.monotonic() - _t0) * 1000))
-            except Exception:
-                pass
+            except Exception as _track_err:
+                logger.warning(f"tti_disclosure_collector: _try_scrape_page track_api_call failed: {_track_err}")
+                try:
+                    from app.worker import _record_cycle_error
+                    _record_cycle_error(
+                        error_type="services__try_scrape_page_track_api_call_failure",
+                        error_message=str(_track_err)[:500],
+                        cycle_phase="tti_disclosure_collector",
+                    )
+                except Exception:
+                    pass
         if resp.status_code == 200:
             text = re.sub(r'<[^>]+>', ' ', resp.text)
             return re.sub(r'\s+', ' ', text).strip()
     except Exception as e:
-        logger.debug(f"Requests fallback also failed for {url}: {e}")
+        logger.warning(f"Requests fallback also failed for {url}: {e}")
+        try:
+            from app.worker import _record_cycle_error
+            _record_cycle_error(
+                error_type="services__try_scrape_page_requests_fallback_failure",
+                error_message=str(e)[:500],
+                cycle_phase="tti_disclosure_collector",
+            )
+        except Exception:
+            pass
 
     return None
 
@@ -454,8 +501,17 @@ def _try_parallel_task_research(entity_slug: str, entity_name: str, issuer: str)
                 if settle:
                     try:
                         data["settlement_time_hours"] = int(re.sub(r'[^\d]', '', str(settle)))
-                    except (ValueError, TypeError):
-                        pass
+                    except (ValueError, TypeError) as e:
+                        logger.warning(f"tti_disclosure_collector: _try_parallel_task_research settlement_time parse failed: {e}")
+                        try:
+                            from app.worker import _record_cycle_error
+                            _record_cycle_error(
+                                error_type="services__try_parallel_task_research_settlement_time_parse_failure",
+                                error_message=str(e)[:500],
+                                cycle_phase="tti_disclosure_collector",
+                            )
+                        except Exception:
+                            pass
 
                 logger.info(f"TTI Parallel Task OK for {entity_slug}: {len(data)} fields")
                 return data

--- a/tools/audit/bare_except_audit.py
+++ b/tools/audit/bare_except_audit.py
@@ -1,0 +1,490 @@
+#!/usr/bin/env python3
+"""
+Bare-except audit (Wave C / V9.12 Class 2).
+
+Walks the AST of every Python file under a given root and emits a structured
+report of every `except` block. Classifies each block so the conversion Wave
+can target the `debug_only` cohort (the V9.12 Class 2 silent-failure pattern).
+
+Background
+----------
+V9.12 Class 2 ("silent-except-on-debug") names a bug class where `except
+Exception` blocks absorb errors and only `logger.debug(...)` them. At debug
+log level (filtered in production) the failure is invisible: no metric, no
+`cycle_errors` row, no operator visibility. The April 12 cluster outage was
+caused by three of these in the orphaned actor_classification chain.
+
+Usage
+-----
+    python tools/audit/bare_except_audit.py app/                 # CSV to stdout
+    python tools/audit/bare_except_audit.py app/collectors/      # subsystem
+    python tools/audit/bare_except_audit.py app/ --summary       # summary only
+    python tools/audit/bare_except_audit.py app/ --classification debug_only
+
+CI gate
+-------
+    python tools/audit/bare_except_audit.py app/ \
+        --max-debug-only 10 --fail-on-regression
+
+Exit codes:
+    0  — all checks passed (no thresholds set, or thresholds met)
+    1  — a threshold check failed (CI gate hit)
+    2  — usage / IO error
+"""
+
+import argparse
+import ast
+import csv
+import os
+import sys
+from pathlib import Path
+from typing import Optional
+
+
+CLASSIFICATIONS = (
+    "debug_only",
+    "info_log",
+    "warn_log",
+    "error_log",
+    "cycle_errors_write",
+    "reraise",
+    "return_error_sentinel",
+    "complex",
+    "bare_except",          # `except:` or `except BaseException:` — Rule 6
+)
+
+
+# ---------------------------------------------------------------------------
+# AST helpers
+# ---------------------------------------------------------------------------
+
+def _parent_map(tree: ast.AST) -> dict[int, ast.AST]:
+    """Build {id(child): parent} map by walking the tree once."""
+    parents: dict[int, ast.AST] = {}
+    for parent in ast.walk(tree):
+        for child in ast.iter_child_nodes(parent):
+            parents[id(child)] = parent
+    return parents
+
+
+def _enclosing_function(node: ast.AST, parents: dict[int, ast.AST]) -> Optional[ast.AST]:
+    """Return the nearest enclosing FunctionDef or AsyncFunctionDef, or None."""
+    cur: Optional[ast.AST] = parents.get(id(node))
+    while cur is not None:
+        if isinstance(cur, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            return cur
+        cur = parents.get(id(cur))
+    return None
+
+
+def _attr_chain_name(node: ast.AST) -> Optional[str]:
+    """Return the rightmost attribute name in an attribute chain, or the Name."""
+    if isinstance(node, ast.Attribute):
+        return node.attr
+    if isinstance(node, ast.Name):
+        return node.id
+    return None
+
+
+def _is_logger_call(call: ast.Call, level: str) -> bool:
+    """True iff the Call looks like `<something>.<level>(...)` — typically
+    `logger.debug(...)` or `log.debug(...)`. Also matches bare `<level>(...)`
+    if `level` is something like `print`."""
+    f = call.func
+    if isinstance(f, ast.Attribute) and f.attr == level:
+        return True
+    if level == "print" and isinstance(f, ast.Name) and f.id == "print":
+        return True
+    return False
+
+
+def _is_record_cycle_error_call(call: ast.Call) -> bool:
+    """Match any reference to _record_cycle_error / record_cycle_error.
+    The function may be imported under either name."""
+    f = call.func
+    name = _attr_chain_name(f)
+    return name in {"_record_cycle_error", "record_cycle_error"}
+
+
+def _is_sentinel_return(stmt: ast.AST) -> bool:
+    """True iff stmt is `return X` where X is None, an empty container,
+    a constant zero/False, or a missing return value."""
+    if not isinstance(stmt, ast.Return):
+        return False
+    v = stmt.value
+    if v is None:
+        return True
+    if isinstance(v, ast.Constant) and v.value in (None, 0, 0.0, False, "", b""):
+        return True
+    if isinstance(v, (ast.List, ast.Tuple, ast.Set)) and not v.elts:
+        return True
+    if isinstance(v, ast.Dict) and not v.keys:
+        return True
+    # `return -1` — UnaryOp wrapping a 0/1 constant is sentinel-ish
+    if (isinstance(v, ast.UnaryOp) and isinstance(v.op, ast.USub)
+            and isinstance(v.operand, ast.Constant)
+            and v.operand.value in (0, 1, 0.0, 1.0)):
+        return True
+    return False
+
+
+def _body_has(body: list[ast.AST], predicate) -> bool:
+    """True iff any top-level statement in body matches predicate.
+    Does not descend into nested functions / class bodies."""
+    for stmt in body:
+        if isinstance(stmt, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+            continue
+        for node in ast.walk(stmt):
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+                # don't recurse — but ast.walk already yielded; skip via predicate
+                continue
+            if predicate(node):
+                return True
+    return False
+
+
+def _has_raise(body: list[ast.AST]) -> bool:
+    """True iff body re-raises (at top level, not buried in try/except).
+    A bare `raise` or `raise X` counts. We allow `raise` inside `if/else`
+    blocks in the body, but not inside nested try/except handlers."""
+    def walk(stmts: list[ast.AST]) -> bool:
+        for s in stmts:
+            if isinstance(s, ast.Raise):
+                return True
+            if isinstance(s, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+                continue
+            if isinstance(s, ast.If):
+                if walk(s.body) or walk(s.orelse):
+                    return True
+            elif isinstance(s, (ast.For, ast.While, ast.AsyncFor, ast.With, ast.AsyncWith)):
+                if walk(s.body):
+                    return True
+            elif isinstance(s, ast.Try):
+                # a raise inside a nested try's handler is not the same as
+                # this except block re-raising. only count raises in the try body.
+                if walk(s.body):
+                    return True
+        return False
+    return walk(body)
+
+
+def _has_cycle_errors_write(body: list[ast.AST]) -> bool:
+    for stmt in body:
+        for node in ast.walk(stmt):
+            if isinstance(node, ast.Call) and _is_record_cycle_error_call(node):
+                return True
+    return False
+
+
+def _logger_call_levels(body: list[ast.AST]) -> set[str]:
+    """Return set of logger levels used at the top level of body."""
+    levels = set()
+    for stmt in body:
+        for node in ast.walk(stmt):
+            if not isinstance(node, ast.Call):
+                continue
+            f = node.func
+            if isinstance(f, ast.Attribute):
+                if f.attr in {"debug", "info", "warning", "warn",
+                              "error", "exception", "critical"}:
+                    levels.add(f.attr)
+            elif isinstance(f, ast.Name) and f.id == "print":
+                levels.add("print")
+    return levels
+
+
+def _is_only_pass_or_comment(body: list[ast.AST]) -> bool:
+    """True iff body is empty, only `pass`, or only ellipsis."""
+    if not body:
+        return True
+    for stmt in body:
+        if isinstance(stmt, ast.Pass):
+            continue
+        if (isinstance(stmt, ast.Expr) and isinstance(stmt.value, ast.Constant)
+                and stmt.value.value is Ellipsis):
+            continue
+        return False
+    return True
+
+
+def _statement_kind(stmt: ast.AST) -> str:
+    """Tag a single body statement so we can compose a body classification."""
+    if isinstance(stmt, ast.Pass):
+        return "pass"
+    if (isinstance(stmt, ast.Expr) and isinstance(stmt.value, ast.Constant)
+            and stmt.value.value is Ellipsis):
+        return "pass"
+    if isinstance(stmt, ast.Return):
+        return "sentinel_return" if _is_sentinel_return(stmt) else "value_return"
+    if isinstance(stmt, ast.Raise):
+        return "raise"
+    if isinstance(stmt, ast.Continue):
+        return "continue"
+    if isinstance(stmt, ast.Break):
+        return "break"
+    if isinstance(stmt, ast.Expr) and isinstance(stmt.value, ast.Call):
+        f = stmt.value.func
+        if isinstance(f, ast.Attribute):
+            if f.attr in {"debug", "info", "warning", "warn",
+                          "error", "exception", "critical"}:
+                return f"log_{f.attr}"
+            if _is_record_cycle_error_call(stmt.value):
+                return "cycle_errors_write"
+        if isinstance(f, ast.Name):
+            if f.id == "print":
+                return "log_debug"
+            if f.id in {"_record_cycle_error", "record_cycle_error"}:
+                return "cycle_errors_write"
+        return "expr_call"
+    return "other"
+
+
+# ---------------------------------------------------------------------------
+# Classification
+# ---------------------------------------------------------------------------
+
+def classify(handler: ast.ExceptHandler) -> str:
+    """Apply the rules from the audit spec to one ExceptHandler."""
+    body = handler.body
+
+    # Rule 6: bare `except:` or `except BaseException:` — always flag.
+    exc_type = handler.type
+    if exc_type is None:
+        return "bare_except"
+    if isinstance(exc_type, ast.Name) and exc_type.id == "BaseException":
+        return "bare_except"
+
+    # cycle_errors_write takes precedence over everything else.
+    if _has_cycle_errors_write(body):
+        return "cycle_errors_write"
+
+    # reraise next.
+    if _has_raise(body):
+        return "reraise"
+
+    # Empty / pass body — debug_only (silent absorber).
+    if _is_only_pass_or_comment(body):
+        return "debug_only"
+
+    levels = _logger_call_levels(body)
+    kinds = [_statement_kind(s) for s in body]
+    non_trivial = [
+        k for k in kinds
+        if k not in {"pass", "sentinel_return", "continue", "break"}
+    ]
+
+    # Body that's purely sentinel-returning (no logging at all) →
+    # return_error_sentinel.
+    if not levels and all(
+            k in {"pass", "sentinel_return", "continue", "break"} for k in kinds):
+        # If the body is JUST a sentinel return / continue / break, that is the
+        # explicit "swallow and produce a default" pattern.
+        if any(k in {"sentinel_return", "continue", "break"} for k in kinds):
+            return "return_error_sentinel"
+        return "debug_only"
+
+    # Single-level logger usage with optional sentinel return / pass.
+    log_only_kinds = {
+        f"log_{lv}" for lv in {"debug", "info", "warning", "warn",
+                               "error", "exception", "critical"}
+    } | {"sentinel_return", "pass", "continue", "break"}
+
+    if all(k in log_only_kinds for k in kinds):
+        # Pick the highest-severity logger level present.
+        if "debug" in levels and not (levels - {"debug"}):
+            return "debug_only"
+        # If only print() is used, treat as debug_only.
+        if levels == {"print"}:
+            return "debug_only"
+        if "debug" in levels and levels.issubset({"debug", "print"}):
+            return "debug_only"
+        if "info" in levels and levels.issubset({"info", "debug", "print"}):
+            return "info_log"
+        if levels & {"warning", "warn"} and not (levels & {"error", "exception", "critical"}):
+            return "warn_log"
+        if levels & {"error", "exception", "critical"}:
+            return "error_log"
+
+    # Anything more elaborate (manual cleanup, fallback logic, retries, etc.)
+    # needs human review.
+    return "complex"
+
+
+# ---------------------------------------------------------------------------
+# File walk
+# ---------------------------------------------------------------------------
+
+def _body_preview(handler: ast.ExceptHandler, src_lines: list[str]) -> str:
+    """One-line preview of the first 1-2 statements of the except body."""
+    if not handler.body:
+        return ""
+    first = handler.body[0]
+    end = getattr(handler.body[-1], "end_lineno", handler.body[-1].lineno)
+    start = first.lineno
+    snippet_lines = src_lines[start - 1: min(end, start + 1)]
+    snippet = " ".join(s.strip() for s in snippet_lines)
+    snippet = snippet.replace("\n", " ").replace("\r", " ")
+    if len(snippet) > 160:
+        snippet = snippet[:157] + "..."
+    return snippet
+
+
+def audit_file(path: Path) -> list[dict]:
+    """Return a list of finding dicts for one file."""
+    try:
+        src = path.read_text(encoding="utf-8")
+        tree = ast.parse(src, filename=str(path))
+    except (SyntaxError, UnicodeDecodeError) as e:
+        print(f"# audit: skip {path}: {e}", file=sys.stderr)
+        return []
+
+    parents = _parent_map(tree)
+    src_lines = src.splitlines()
+    findings = []
+
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.ExceptHandler):
+            continue
+        fn = _enclosing_function(node, parents)
+        is_async = isinstance(fn, ast.AsyncFunctionDef)
+        fn_name = fn.name if fn is not None else "<module>"
+        err_var = node.name or ""
+        classification = classify(node)
+        first_is_return = (
+            bool(node.body)
+            and isinstance(node.body[0], ast.Return)
+        )
+        findings.append({
+            "path": str(path),
+            "line": node.lineno,
+            "function": fn_name,
+            "classification": classification,
+            "is_async": "1" if is_async else "0",
+            "error_var": err_var,
+            "first_is_return": "1" if first_is_return else "0",
+            "body_preview": _body_preview(node, src_lines),
+        })
+    return findings
+
+
+def walk_root(root: Path) -> list[dict]:
+    findings = []
+    if root.is_file() and root.suffix == ".py":
+        return audit_file(root)
+    for path in sorted(root.rglob("*.py")):
+        # Skip __pycache__ and similar.
+        if any(part.startswith(".") or part == "__pycache__" for part in path.parts):
+            continue
+        findings.extend(audit_file(path))
+    return findings
+
+
+# ---------------------------------------------------------------------------
+# Output
+# ---------------------------------------------------------------------------
+
+def write_csv(findings: list[dict], out) -> None:
+    fieldnames = [
+        "path", "line", "function", "classification",
+        "is_async", "error_var", "first_is_return", "body_preview",
+    ]
+    writer = csv.DictWriter(out, fieldnames=fieldnames)
+    writer.writeheader()
+    for f in findings:
+        writer.writerow(f)
+
+
+def summary(findings: list[dict]) -> dict[str, int]:
+    counts = {c: 0 for c in CLASSIFICATIONS}
+    for f in findings:
+        counts[f["classification"]] = counts.get(f["classification"], 0) + 1
+    counts["TOTAL"] = len(findings)
+    return counts
+
+
+def print_summary(counts: dict[str, int], out=sys.stdout) -> None:
+    print("# bare-except audit summary", file=out)
+    print(f"#   total: {counts['TOTAL']}", file=out)
+    for c in CLASSIFICATIONS:
+        print(f"#   {c:<24} {counts.get(c, 0)}", file=out)
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+def main() -> int:
+    p = argparse.ArgumentParser(description="Audit bare-except blocks (V9.12 Class 2).")
+    p.add_argument("root", help="Directory or .py file to audit (e.g. app/, app/collectors/)")
+    p.add_argument("--summary", action="store_true",
+                   help="Print summary counts only (no CSV body)")
+    p.add_argument("--classification", default=None,
+                   help="Filter to one classification (e.g. debug_only)")
+    p.add_argument("--max-debug-only", type=int, default=None,
+                   help="CI gate: fail if debug_only count exceeds this number")
+    p.add_argument("--fail-on-regression", action="store_true",
+                   help="CI gate: combined with --max-debug-only, exit 1 if exceeded")
+    p.add_argument("--baseline", default=None,
+                   help="Path to a previous audit CSV; report deltas relative to it")
+    args = p.parse_args()
+
+    root = Path(args.root)
+    if not root.exists():
+        print(f"audit: root '{root}' not found", file=sys.stderr)
+        return 2
+
+    findings = walk_root(root)
+
+    if args.classification:
+        if args.classification not in CLASSIFICATIONS:
+            print(
+                f"audit: unknown classification '{args.classification}'. "
+                f"valid: {', '.join(CLASSIFICATIONS)}",
+                file=sys.stderr,
+            )
+            return 2
+        findings = [f for f in findings if f["classification"] == args.classification]
+
+    counts = summary(findings)
+
+    if args.summary:
+        print_summary(counts)
+    else:
+        write_csv(findings, sys.stdout)
+        print_summary(counts, out=sys.stderr)
+
+    # Baseline regression report (printed to stderr; doesn't affect exit code
+    # on its own — combine with --fail-on-regression for CI use).
+    if args.baseline:
+        try:
+            with open(args.baseline) as fh:
+                base_rows = list(csv.DictReader(fh))
+            base_counts = {c: 0 for c in CLASSIFICATIONS}
+            for r in base_rows:
+                base_counts[r["classification"]] = base_counts.get(r["classification"], 0) + 1
+            print("# baseline delta", file=sys.stderr)
+            for c in CLASSIFICATIONS:
+                delta = counts.get(c, 0) - base_counts.get(c, 0)
+                if delta:
+                    sign = "+" if delta > 0 else ""
+                    print(f"#   {c:<24} {sign}{delta}", file=sys.stderr)
+        except OSError as e:
+            print(f"audit: could not read baseline: {e}", file=sys.stderr)
+
+    # CI gate.
+    if args.max_debug_only is not None:
+        debug_only = counts.get("debug_only", 0)
+        if debug_only > args.max_debug_only:
+            print(
+                f"audit: debug_only={debug_only} exceeds threshold "
+                f"{args.max_debug_only}",
+                file=sys.stderr,
+            )
+            if args.fail_on_regression:
+                return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/audit/bare_except_audit.py
+++ b/tools/audit/bare_except_audit.py
@@ -47,6 +47,7 @@ CLASSIFICATIONS = (
     "warn_log",
     "error_log",
     "cycle_errors_write",
+    "cycle_errors_protective_wrapper",  # inner `except: pass` around _record_cycle_error itself
     "reraise",
     "return_error_sentinel",
     "complex",
@@ -243,7 +244,46 @@ def _statement_kind(stmt: ast.AST) -> str:
 # Classification
 # ---------------------------------------------------------------------------
 
-def classify(handler: ast.ExceptHandler) -> str:
+def _is_protective_cycle_error_wrapper(handler: ast.ExceptHandler,
+                                       parents: dict[int, ast.AST]) -> bool:
+    """Detect the spec-mandated defensive wrapper pattern around
+    ``_record_cycle_error`` itself:
+
+        try:
+            from app.worker import _record_cycle_error
+            _record_cycle_error(...)
+        except Exception:
+            pass
+
+    The inner ``except Exception: pass`` is intentional — error logging must
+    never break the calling function. Without this exemption, every Wave-C
+    conversion would inflate the ``debug_only`` count by one and tip over
+    the CI gate.
+
+    Match condition:
+      - except body is exactly ``pass`` (or ``...``)
+      - parent ast.Try's body contains a call to ``_record_cycle_error``
+    """
+    body = handler.body
+    if len(body) != 1:
+        return False
+    only = body[0]
+    is_pass = isinstance(only, ast.Pass)
+    is_ellipsis = (
+        isinstance(only, ast.Expr)
+        and isinstance(only.value, ast.Constant)
+        and only.value.value is Ellipsis
+    )
+    if not (is_pass or is_ellipsis):
+        return False
+    parent = parents.get(id(handler))
+    if not isinstance(parent, ast.Try):
+        return False
+    return _has_cycle_errors_write(parent.body)
+
+
+def classify(handler: ast.ExceptHandler,
+             parents: dict[int, ast.AST]) -> str:
     """Apply the rules from the audit spec to one ExceptHandler."""
     body = handler.body
 
@@ -261,6 +301,13 @@ def classify(handler: ast.ExceptHandler) -> str:
     # reraise next.
     if _has_raise(body):
         return "reraise"
+
+    # Spec-mandated protective wrapper around _record_cycle_error itself.
+    # Detected before the pass-body check so it doesn't get miscounted as
+    # debug_only — the wrapper is intentional defensive code, not a V9.12
+    # Class 2 silent absorber.
+    if _is_protective_cycle_error_wrapper(handler, parents):
+        return "cycle_errors_protective_wrapper"
 
     # Empty / pass body — debug_only (silent absorber).
     if _is_only_pass_or_comment(body):
@@ -349,7 +396,7 @@ def audit_file(path: Path) -> list[dict]:
         is_async = isinstance(fn, ast.AsyncFunctionDef)
         fn_name = fn.name if fn is not None else "<module>"
         err_var = node.name or ""
-        classification = classify(node)
+        classification = classify(node, parents)
         first_is_return = (
             bool(node.body)
             and isinstance(node.body[0], ast.Return)


### PR DESCRIPTION
**Merge order: 5 of 7** (Wave A/B/C tonight). Merge after PR 4 lands. Verify before proceeding to PR 6.

## Why

Wave C Phase 2 — convert `debug_only` / bare-except patterns in `app/services/` to structured `cycle_errors` writes so service-layer failures (CDA, temporal, backfill, vendor clients) surface in the errors table.

## What

- 45 conversions across 13 files in `app/services/`.
- Diff: +1019 / -80 LOC.

## Verification (after Railway redeploys Scoring-Worker, wait ~10 min)

```bash
PAGER=cat psql "$DATABASE_URL" -c "SELECT stablecoin_id, overall_score FROM scores WHERE stablecoin_id IN ('usdc','usdt','dai');"
PAGER=cat psql "$DATABASE_URL" -c "SELECT cycle_phase, error_type, COUNT(*) FROM cycle_errors WHERE occurred_at > NOW() - INTERVAL '15 min' GROUP BY 1,2 ORDER BY 3 DESC LIMIT 10;"
```

**Pass:** USDC/USDT/DAI scores within 5 points of pre-merge values; no error flood.
**Fail:** scores swing wildly, OR `cycle_errors` floods with repeating service-related error types.

If fail: STOP, do not proceed to PR 6.

https://claude.ai/code/session_01XuHuGXV2AyY8q7H4ECEFjk

---
_Generated by [Claude Code](https://claude.ai/code/session_01XuHuGXV2AyY8q7H4ECEFjk)_