### PR TITLE
audit(data_layer): convert 92 debug_only blocks to structured cycle_errors writes

### DIFF
--- a/app/data_layer/approval_collector.py
+++ b/app/data_layer/approval_collector.py
@@ -111,8 +111,19 @@ async def run_approval_collection() -> dict:
                         status=_ap_status,
                         latency_ms=int((time.monotonic() - _t0) * 1000),
                     )
-                except Exception:
-                    pass
+                except asyncio.CancelledError:
+                    raise
+                except Exception as e:
+                    logger.warning(f"[approval_collector] track_api_call failed: {e}")
+                    try:
+                        from app.worker import _record_cycle_error
+                        _record_cycle_error(
+                            error_type="data_layer_run_approval_collection_track_api_call_failure",
+                            error_message=str(e)[:500],
+                            cycle_phase="approval_collector",
+                        )
+                    except Exception:
+                        pass
             if wi < 3:
                 logger.error(f"[approval_collector] step E.{wi}: HTTP {resp.status_code}")
 
@@ -223,8 +234,19 @@ async def run_approval_collection() -> dict:
         from app.data_layer.provenance_scaling import attest_data_batch
         if total_inserted > 0:
             await asyncio.to_thread(attest_data_batch, "token_approvals", [{"inserted": total_inserted}])
-    except Exception:
-        pass
+    except asyncio.CancelledError:
+        raise
+    except Exception as e:
+        logger.warning(f"[approval_collector] attestation failed: {e}")
+        try:
+            from app.worker import _record_cycle_error
+            _record_cycle_error(
+                error_type="data_layer_run_approval_collection_attestation_failure",
+                error_message=str(e)[:500],
+                cycle_phase="approval_collector",
+            )
+        except Exception:
+            pass
 
     logger.error(
         f"[approval_collector] SUMMARY: wallets_scanned={len(wallets)}, "

--- a/app/data_layer/bridge_flow_collector.py
+++ b/app/data_layer/bridge_flow_collector.py
@@ -235,8 +235,19 @@ async def run_bridge_flow_collection() -> dict:
         if total_flows > 0:
             await asyncio.to_thread(attest_data_batch, "bridge_flows", [{"flows": total_flows, "bridges": bridges_processed}])
             await link_batch_to_proof("bridge_flows", "bridge_flows")
+    except asyncio.CancelledError:
+        raise
     except Exception as e:
-        logger.debug(f"Bridge flow provenance failed: {e}")
+        logger.warning(f"Bridge flow provenance failed: {e}")
+        try:
+            from app.worker import _record_cycle_error
+            _record_cycle_error(
+                error_type="data_layer_run_bridge_flow_collection_provenance_failure",
+                error_message=str(e)[:500],
+                cycle_phase="bridge_flow_collector",
+            )
+        except Exception:
+            pass
 
     logger.info(
         f"Bridge flow collection complete: {total_flows} flow records "

--- a/app/data_layer/catalog.py
+++ b/app/data_layer/catalog.py
@@ -3,6 +3,7 @@ Data Catalog — keeps the data_catalog table in sync.
 Auto-updates freshness, row counts, and history depth for all data types.
 """
 
+import asyncio
 import json
 import logging
 from datetime import datetime, timezone
@@ -245,8 +246,19 @@ async def update_catalog():
                     dt.get("staleness_threshold_hours"),
                 ),
             )
+        except asyncio.CancelledError:
+            raise
         except Exception as e:
             # Table may not exist yet — skip
-            logger.debug(f"Catalog update skipped for {dt['data_type']}: {e}")
+            logger.warning(f"Catalog update skipped for {dt['data_type']}: {e}")
+            try:
+                from app.worker import _record_cycle_error
+                _record_cycle_error(
+                    error_type="data_layer_update_catalog_update_failure",
+                    error_message=str(e)[:500],
+                    cycle_phase="catalog",
+                )
+            except Exception:
+                pass
 
     logger.info(f"Data catalog updated: {len(DATA_TYPES)} data types")

--- a/app/data_layer/coherence_guards.py
+++ b/app/data_layer/coherence_guards.py
@@ -132,8 +132,17 @@ def store_violation(violation: CoherenceViolation):
                     json.dumps(violation.to_dict()),
                 ),
             )
-        except Exception:
-            logger.debug(f"Could not store coherence violation: {e}")
+        except Exception as e2:
+            logger.warning(f"Could not store coherence violation: primary={e}, fallback={e2}")
+            try:
+                from app.worker import _record_cycle_error
+                _record_cycle_error(
+                    error_type="data_layer_store_violation_failure",
+                    error_message=f"primary={str(e)[:200]}, fallback={str(e2)[:200]}"[:500],
+                    cycle_phase="coherence_guards",
+                )
+            except Exception:
+                pass
 
 
 # =============================================================================
@@ -241,8 +250,17 @@ class DataCoherenceGuard:
                             severity="warning",
                             details=f"High-volume venue went to zero ({float(prev['volume_24h']):,.0f} → 0)",
                         ))
-                except Exception:
-                    pass
+                except Exception as e:
+                    logger.warning(f"[coherence_guards] liquidity venue check failed for {asset_id}:{venue}: {e}")
+                    try:
+                        from app.worker import _record_cycle_error
+                        _record_cycle_error(
+                            error_type="data_layer_validate_liquidity_check_failure",
+                            error_message=str(e)[:500],
+                            cycle_phase="coherence_guards",
+                        )
+                    except Exception:
+                        pass
 
         self._violations.extend(violations)
         return violations
@@ -287,8 +305,17 @@ class DataCoherenceGuard:
                 )
                 if v:
                     violations.append(v)
-        except Exception:
-            pass
+        except Exception as e:
+            logger.warning(f"[coherence_guards] yield TVL drop check failed for {pool_id}: {e}")
+            try:
+                from app.worker import _record_cycle_error
+                _record_cycle_error(
+                    error_type="data_layer_validate_yield_check_failure",
+                    error_message=str(e)[:500],
+                    cycle_phase="coherence_guards",
+                )
+            except Exception:
+                pass
 
         self._violations.extend(violations)
         return violations
@@ -321,8 +348,17 @@ class DataCoherenceGuard:
                             severity="warning",
                             details=f"Trust score changed: {old_ts} → {new_ts}",
                         ))
-            except Exception:
-                pass
+            except Exception as e:
+                logger.warning(f"[coherence_guards] exchange trust check failed for {exchange_id}: {e}")
+                try:
+                    from app.worker import _record_cycle_error
+                    _record_cycle_error(
+                        error_type="data_layer_validate_exchange_check_failure",
+                        error_message=str(e)[:500],
+                        cycle_phase="coherence_guards",
+                    )
+                except Exception:
+                    pass
 
         self._violations.extend(violations)
         return violations

--- a/app/data_layer/component_replay.py
+++ b/app/data_layer/component_replay.py
@@ -220,7 +220,16 @@ def get_replay_candidates() -> list[dict]:
                     "description": check["description"],
                     "data_points_30d": data_points,
                 })
-        except Exception:
-            pass
+        except Exception as e:
+            logger.warning(f"[component_replay] check failed for {check.get('name')}: {e}")
+            try:
+                from app.worker import _record_cycle_error
+                _record_cycle_error(
+                    error_type="data_layer_get_replay_candidates_check_failure",
+                    error_message=str(e)[:500],
+                    cycle_phase="component_replay",
+                )
+            except Exception:
+                pass
 
     return candidates

--- a/app/data_layer/contract_surveillance.py
+++ b/app/data_layer/contract_surveillance.py
@@ -283,8 +283,19 @@ async def run_contract_surveillance() -> dict:
                         "chain": timelock.get("chain", "ethereum"),
                         "contract_address": timelock["address"],
                     })
+    except asyncio.CancelledError:
+        raise
     except Exception as e:
-        logger.debug(f"Contract registry load failed: {e}")
+        logger.warning(f"Contract registry load failed: {e}")
+        try:
+            from app.worker import _record_cycle_error
+            _record_cycle_error(
+                error_type="data_layer_run_contract_surveillance_registry_load_failure",
+                error_message=str(e)[:500],
+                cycle_phase="contract_surveillance",
+            )
+        except Exception:
+            pass
 
     if not contracts_to_scan:
         return {"error": "no contracts to scan"}
@@ -369,8 +380,19 @@ async def run_contract_surveillance() -> dict:
                         json.dumps(change),
                     ),
                 )
+        except asyncio.CancelledError:
+            raise
         except Exception as e:
-            logger.debug(f"Contract change signal failed: {e}")
+            logger.warning(f"Contract change signal failed: {e}")
+            try:
+                from app.worker import _record_cycle_error
+                _record_cycle_error(
+                    error_type="data_layer_run_contract_surveillance_signal_failure",
+                    error_message=str(e)[:500],
+                    cycle_phase="contract_surveillance",
+                )
+            except Exception:
+                pass
 
     # Provenance
     try:
@@ -378,8 +400,19 @@ async def run_contract_surveillance() -> dict:
         if total_scanned > 0:
             await asyncio.to_thread(attest_data_batch, "contract_surveillance", [{"scanned": total_scanned, "changes": len(changes_detected)}])
             await link_batch_to_proof("contract_surveillance", "contract_surveillance")
+    except asyncio.CancelledError:
+        raise
     except Exception as e:
-        logger.debug(f"Contract surveillance provenance failed: {e}")
+        logger.warning(f"Contract surveillance provenance failed: {e}")
+        try:
+            from app.worker import _record_cycle_error
+            _record_cycle_error(
+                error_type="data_layer_run_contract_surveillance_provenance_failure",
+                error_message=str(e)[:500],
+                cycle_phase="contract_surveillance",
+            )
+        except Exception:
+            pass
 
     logger.info(
         f"Contract surveillance complete: {total_scanned} contracts scanned, "

--- a/app/data_layer/entity_discovery.py
+++ b/app/data_layer/entity_discovery.py
@@ -79,16 +79,38 @@ async def _get_existing_entities() -> set:
         )
         if rows:
             existing.update(r["entity_id"] for r in rows)
-    except Exception:
-        pass
+    except asyncio.CancelledError:
+        raise
+    except Exception as e:
+        logger.warning(f"[entity_discovery] generic_index_scores query failed: {e}")
+        try:
+            from app.worker import _record_cycle_error
+            _record_cycle_error(
+                error_type="data_layer__get_existing_entities_index_scores_failure",
+                error_message=str(e)[:500],
+                cycle_phase="entity_discovery",
+            )
+        except Exception:
+            pass
 
     # Also check manually configured entities
     try:
         rows = await fetch_all_async("SELECT DISTINCT protocol_slug FROM rpi_protocol_config WHERE enabled = TRUE")
         if rows:
             existing.update(r["protocol_slug"] for r in rows)
-    except Exception:
-        pass
+    except asyncio.CancelledError:
+        raise
+    except Exception as e:
+        logger.warning(f"[entity_discovery] rpi_protocol_config query failed: {e}")
+        try:
+            from app.worker import _record_cycle_error
+            _record_cycle_error(
+                error_type="data_layer__get_existing_entities_rpi_config_failure",
+                error_message=str(e)[:500],
+                cycle_phase="entity_discovery",
+            )
+        except Exception:
+            pass
 
     return existing
 

--- a/app/data_layer/entity_snapshots.py
+++ b/app/data_layer/entity_snapshots.py
@@ -198,8 +198,19 @@ async def run_entity_snapshots() -> dict:
                         "entity_type": "protocol_token",
                         "coingecko_id": cg_id,
                     })
+    except asyncio.CancelledError:
+        raise
     except Exception as e:
-        logger.debug(f"PSI entity lookup failed: {e}")
+        logger.warning(f"PSI entity lookup failed: {e}")
+        try:
+            from app.worker import _record_cycle_error
+            _record_cycle_error(
+                error_type="data_layer_run_entity_snapshots_psi_lookup_failure",
+                error_message=str(e)[:500],
+                cycle_phase="entity_snapshots",
+            )
+        except Exception:
+            pass
 
     # Circle 7 entities — LSTs, bridges, vaults, exchanges, DAOs, TTIs
     CIRCLE7_CG_MAP = {
@@ -230,8 +241,19 @@ async def run_entity_snapshots() -> dict:
                 "entity_type": "circle7",
                 "coingecko_id": cg_id,
             })
+    except asyncio.CancelledError:
+        raise
     except Exception as e:
-        logger.debug(f"Circle 7 entity mapping failed: {e}")
+        logger.warning(f"Circle 7 entity mapping failed: {e}")
+        try:
+            from app.worker import _record_cycle_error
+            _record_cycle_error(
+                error_type="data_layer_run_entity_snapshots_circle7_mapping_failure",
+                error_message=str(e)[:500],
+                cycle_phase="entity_snapshots",
+            )
+        except Exception:
+            pass
 
     if not entities:
         return {"error": "no entities to snapshot"}
@@ -303,8 +325,19 @@ async def run_entity_snapshots() -> dict:
         if total_snapshots > 0:
             await asyncio.to_thread(attest_data_batch, "entity_snapshots_hourly", [{"entities": total_snapshots}])
             await link_batch_to_proof("entity_snapshots_hourly", "entity_snapshots_hourly")
+    except asyncio.CancelledError:
+        raise
     except Exception as e:
-        logger.debug(f"Entity snapshot provenance failed: {e}")
+        logger.warning(f"Entity snapshot provenance failed: {e}")
+        try:
+            from app.worker import _record_cycle_error
+            _record_cycle_error(
+                error_type="data_layer_run_entity_snapshots_provenance_failure",
+                error_message=str(e)[:500],
+                cycle_phase="entity_snapshots",
+            )
+        except Exception:
+            pass
 
     logger.info(f"Entity snapshots complete: {total_snapshots}/{len(entities)} entities")
 

--- a/app/data_layer/exchange_collector.py
+++ b/app/data_layer/exchange_collector.py
@@ -238,8 +238,19 @@ async def run_exchange_collection() -> dict:
                     vol_history = await _fetch_exchange_volume_history(client, exchange_id, days=30)
                     if vol_history:
                         snapshot["raw_data"]["volume_history_points"] = len(vol_history)
-                except Exception:
-                    pass
+                except asyncio.CancelledError:
+                    raise
+                except Exception as e:
+                    logger.warning(f"[exchange_collector] volume history fetch failed for {exchange_id}: {e}")
+                    try:
+                        from app.worker import _record_cycle_error
+                        _record_cycle_error(
+                            error_type="data_layer_run_exchange_collection_volume_history_failure",
+                            error_message=str(e)[:500],
+                            cycle_phase="exchange_collector",
+                        )
+                    except Exception:
+                        pass
 
             except Exception as e:
                 logger.warning(f"Exchange collection failed for {exchange_id}: {e}")
@@ -255,8 +266,19 @@ async def run_exchange_collection() -> dict:
         if total_snapshots > 0:
             await asyncio.to_thread(attest_data_batch, "exchange_snapshots", [{"exchanges": total_snapshots}])
             await link_batch_to_proof("exchange_snapshots", "exchange_snapshots")
+    except asyncio.CancelledError:
+        raise
     except Exception as e:
-        logger.debug(f"Exchange provenance failed: {e}")
+        logger.warning(f"Exchange provenance failed: {e}")
+        try:
+            from app.worker import _record_cycle_error
+            _record_cycle_error(
+                error_type="data_layer_run_exchange_collection_provenance_failure",
+                error_message=str(e)[:500],
+                cycle_phase="exchange_collector",
+            )
+        except Exception:
+            pass
 
     logger.info(
         f"Exchange collection complete: {total_snapshots} exchanges, "

--- a/app/data_layer/governance_collector.py
+++ b/app/data_layer/governance_collector.py
@@ -396,8 +396,19 @@ async def run_governance_collection() -> dict:
                             ]
                             await asyncio.to_thread(_store_voters, voter_records)
                             total_voters += len(voter_records)
+                    except asyncio.CancelledError:
+                        raise
                     except Exception as e:
-                        logger.debug(f"Voter collection failed for {prop['id']}: {e}")
+                        logger.warning(f"Voter collection failed for {prop['id']}: {e}")
+                        try:
+                            from app.worker import _record_cycle_error
+                            _record_cycle_error(
+                                error_type="data_layer_run_governance_collection_voter_failure",
+                                error_message=str(e)[:500],
+                                cycle_phase="governance_collector",
+                            )
+                        except Exception:
+                            pass
 
                 spaces_processed += 1
 
@@ -462,8 +473,19 @@ async def run_governance_collection() -> dict:
             await asyncio.to_thread(attest_data_batch, "governance_proposals", [{"proposals": total_proposals, "voters": total_voters}])
             await link_batch_to_proof("governance_proposals", "governance_proposals")
             await link_batch_to_proof("governance_voters", "governance_voters")
+    except asyncio.CancelledError:
+        raise
     except Exception as e:
-        logger.debug(f"Governance provenance failed: {e}")
+        logger.warning(f"Governance provenance failed: {e}")
+        try:
+            from app.worker import _record_cycle_error
+            _record_cycle_error(
+                error_type="data_layer_run_governance_collection_provenance_failure",
+                error_message=str(e)[:500],
+                cycle_phase="governance_collector",
+            )
+        except Exception:
+            pass
 
     logger.info(
         f"Governance collection complete: {total_proposals} proposals, "

--- a/app/data_layer/holder_discovery.py
+++ b/app/data_layer/holder_discovery.py
@@ -264,8 +264,19 @@ async def run_holder_discovery() -> dict:
         from app.data_layer.provenance_scaling import attest_data_batch
         if total_discovered > 0:
             await asyncio.to_thread(attest_data_batch, "wallet_holdings", [{"discovered": total_discovered, "seeded": total_seeded}])
-    except Exception:
-        pass
+    except asyncio.CancelledError:
+        raise
+    except Exception as e:
+        logger.warning(f"[holder_discovery] attestation failed: {e}")
+        try:
+            from app.worker import _record_cycle_error
+            _record_cycle_error(
+                error_type="data_layer_run_holder_discovery_attestation_failure",
+                error_message=str(e)[:500],
+                cycle_phase="holder_discovery",
+            )
+        except Exception:
+            pass
 
     logger.info(
         f"Holder discovery complete: {total_discovered} new addresses across "

--- a/app/data_layer/holder_ingestion_collector.py
+++ b/app/data_layer/holder_ingestion_collector.py
@@ -192,8 +192,19 @@ async def _fetch_holders_etherscan(
                 status=_status,
                 latency_ms=int((time.monotonic() - _t0) * 1000),
             )
-        except Exception:
-            pass
+        except asyncio.CancelledError:
+            raise
+        except Exception as e:
+            logger.warning(f"[holder_ingestion] track_api_call failed: {e}")
+            try:
+                from app.worker import _record_cycle_error
+                _record_cycle_error(
+                    error_type="data_layer__fetch_holders_etherscan_track_api_call_failure",
+                    error_message=str(e)[:500],
+                    cycle_phase="holder_ingestion_collector",
+                )
+            except Exception:
+                pass
 
 
 async def _fetch_holders_blockscout(
@@ -389,8 +400,19 @@ async def run_holder_ingestion() -> dict:
         total_new = sum(s["new_wallets"] for s in stats.values())
         if total_new > 0:
             await asyncio.to_thread(attest_data_batch, "wallet_holder_discovery", [dict(stats)])
-    except Exception:
-        pass
+    except asyncio.CancelledError:
+        raise
+    except Exception as e:
+        logger.warning(f"[holder_ingestion] attestation failed: {e}")
+        try:
+            from app.worker import _record_cycle_error
+            _record_cycle_error(
+                error_type="data_layer_run_holder_ingestion_attestation_failure",
+                error_message=str(e)[:500],
+                cycle_phase="holder_ingestion_collector",
+            )
+        except Exception:
+            pass
 
     # SUMMARY
     for etype, s in sorted(stats.items()):

--- a/app/data_layer/index_simulator.py
+++ b/app/data_layer/index_simulator.py
@@ -219,8 +219,17 @@ def simulate_index(definition: dict) -> dict:
                         entity_score += weighted
                         component_scores[comp["id"]] = round(normalized, 2)
                         data_coverage += 1
-                except Exception:
-                    pass
+                except Exception as e:
+                    logger.warning(f"[index_simulator] component score failed for {comp.get('id')}: {e}")
+                    try:
+                        from app.worker import _record_cycle_error
+                        _record_cycle_error(
+                            error_type="data_layer_simulate_index_component_failure",
+                            error_message=str(e)[:500],
+                            cycle_phase="index_simulator",
+                        )
+                    except Exception:
+                        pass
 
             if data_coverage > 0:
                 simulated_scores.append({

--- a/app/data_layer/liquidity_collector.py
+++ b/app/data_layer/liquidity_collector.py
@@ -380,8 +380,19 @@ async def run_liquidity_collection() -> dict:
         if total_records > 0:
             await asyncio.to_thread(attest_data_batch, "liquidity_depth", [{"records": total_records, "cex": total_cex, "dex": total_dex}])
             await link_batch_to_proof("liquidity_depth", "liquidity_depth")
+    except asyncio.CancelledError:
+        raise
     except Exception as e:
-        logger.debug(f"Liquidity provenance failed: {e}")
+        logger.warning(f"Liquidity provenance failed: {e}")
+        try:
+            from app.worker import _record_cycle_error
+            _record_cycle_error(
+                error_type="data_layer_run_liquidity_collection_provenance_failure",
+                error_message=str(e)[:500],
+                cycle_phase="liquidity_collector",
+            )
+        except Exception:
+            pass
 
     logger.error(
         f"[liquidity_depth] SUMMARY: stablecoins={stablecoins_processed}, "

--- a/app/data_layer/market_chart_backfill.py
+++ b/app/data_layer/market_chart_backfill.py
@@ -144,8 +144,17 @@ def _store_market_chart_records(records: list[dict]):
                         row,
                     )
                 stored += 1
-            except Exception:
-                pass
+            except Exception as e:
+                logger.warning(f"[market_chart_backfill] per-row insert failed: {e}")
+                try:
+                    from app.worker import _record_cycle_error
+                    _record_cycle_error(
+                        error_type="data_layer__store_market_chart_records_insert_failure",
+                        error_message=str(e)[:500],
+                        cycle_phase="market_chart_backfill",
+                    )
+                except Exception:
+                    pass
 
     elapsed = _t.monotonic() - _start
     logger.error(f"market_chart_history: {stored}/{len(rows)} stored in {elapsed:.1f}s")
@@ -348,8 +357,19 @@ async def run_market_chart_backfill(backfill_days: int = 90) -> dict:
         from app.data_layer.provenance_scaling import attest_data_batch, link_batch_to_proof
         if total_records > 0:
             await asyncio.to_thread(attest_data_batch, "market_chart_history", [{"records": total_records, "coins": coins_processed}])
-    except Exception:
-        pass
+    except asyncio.CancelledError:
+        raise
+    except Exception as e:
+        logger.warning(f"[market_chart_backfill] attestation failed: {e}")
+        try:
+            from app.worker import _record_cycle_error
+            _record_cycle_error(
+                error_type="data_layer_run_market_chart_backfill_attestation_failure",
+                error_message=str(e)[:500],
+                cycle_phase="market_chart_backfill",
+            )
+        except Exception:
+            pass
 
     logger.info(
         f"Market chart backfill complete: {total_records} records from "

--- a/app/data_layer/markets_collector.py
+++ b/app/data_layer/markets_collector.py
@@ -296,8 +296,19 @@ async def run_extended_5min_pulls() -> dict:
         from app.data_layer.provenance_scaling import attest_data_batch
         if total_records > 0:
             await asyncio.to_thread(attest_data_batch, "market_chart_history", [{"records": total_records, "entities": entities_processed, "type": "circle7_5min"}])
-    except Exception:
-        pass
+    except asyncio.CancelledError:
+        raise
+    except Exception as e:
+        logger.warning(f"[markets_collector] attestation failed: {e}")
+        try:
+            from app.worker import _record_cycle_error
+            _record_cycle_error(
+                error_type="data_layer_run_extended_5min_pulls_attestation_failure",
+                error_message=str(e)[:500],
+                cycle_phase="markets_collector",
+            )
+        except Exception:
+            pass
 
     logger.info(
         f"Extended 5-min pulls: {total_records} records from "

--- a/app/data_layer/mempool_watcher.py
+++ b/app/data_layer/mempool_watcher.py
@@ -214,8 +214,19 @@ async def _attest_capture_status(status: str, note: str, gap_seconds: int | None
             """,
             ("mempool_capture_status", status, content_hash, 1, "mempool-v0.1.0"),
         )
+    except asyncio.CancelledError:
+        raise
     except Exception as e:
-        logger.debug(f"[mempool_watcher] capture-status attestation skipped: {e}")
+        logger.warning(f"[mempool_watcher] capture-status attestation skipped: {e}")
+        try:
+            from app.worker import _record_cycle_error
+            _record_cycle_error(
+                error_type="data_layer__attest_capture_status_attestation_failure",
+                error_message=str(e)[:500],
+                cycle_phase="mempool_watcher",
+            )
+        except Exception:
+            pass
 
 
 # ---------------------------------------------------------------------------
@@ -270,8 +281,19 @@ def _insert_observation(tx: dict) -> bool:
             ),
         )
         return True
+    except asyncio.CancelledError:
+        raise
     except Exception as e:
-        logger.debug(f"[mempool_watcher] insert failed: {type(e).__name__}: {e}")
+        logger.warning(f"[mempool_watcher] insert failed: {type(e).__name__}: {e}")
+        try:
+            from app.worker import _record_cycle_error
+            _record_cycle_error(
+                error_type="data_layer__insert_observation_insert_failure",
+                error_message=str(e)[:500],
+                cycle_phase="mempool_watcher",
+            )
+        except Exception:
+            pass
         return False
 
 
@@ -293,8 +315,19 @@ def _attest_observation(tx_hash: str, seen_at_ms: int) -> None:
             """,
             ("mempool_observations", tx_hash, content_hash, 1, "mempool-v0.1.0"),
         )
-    except Exception:
-        pass
+    except asyncio.CancelledError:
+        raise
+    except Exception as e:
+        logger.warning(f"[mempool_watcher] observation attestation failed: {e}")
+        try:
+            from app.worker import _record_cycle_error
+            _record_cycle_error(
+                error_type="data_layer__attest_observation_attestation_failure",
+                error_message=str(e)[:500],
+                cycle_phase="mempool_watcher",
+            )
+        except Exception:
+            pass
 
 
 # ---------------------------------------------------------------------------
@@ -622,8 +655,19 @@ async def emit_24h_summary() -> None:
                OR confirmed_at > NOW() - INTERVAL '24 hours'
             """
         )
+    except asyncio.CancelledError:
+        raise
     except Exception as e:
-        logger.debug(f"[mempool_observations] 24h SUMMARY skipped: {e}")
+        logger.warning(f"[mempool_observations] 24h SUMMARY skipped: {e}")
+        try:
+            from app.worker import _record_cycle_error
+            _record_cycle_error(
+                error_type="data_layer_emit_24h_summary_query_failure",
+                error_message=str(e)[:500],
+                cycle_phase="mempool_watcher",
+            )
+        except Exception:
+            pass
         return
 
     if not summary or not summary.get("captured"):

--- a/app/data_layer/mint_burn_collector.py
+++ b/app/data_layer/mint_burn_collector.py
@@ -228,8 +228,17 @@ async def run_mint_burn_collection() -> dict:
                                 ts = datetime.fromtimestamp(
                                     int(tx["timeStamp"]), tz=timezone.utc
                                 )
-                            except (ValueError, OSError):
-                                pass
+                            except (ValueError, OSError) as e:
+                                logger.warning(f"[mint_burn_collector] timestamp parse failed: {e}")
+                                try:
+                                    from app.worker import _record_cycle_error
+                                    _record_cycle_error(
+                                        error_type="data_layer_run_mint_burn_collection_timestamp_parse_failure",
+                                        error_message=str(e)[:500],
+                                        cycle_phase="mint_burn_collector",
+                                    )
+                                except Exception:
+                                    pass
 
                         evt = {
                             "stablecoin_id": stablecoin_id,
@@ -289,8 +298,19 @@ async def run_mint_burn_collection() -> dict:
                         json.dumps(evt),
                     ),
                 )
+        except asyncio.CancelledError:
+            raise
         except Exception as e:
-            logger.debug(f"Mint/burn signal emission failed: {e}")
+            logger.warning(f"Mint/burn signal emission failed: {e}")
+            try:
+                from app.worker import _record_cycle_error
+                _record_cycle_error(
+                    error_type="data_layer_run_mint_burn_collection_signal_emission_failure",
+                    error_message=str(e)[:500],
+                    cycle_phase="mint_burn_collector",
+                )
+            except Exception:
+                pass
 
     # Check for redemption acceleration pattern
     anomalies = await _detect_redemption_acceleration()
@@ -301,8 +321,19 @@ async def run_mint_burn_collection() -> dict:
         if total_mints + total_burns > 0:
             await asyncio.to_thread(attest_data_batch, "mint_burn_events", [{"mints": total_mints, "burns": total_burns}])
             await link_batch_to_proof("mint_burn_events", "mint_burn_events")
+    except asyncio.CancelledError:
+        raise
     except Exception as e:
-        logger.debug(f"Mint/burn provenance failed: {e}")
+        logger.warning(f"Mint/burn provenance failed: {e}")
+        try:
+            from app.worker import _record_cycle_error
+            _record_cycle_error(
+                error_type="data_layer_run_mint_burn_collection_provenance_failure",
+                error_message=str(e)[:500],
+                cycle_phase="mint_burn_collector",
+            )
+        except Exception:
+            pass
 
     logger.info(
         f"Mint/burn collection complete: {total_mints} mints, {total_burns} burns, "
@@ -370,7 +401,18 @@ async def _detect_redemption_acceleration() -> list[dict]:
                         "mean_per_6h_window": round(mean, 2),
                         "z_score": round(z_score, 2),
                     })
+    except asyncio.CancelledError:
+        raise
     except Exception as e:
-        logger.debug(f"Redemption acceleration detection failed: {e}")
+        logger.warning(f"Redemption acceleration detection failed: {e}")
+        try:
+            from app.worker import _record_cycle_error
+            _record_cycle_error(
+                error_type="data_layer__detect_redemption_acceleration_failure",
+                error_message=str(e)[:500],
+                cycle_phase="mint_burn_collector",
+            )
+        except Exception:
+            pass
 
     return anomalies

--- a/app/data_layer/multichain_holder_collector.py
+++ b/app/data_layer/multichain_holder_collector.py
@@ -191,8 +191,19 @@ async def run_multichain_holder_scan() -> dict:
                                              rank_in_entity = EXCLUDED.rank_in_entity,
                                              discovered_at = NOW()
                             """, (h["address"], symbol, contract, chain, h["balance_usd"], h["rank"]))
-                    except Exception:
-                        pass
+                    except asyncio.CancelledError:
+                        raise
+                    except Exception as e:
+                        logger.warning(f"[multichain_holder] discovery insert failed for {symbol}/{chain}: {e}")
+                        try:
+                            from app.worker import _record_cycle_error
+                            _record_cycle_error(
+                                error_type="data_layer_run_multichain_holder_scan_discovery_insert_failure",
+                                error_message=str(e)[:500],
+                                cycle_phase="multichain_holder_collector",
+                            )
+                        except Exception:
+                            pass
 
                 # Insert chain presence
                 new_presences = 0
@@ -203,8 +214,19 @@ async def run_multichain_holder_scan() -> dict:
                         )
                         if _statusmsg and "INSERT" in _statusmsg:
                             new_presences += 1
-                    except Exception:
-                        pass
+                    except asyncio.CancelledError:
+                        raise
+                    except Exception as e:
+                        logger.warning(f"[multichain_holder] chain presence insert failed for {symbol}/{chain}: {e}")
+                        try:
+                            from app.worker import _record_cycle_error
+                            _record_cycle_error(
+                                error_type="data_layer_run_multichain_holder_scan_presence_insert_failure",
+                                error_message=str(e)[:500],
+                                cycle_phase="multichain_holder_collector",
+                            )
+                        except Exception:
+                            pass
                 stats[chain]["new_presences"] += new_presences
 
                 # Promote new wallets to wallet_graph
@@ -227,8 +249,19 @@ async def run_multichain_holder_scan() -> dict:
         total_presences = sum(s["new_presences"] for s in stats.values())
         if total_presences > 0:
             await asyncio.to_thread(attest_data_batch, "wallet_chain_presence", [dict(stats)])
-    except Exception:
-        pass
+    except asyncio.CancelledError:
+        raise
+    except Exception as e:
+        logger.warning(f"[multichain_holder] attestation failed: {e}")
+        try:
+            from app.worker import _record_cycle_error
+            _record_cycle_error(
+                error_type="data_layer_run_multichain_holder_scan_attestation_failure",
+                error_message=str(e)[:500],
+                cycle_phase="multichain_holder_collector",
+            )
+        except Exception:
+            pass
 
     # SUMMARY
     for chain, s in sorted(stats.items()):

--- a/app/data_layer/ohlcv_collector.py
+++ b/app/data_layer/ohlcv_collector.py
@@ -237,8 +237,19 @@ async def run_ohlcv_collection() -> dict:
                         total_records += len(records)
                         pools_processed += 1
                         top_processed += 1
+            except asyncio.CancelledError:
+                raise
             except Exception as e:
-                logger.debug(f"15min OHLCV failed for {pool_address[:10]}…: {e}")
+                logger.warning(f"15min OHLCV failed for {pool_address[:10]}…: {e}")
+                try:
+                    from app.worker import _record_cycle_error
+                    _record_cycle_error(
+                        error_type="data_layer_run_ohlcv_collection_15min_failure",
+                        error_message=str(e)[:500],
+                        cycle_phase="ohlcv_collector",
+                    )
+                except Exception:
+                    pass
 
         # Other pools: hourly resolution
         for pool in other_pools:
@@ -258,8 +269,19 @@ async def run_ohlcv_collection() -> dict:
                         await asyncio.to_thread(_store_ohlcv_records, records)
                         total_records += len(records)
                         pools_processed += 1
+            except asyncio.CancelledError:
+                raise
             except Exception as e:
-                logger.debug(f"Hourly OHLCV failed for {pool_address[:10]}…: {e}")
+                logger.warning(f"Hourly OHLCV failed for {pool_address[:10]}…: {e}")
+                try:
+                    from app.worker import _record_cycle_error
+                    _record_cycle_error(
+                        error_type="data_layer_run_ohlcv_collection_hourly_failure",
+                        error_message=str(e)[:500],
+                        cycle_phase="ohlcv_collector",
+                    )
+                except Exception:
+                    pass
 
     # Provenance
     try:
@@ -267,8 +289,19 @@ async def run_ohlcv_collection() -> dict:
         if total_records > 0:
             await asyncio.to_thread(attest_data_batch, "dex_pool_ohlcv", [{"records": total_records, "pools": pools_processed}])
             await link_batch_to_proof("dex_pool_ohlcv", "liquidity_depth")
-    except Exception:
-        pass
+    except asyncio.CancelledError:
+        raise
+    except Exception as e:
+        logger.warning(f"[ohlcv_collector] provenance failed: {e}")
+        try:
+            from app.worker import _record_cycle_error
+            _record_cycle_error(
+                error_type="data_layer_run_ohlcv_collection_provenance_failure",
+                error_message=str(e)[:500],
+                cycle_phase="ohlcv_collector",
+            )
+        except Exception:
+            pass
 
     logger.error(
         f"[dex_pool_ohlcv] SUMMARY: pools_queried={pools_processed}, bars_received={total_records}, "

--- a/app/data_layer/oracle_cadence_collector.py
+++ b/app/data_layer/oracle_cadence_collector.py
@@ -61,8 +61,19 @@ async def _eth_call(client: httpx.AsyncClient, rpc_url: str, to: str, data: str)
     finally:
         try:
             track_api_call(provider="alchemy", endpoint="eth_call", caller="data_layer.oracle_cadence_collector", status=_status, latency_ms=int((time.monotonic() - _t0) * 1000))
-        except Exception:
-            pass
+        except asyncio.CancelledError:
+            raise
+        except Exception as e:
+            logger.warning(f"[oracle_cadence] track_api_call failed: {e}")
+            try:
+                from app.worker import _record_cycle_error
+                _record_cycle_error(
+                    error_type="data_layer__eth_call_track_api_call_failure",
+                    error_message=str(e)[:500],
+                    cycle_phase="oracle_cadence_collector",
+                )
+            except Exception:
+                pass
     result = resp.json()
     if "error" in result:
         raise Exception(result["error"].get("message", str(result["error"])))
@@ -177,8 +188,19 @@ async def _sample_oracles(client: httpx.AsyncClient) -> dict:
         try:
             from app.data_layer.provenance_scaling import attest_data_batch
             await asyncio.to_thread(attest_data_batch, "oracle_cadence", [{"new_rounds": new_rounds}])
-        except Exception:
-            pass
+        except asyncio.CancelledError:
+            raise
+        except Exception as e:
+            logger.warning(f"[oracle_cadence] attestation failed: {e}")
+            try:
+                from app.worker import _record_cycle_error
+                _record_cycle_error(
+                    error_type="data_layer__sample_oracles_attestation_failure",
+                    error_message=str(e)[:500],
+                    cycle_phase="oracle_cadence_collector",
+                )
+            except Exception:
+                pass
 
     return {
         "oracles": len(oracles),

--- a/app/data_layer/peg_monitor.py
+++ b/app/data_layer/peg_monitor.py
@@ -137,8 +137,17 @@ def _store_peg_snapshots(stablecoin_id: str, price_points: list[tuple]):
                         row,
                     )
                 stored += 1
-            except Exception:
-                pass
+            except Exception as e:
+                logger.warning(f"[peg_monitor] snapshot insert failed for {stablecoin_id}: {e}")
+                try:
+                    from app.worker import _record_cycle_error
+                    _record_cycle_error(
+                        error_type="data_layer__store_peg_snapshots_insert_failure",
+                        error_message=str(e)[:500],
+                        cycle_phase="peg_monitor",
+                    )
+                except Exception:
+                    pass
 
     elapsed = _t.monotonic() - _start
     logger.error(f"peg {stablecoin_id}: {stored} rows in {elapsed:.1f}s (skipped={skipped})")
@@ -342,8 +351,19 @@ async def run_peg_monitoring() -> dict:
                             await asyncio.to_thread(
                                 _store_volatility_surface_90d_sync, stablecoin_id, vol_90d
                             )
+                except asyncio.CancelledError:
+                    raise
                 except Exception as e:
-                    logger.debug(f"90d vol surface failed for {stablecoin_id}: {e}")
+                    logger.warning(f"90d vol surface failed for {stablecoin_id}: {e}")
+                    try:
+                        from app.worker import _record_cycle_error
+                        _record_cycle_error(
+                            error_type="data_layer_run_peg_monitoring_vol_90d_failure",
+                            error_message=str(e)[:500],
+                            cycle_phase="peg_monitor",
+                        )
+                    except Exception:
+                        pass
 
             except Exception as e:
                 logger.warning(f"Peg monitoring failed for {stablecoin_id}: {e}")
@@ -355,8 +375,19 @@ async def run_peg_monitoring() -> dict:
             await asyncio.to_thread(attest_data_batch, "peg_snapshots_5m", [{"snapshots": total_snapshots, "vol_surfaces": vol_surfaces}])
             await link_batch_to_proof("peg_snapshots_5m", "peg_snapshots_5m")
             await link_batch_to_proof("volatility_surfaces", "volatility_surfaces")
+    except asyncio.CancelledError:
+        raise
     except Exception as e:
-        logger.debug(f"Peg provenance failed: {e}")
+        logger.warning(f"Peg provenance failed: {e}")
+        try:
+            from app.worker import _record_cycle_error
+            _record_cycle_error(
+                error_type="data_layer_run_peg_monitoring_provenance_failure",
+                error_message=str(e)[:500],
+                cycle_phase="peg_monitor",
+            )
+        except Exception:
+            pass
 
     logger.info(
         f"Peg monitoring complete: {total_snapshots} snapshots, "
@@ -368,8 +399,19 @@ async def run_peg_monitoring() -> dict:
     if micro_depegs:
         try:
             await asyncio.to_thread(_emit_depeg_signals_sync, micro_depegs)
+        except asyncio.CancelledError:
+            raise
         except Exception as e:
-            logger.debug(f"Micro-depeg signal emission failed: {e}")
+            logger.warning(f"Micro-depeg signal emission failed: {e}")
+            try:
+                from app.worker import _record_cycle_error
+                _record_cycle_error(
+                    error_type="data_layer_run_peg_monitoring_signal_emission_failure",
+                    error_message=str(e)[:500],
+                    cycle_phase="peg_monitor",
+                )
+            except Exception:
+                pass
 
     return {
         "stablecoins_monitored": len(rows),

--- a/app/data_layer/provenance_scaling.py
+++ b/app/data_layer/provenance_scaling.py
@@ -22,6 +22,7 @@ Strategy — SAMPLE PROVENANCE:
 - Every data table has provenance_proof_id linking to nearest proof
 """
 
+import asyncio
 import json
 import logging
 from datetime import datetime, timezone
@@ -179,7 +180,16 @@ def attest_data_batch(
         domain = f"data_layer:{data_type}"
         return attest_state(domain, records, entity_id=entity_id)
     except Exception as e:
-        logger.debug(f"State attestation failed for {data_type}: {e}")
+        logger.warning(f"State attestation failed for {data_type}: {e}")
+        try:
+            from app.worker import _record_cycle_error
+            _record_cycle_error(
+                error_type="data_layer_attest_data_batch_failure",
+                error_message=str(e)[:500],
+                cycle_phase="provenance_scaling",
+            )
+        except Exception:
+            pass
         return ""
 
 
@@ -257,8 +267,19 @@ async def link_batch_to_proof(table_name: str, data_type: str, batch_timestamp: 
             (proof_id,),
         )
         return proof_id
+    except asyncio.CancelledError:
+        raise
     except Exception as e:
-        logger.debug(f"Proof linking failed for {table_name}: {e}")
+        logger.warning(f"Proof linking failed for {table_name}: {e}")
+        try:
+            from app.worker import _record_cycle_error
+            _record_cycle_error(
+                error_type="data_layer_link_batch_to_proof_failure",
+                error_message=str(e)[:500],
+                cycle_phase="provenance_scaling",
+            )
+        except Exception:
+            pass
         return 0
 
 
@@ -286,8 +307,19 @@ async def get_provenance_registry() -> dict:
                     "proved_at": row["proved_at"].isoformat() if row.get("proved_at") else None,
                     "hash": row.get("attestation_hash"),
                 }
-        except Exception:
-            pass
+        except asyncio.CancelledError:
+            raise
+        except Exception as e:
+            logger.warning(f"[provenance_scaling] proof lookup failed for {source_id}: {e}")
+            try:
+                from app.worker import _record_cycle_error
+                _record_cycle_error(
+                    error_type="data_layer_get_provenance_registry_proof_lookup_failure",
+                    error_message=str(e)[:500],
+                    cycle_phase="provenance_scaling",
+                )
+            except Exception:
+                pass
 
         # Check state attestation too
         latest_attestation = None
@@ -306,8 +338,19 @@ async def get_provenance_registry() -> dict:
                         "timestamp": att["cycle_timestamp"].isoformat() if att.get("cycle_timestamp") else None,
                     }
                     break
-            except Exception:
-                pass
+            except asyncio.CancelledError:
+                raise
+            except Exception as e:
+                logger.warning(f"[provenance_scaling] attestation lookup failed for {dt}: {e}")
+                try:
+                    from app.worker import _record_cycle_error
+                    _record_cycle_error(
+                        error_type="data_layer_get_provenance_registry_attestation_lookup_failure",
+                        error_message=str(e)[:500],
+                        cycle_phase="provenance_scaling",
+                    )
+                except Exception:
+                    pass
 
         registry[source_id] = {
             **source,
@@ -346,8 +389,19 @@ async def get_data_type_provenance(data_type: str) -> dict:
             )
             if rows:
                 proofs.extend([dict(r) for r in rows])
-        except Exception:
-            pass
+        except asyncio.CancelledError:
+            raise
+        except Exception as e:
+            logger.warning(f"[provenance_scaling] proof query failed for {source_id}: {e}")
+            try:
+                from app.worker import _record_cycle_error
+                _record_cycle_error(
+                    error_type="data_layer_get_data_type_provenance_proof_query_failure",
+                    error_message=str(e)[:500],
+                    cycle_phase="provenance_scaling",
+                )
+            except Exception:
+                pass
 
     # Also check state attestations
     attestations = []
@@ -361,8 +415,19 @@ async def get_data_type_provenance(data_type: str) -> dict:
         )
         if att_rows:
             attestations = [dict(r) for r in att_rows]
-    except Exception:
-        pass
+    except asyncio.CancelledError:
+        raise
+    except Exception as e:
+        logger.warning(f"[provenance_scaling] attestation query failed for {data_type}: {e}")
+        try:
+            from app.worker import _record_cycle_error
+            _record_cycle_error(
+                error_type="data_layer_get_data_type_provenance_attestation_query_failure",
+                error_message=str(e)[:500],
+                cycle_phase="provenance_scaling",
+            )
+        except Exception:
+            pass
 
     return {
         "data_type": data_type,
@@ -425,8 +490,19 @@ async def update_catalog_provenance():
                 ),
             )
             updated += 1
+        except asyncio.CancelledError:
+            raise
         except Exception as e:
-            logger.debug(f"Catalog provenance update failed for {data_type}: {e}")
+            logger.warning(f"Catalog provenance update failed for {data_type}: {e}")
+            try:
+                from app.worker import _record_cycle_error
+                _record_cycle_error(
+                    error_type="data_layer_update_catalog_provenance_update_failure",
+                    error_message=str(e)[:500],
+                    cycle_phase="provenance_scaling",
+                )
+            except Exception:
+                pass
 
     logger.info(f"Data catalog provenance updated: {updated} data types")
 
@@ -457,8 +533,19 @@ async def run_provenance_linking():
             result = await link_batch_to_proof(table_name, data_type)
             if result:
                 linked += 1
-        except Exception:
-            pass
+        except asyncio.CancelledError:
+            raise
+        except Exception as e:
+            logger.warning(f"[provenance_scaling] proof linking failed for {table_name}: {e}")
+            try:
+                from app.worker import _record_cycle_error
+                _record_cycle_error(
+                    error_type="data_layer_run_provenance_linking_failure",
+                    error_message=str(e)[:500],
+                    cycle_phase="provenance_scaling",
+                )
+            except Exception:
+                pass
 
     logger.info(f"Provenance linking complete: {linked}/{len(tables)} tables linked")
     return linked

--- a/app/data_layer/prover_source_registry.py
+++ b/app/data_layer/prover_source_registry.py
@@ -17,6 +17,7 @@ if co-located. The hub worker also calls `run_provenance_health_recheck()`
 in the slow cycle.
 """
 
+import asyncio
 import json
 import logging
 import time
@@ -251,8 +252,19 @@ async def _report_alert(source_id: str, event: str, old_url: str = None,
             (source_id, event, old_url, redirect_url,
              json.dumps(details) if details else None),
         )
+    except asyncio.CancelledError:
+        raise
     except Exception as e:
-        logger.debug(f"Failed to write health alert for {source_id}: {e}")
+        logger.warning(f"Failed to write health alert for {source_id}: {e}")
+        try:
+            from app.worker import _record_cycle_error
+            _record_cycle_error(
+                error_type="data_layer__report_alert_failure",
+                error_message=str(e)[:500],
+                cycle_phase="prover_source_registry",
+            )
+        except Exception:
+            pass
 
 
 # =============================================================================
@@ -290,8 +302,19 @@ async def bump_recheck_timestamp(source_id: str):
             "UPDATE provenance_sources SET last_failure = NOW() WHERE id = %s",
             (source_id,),
         )
+    except asyncio.CancelledError:
+        raise
     except Exception as e:
-        logger.debug(f"Failed to bump recheck timestamp for {source_id}: {e}")
+        logger.warning(f"Failed to bump recheck timestamp for {source_id}: {e}")
+        try:
+            from app.worker import _record_cycle_error
+            _record_cycle_error(
+                error_type="data_layer_bump_recheck_timestamp_failure",
+                error_message=str(e)[:500],
+                cycle_phase="prover_source_registry",
+            )
+        except Exception:
+            pass
 
 
 async def run_provenance_health_recheck():
@@ -343,8 +366,19 @@ async def run_provenance_health_recheck():
                     try:
                         _provider = urlparse(url).netloc or "unknown"
                         track_api_call(provider=_provider, endpoint="HEAD", caller="data_layer.prover_source_registry", status=_status, latency_ms=int((time.monotonic() - _t0) * 1000))
-                    except Exception:
-                        pass
+                    except asyncio.CancelledError:
+                        raise
+                    except Exception as e:
+                        logger.warning(f"[prover_source_registry] track_api_call failed: {e}")
+                        try:
+                            from app.worker import _record_cycle_error
+                            _record_cycle_error(
+                                error_type="data_layer_run_provenance_health_recheck_track_api_call_failure",
+                                error_message=str(e)[:500],
+                                cycle_phase="prover_source_registry",
+                            )
+                        except Exception:
+                            pass
 
                 if resp.status_code == 200:
                     await record_re_enable(source_id)
@@ -417,8 +451,19 @@ async def seed_from_local_config() -> int:
             )
             if row:
                 seeded += 1
+        except asyncio.CancelledError:
+            raise
         except Exception as e:
-            logger.debug(f"Failed to seed source {src.get('id')}: {e}")
+            logger.warning(f"Failed to seed source {src.get('id')}: {e}")
+            try:
+                from app.worker import _record_cycle_error
+                _record_cycle_error(
+                    error_type="data_layer_seed_from_local_config_failure",
+                    error_message=str(e)[:500],
+                    cycle_phase="prover_source_registry",
+                )
+            except Exception:
+                pass
 
     if seeded:
         logger.info(f"Seeded {seeded} sources from local config into DB")
@@ -433,8 +478,17 @@ def _get_local_sources() -> list[dict]:
     try:
         from app.data_layer.provenance_scaling import PROVENANCE_SOURCES
         from app.collectors.registry import _build_url, _infer_source_type
-    except ImportError:
-        logger.debug("Local provenance config not available")
+    except ImportError as e:
+        logger.warning(f"Local provenance config not available: {e}")
+        try:
+            from app.worker import _record_cycle_error
+            _record_cycle_error(
+                error_type="data_layer__get_local_sources_import_failure",
+                error_message=str(e)[:500],
+                cycle_phase="prover_source_registry",
+            )
+        except Exception:
+            pass
         return []
 
     sources = []
@@ -485,6 +539,17 @@ async def get_source_counts() -> dict:
                 "disabled": row["disabled"],
                 "total": row["total"],
             }
+    except asyncio.CancelledError:
+        raise
     except Exception as e:
-        logger.debug(f"Failed to get source counts: {e}")
+        logger.warning(f"Failed to get source counts: {e}")
+        try:
+            from app.worker import _record_cycle_error
+            _record_cycle_error(
+                error_type="data_layer_get_source_counts_failure",
+                error_message=str(e)[:500],
+                cycle_phase="prover_source_registry",
+            )
+        except Exception:
+            pass
     return {"active": 0, "disabled": 0, "total": 0}

--- a/app/data_layer/state_growth.py
+++ b/app/data_layer/state_growth.py
@@ -138,8 +138,19 @@ async def _bulk_row_counts() -> dict[str, int]:
         for r in (rows or []):
             counts[r["full_name"]] = int(r["n_live_tup"])
             counts[r["relname"]] = int(r["n_live_tup"])
-    except Exception:
-        pass
+    except asyncio.CancelledError:
+        raise
+    except Exception as e:
+        logger.warning(f"[state_growth] pg_stat row count fetch failed: {e}")
+        try:
+            from app.worker import _record_cycle_error
+            _record_cycle_error(
+                error_type="data_layer__bulk_row_counts_pg_stat_failure",
+                error_message=str(e)[:500],
+                cycle_phase="state_growth",
+            )
+        except Exception:
+            pass
 
     # Override pg_stat for tables with upsert/DELETE+INSERT churn patterns.
     # pg_stat n_live_tup inflates massively between VACUUM cycles for these.
@@ -163,8 +174,19 @@ async def _bulk_row_counts() -> dict[str, int]:
                 counts[table_name] = real_count
                 plain = table_name.split(".")[-1] if "." in table_name else table_name
                 counts[plain] = real_count
-        except Exception:
-            pass
+        except asyncio.CancelledError:
+            raise
+        except Exception as e:
+            logger.warning(f"[state_growth] table count override failed for {table_name}: {e}")
+            try:
+                from app.worker import _record_cycle_error
+                _record_cycle_error(
+                    error_type="data_layer__bulk_row_counts_override_failure",
+                    error_message=str(e)[:500],
+                    cycle_phase="state_growth",
+                )
+            except Exception:
+                pass
 
     return counts
 
@@ -210,8 +232,19 @@ async def snapshot_row_counts():
     try:
         pg = await _bulk_row_counts()
         await asyncio.to_thread(_snapshot_row_counts_sync, pg)
+    except asyncio.CancelledError:
+        raise
     except Exception as e:
-        logger.debug(f"Row count snapshot failed: {e}")
+        logger.warning(f"Row count snapshot failed: {e}")
+        try:
+            from app.worker import _record_cycle_error
+            _record_cycle_error(
+                error_type="data_layer_snapshot_row_counts_failure",
+                error_message=str(e)[:500],
+                cycle_phase="state_growth",
+            )
+        except Exception:
+            pass
 
 
 async def _load_snapshots() -> dict:
@@ -242,8 +275,19 @@ async def _load_snapshots() -> dict:
             if "week_start" not in entry or sd <= entry.get("week_start_date", today):
                 entry["week_start"] = count
                 entry["week_start_date"] = sd
-    except Exception:
-        pass
+    except asyncio.CancelledError:
+        raise
+    except Exception as e:
+        logger.warning(f"[state_growth] snapshot load failed: {e}")
+        try:
+            from app.worker import _record_cycle_error
+            _record_cycle_error(
+                error_type="data_layer__load_snapshots_failure",
+                error_message=str(e)[:500],
+                cycle_phase="state_growth",
+            )
+        except Exception:
+            pass
 
     # If no snapshot history yet, seed from daily_pulses state_accumulation
     has_yesterday = any("yesterday" in v for v in result.values())
@@ -283,8 +327,19 @@ async def _load_snapshots() -> dict:
                     result.setdefault("wallet_graph.wallet_risk_scores", {})["yesterday"] = int(ns["wallets_scored"])
                 if ns.get("edge_count"):
                     result.setdefault("wallet_graph.wallet_edges", {})["yesterday"] = int(ns["edge_count"])
-        except Exception:
-            pass
+        except asyncio.CancelledError:
+            raise
+        except Exception as e:
+            logger.warning(f"[state_growth] daily_pulses fallback failed: {e}")
+            try:
+                from app.worker import _record_cycle_error
+                _record_cycle_error(
+                    error_type="data_layer__load_snapshots_pulse_fallback_failure",
+                    error_message=str(e)[:500],
+                    cycle_phase="state_growth",
+                )
+            except Exception:
+                pass
 
     return result
 
@@ -433,8 +488,19 @@ async def get_state_growth() -> dict:
                     if daily_limit else None
                 ),
             }
-    except Exception:
-        pass
+    except asyncio.CancelledError:
+        raise
+    except Exception as e:
+        logger.warning(f"[state_growth] api utilization fetch failed: {e}")
+        try:
+            from app.worker import _record_cycle_error
+            _record_cycle_error(
+                error_type="data_layer_get_state_growth_api_utilization_failure",
+                error_message=str(e)[:500],
+                cycle_phase="state_growth",
+            )
+        except Exception:
+            pass
 
     # =========================================================================
     # 5. Provenance coverage
@@ -527,8 +593,19 @@ async def get_state_growth() -> dict:
         )
         if row:
             db_size_mb = round(float(row["size_mb"]), 1)
-    except Exception:
-        pass
+    except asyncio.CancelledError:
+        raise
+    except Exception as e:
+        logger.warning(f"[state_growth] db size fetch failed: {e}")
+        try:
+            from app.worker import _record_cycle_error
+            _record_cycle_error(
+                error_type="data_layer_get_state_growth_db_size_failure",
+                error_message=str(e)[:500],
+                cycle_phase="state_growth",
+            )
+        except Exception:
+            pass
 
     storage = {
         "estimated_total_mb": total_size_mb,
@@ -564,8 +641,19 @@ async def get_state_growth() -> dict:
                 "avg_latency_ms": r.get("avg_latency_ms", 0),
                 "total_components": r.get("total_components", 0),
             })
-    except Exception:
-        pass
+    except asyncio.CancelledError:
+        raise
+    except Exception as e:
+        logger.warning(f"[state_growth] collector health fetch failed: {e}")
+        try:
+            from app.worker import _record_cycle_error
+            _record_cycle_error(
+                error_type="data_layer_get_state_growth_collector_health_failure",
+                error_message=str(e)[:500],
+                cycle_phase="state_growth",
+            )
+        except Exception:
+            pass
 
     # =========================================================================
     # 10. Active alerts — things needing human attention
@@ -610,8 +698,19 @@ async def get_state_growth() -> dict:
         keeper_status["cycles_24h"] = await _safe_count(
             "SELECT COUNT(*) as cnt FROM ops.keeper_cycles WHERE started_at >= NOW() - INTERVAL '24 hours'"
         )
-    except Exception:
-        pass
+    except asyncio.CancelledError:
+        raise
+    except Exception as e:
+        logger.warning(f"[state_growth] keeper status fetch failed: {e}")
+        try:
+            from app.worker import _record_cycle_error
+            _record_cycle_error(
+                error_type="data_layer_get_state_growth_keeper_status_failure",
+                error_message=str(e)[:500],
+                cycle_phase="state_growth",
+            )
+        except Exception:
+            pass
 
     # =========================================================================
     # 12. Scoring performance — cycle durations and throughput
@@ -653,8 +752,19 @@ async def get_state_growth() -> dict:
         scoring_performance["avg_components_per_coin"] = (
             round(float(avg_comps["avg_cnt"]), 1) if avg_comps and avg_comps.get("avg_cnt") else 0
         )
-    except Exception:
-        pass
+    except asyncio.CancelledError:
+        raise
+    except Exception as e:
+        logger.warning(f"[state_growth] scoring performance fetch failed: {e}")
+        try:
+            from app.worker import _record_cycle_error
+            _record_cycle_error(
+                error_type="data_layer_get_state_growth_scoring_performance_failure",
+                error_message=str(e)[:500],
+                cycle_phase="state_growth",
+            )
+        except Exception:
+            pass
 
     # =========================================================================
     # 13. CDA freshness — per-issuer extraction staleness
@@ -688,8 +798,19 @@ async def get_state_growth() -> dict:
                 "days_since": days_since,
                 "stale": False if no_attestation else (days_since is None or days_since > 30),
             })
-    except Exception:
-        pass
+    except asyncio.CancelledError:
+        raise
+    except Exception as e:
+        logger.warning(f"[state_growth] cda freshness fetch failed: {e}")
+        try:
+            from app.worker import _record_cycle_error
+            _record_cycle_error(
+                error_type="data_layer_get_state_growth_cda_freshness_failure",
+                error_message=str(e)[:500],
+                cycle_phase="state_growth",
+            )
+        except Exception:
+            pass
 
     # =========================================================================
     # 14. Component coverage — per-index: defined, automated, static, empty
@@ -731,8 +852,19 @@ async def get_state_growth() -> dict:
         component_coverage["rpi"] = {
             "unique_components": rpi_comp_count,
         }
-    except Exception:
-        pass
+    except asyncio.CancelledError:
+        raise
+    except Exception as e:
+        logger.warning(f"[state_growth] component coverage fetch failed: {e}")
+        try:
+            from app.worker import _record_cycle_error
+            _record_cycle_error(
+                error_type="data_layer_get_state_growth_component_coverage_failure",
+                error_message=str(e)[:500],
+                cycle_phase="state_growth",
+            )
+        except Exception:
+            pass
 
     # =========================================================================
     # 15. CQI contagion coverage
@@ -749,8 +881,19 @@ async def get_state_growth() -> dict:
             "coverage_pct": round(pairs_with_pools / max(pairs_total, 1) * 100, 1),
             "pool_wallets_discovered": await _safe_count("SELECT COUNT(*) as cnt FROM protocol_pool_wallets"),
         }
-    except Exception:
-        pass
+    except asyncio.CancelledError:
+        raise
+    except Exception as e:
+        logger.warning(f"[state_growth] cqi contagion fetch failed: {e}")
+        try:
+            from app.worker import _record_cycle_error
+            _record_cycle_error(
+                error_type="data_layer_get_state_growth_cqi_contagion_failure",
+                error_message=str(e)[:500],
+                cycle_phase="state_growth",
+            )
+        except Exception:
+            pass
 
     # =========================================================================
     # 16. x402 revenue
@@ -789,8 +932,19 @@ async def get_state_growth() -> dict:
              "revenue_usd": round(float(r["revenue"]), 6) if r.get("revenue") else 0}
             for r in top_endpoints
         ]
-    except Exception:
-        pass
+    except asyncio.CancelledError:
+        raise
+    except Exception as e:
+        logger.warning(f"[state_growth] x402 revenue fetch failed: {e}")
+        try:
+            from app.worker import _record_cycle_error
+            _record_cycle_error(
+                error_type="data_layer_get_state_growth_x402_revenue_failure",
+                error_message=str(e)[:500],
+                cycle_phase="state_growth",
+            )
+        except Exception:
+            pass
 
     # =========================================================================
     # 17. Security scanning — contract surveillance status
@@ -836,8 +990,19 @@ async def get_state_growth() -> dict:
             scored_entities.update(str(r["id"]) for r in sii_entities)
             psi_entities = await fetch_all_async("SELECT DISTINCT protocol_slug FROM psi_scores") or []
             scored_entities.update(r["protocol_slug"] for r in psi_entities)
-        except Exception:
-            pass
+        except asyncio.CancelledError:
+            raise
+        except Exception as e:
+            logger.warning(f"[state_growth] scored entities query failed: {e}")
+            try:
+                from app.worker import _record_cycle_error
+                _record_cycle_error(
+                    error_type="data_layer_get_state_growth_scored_entities_failure",
+                    error_message=str(e)[:500],
+                    cycle_phase="state_growth",
+                )
+            except Exception:
+                pass
 
         monitored_entities = set(r["entity_id"] for r in monitored)
         unmonitored = sorted(scored_entities - monitored_entities)
@@ -871,8 +1036,19 @@ async def get_state_growth() -> dict:
             security_scanning["last_scan"] = lt.isoformat() if hasattr(lt, 'isoformat') else str(lt)
         else:
             security_scanning["last_scan"] = None
-    except Exception:
-        pass
+    except asyncio.CancelledError:
+        raise
+    except Exception as e:
+        logger.warning(f"[state_growth] security scanning fetch failed: {e}")
+        try:
+            from app.worker import _record_cycle_error
+            _record_cycle_error(
+                error_type="data_layer_get_state_growth_security_scanning_failure",
+                error_message=str(e)[:500],
+                cycle_phase="state_growth",
+            )
+        except Exception:
+            pass
 
     return {
         "generated_at": now.isoformat(),

--- a/app/data_layer/trace_collector.py
+++ b/app/data_layer/trace_collector.py
@@ -153,8 +153,19 @@ async def run_trace_collection() -> dict:
                         status=_tx_status,
                         latency_ms=int((time.monotonic() - _t0) * 1000),
                     )
-                except Exception:
-                    pass
+                except asyncio.CancelledError:
+                    raise
+                except Exception as e:
+                    logger.warning(f"[trace_collector] track_api_call (tx) failed: {e}")
+                    try:
+                        from app.worker import _record_cycle_error
+                        _record_cycle_error(
+                            error_type="data_layer_run_trace_collection_track_tx_failure",
+                            error_message=str(e)[:500],
+                            cycle_phase="trace_collector",
+                        )
+                    except Exception:
+                        pass
             logger.error(f"[trace_collector] step E.{i}: HTTP {resp.status_code}")
             if resp.status_code != 200:
                 total_errors += 1
@@ -195,8 +206,19 @@ async def run_trace_collection() -> dict:
                             status=_trace_status,
                             latency_ms=int((time.monotonic() - _t1) * 1000),
                         )
-                    except Exception:
-                        pass
+                    except asyncio.CancelledError:
+                        raise
+                    except Exception as e:
+                        logger.warning(f"[trace_collector] track_api_call (trace) failed: {e}")
+                        try:
+                            from app.worker import _record_cycle_error
+                            _record_cycle_error(
+                                error_type="data_layer_run_trace_collection_track_trace_failure",
+                                error_message=str(e)[:500],
+                                cycle_phase="trace_collector",
+                            )
+                        except Exception:
+                            pass
 
                 if trace_resp.status_code != 200:
                     total_errors += 1
@@ -246,8 +268,19 @@ async def run_trace_collection() -> dict:
         from app.data_layer.provenance_scaling import attest_data_batch
         if total_traces > 0:
             await asyncio.to_thread(attest_data_batch, "protocol_traces", [{"traces": total_traces}])
-    except Exception:
-        pass
+    except asyncio.CancelledError:
+        raise
+    except Exception as e:
+        logger.warning(f"[trace_collector] attestation failed: {e}")
+        try:
+            from app.worker import _record_cycle_error
+            _record_cycle_error(
+                error_type="data_layer_run_trace_collection_attestation_failure",
+                error_message=str(e)[:500],
+                cycle_phase="trace_collector",
+            )
+        except Exception:
+            pass
 
     logger.error(
         f"[trace_collector] SUMMARY: protocols={protocols_processed}, "

--- a/app/data_layer/transfer_edge_builder.py
+++ b/app/data_layer/transfer_edge_builder.py
@@ -97,8 +97,19 @@ async def _fetch_tokentx(wallet: str, api_key: str) -> list[dict]:
                 status=_status,
                 latency_ms=int((time.monotonic() - _t0) * 1000),
             )
-        except Exception:
-            pass
+        except asyncio.CancelledError:
+            raise
+        except Exception as e:
+            logger.warning(f"[transfer_edge_builder] track_api_call failed: {e}")
+            try:
+                from app.worker import _record_cycle_error
+                _record_cycle_error(
+                    error_type="data_layer__fetch_tokentx_track_api_call_failure",
+                    error_message=str(e)[:500],
+                    cycle_phase="transfer_edge_builder",
+                )
+            except Exception:
+                pass
 
 
 async def _process_wallet(wallet: str, api_key: str) -> dict:
@@ -184,8 +195,19 @@ async def _process_wallet(wallet: str, api_key: str) -> dict:
                 edges_created = wallet_graph.edge_build_status.edges_created + EXCLUDED.edges_created,
                 status = 'complete'
         """, (wallet_lower, len(txs), edges_written))
-    except Exception:
-        pass
+    except asyncio.CancelledError:
+        raise
+    except Exception as e:
+        logger.warning(f"[transfer_edge_builder] edge_build_status upsert failed for {wallet_lower}: {e}")
+        try:
+            from app.worker import _record_cycle_error
+            _record_cycle_error(
+                error_type="data_layer__process_wallet_status_upsert_failure",
+                error_message=str(e)[:500],
+                cycle_phase="transfer_edge_builder",
+            )
+        except Exception:
+            pass
 
     return {"edges": edges_written, "txs": len(txs)}
 

--- a/app/data_layer/wallet_behavior.py
+++ b/app/data_layer/wallet_behavior.py
@@ -203,8 +203,17 @@ def _classify_wallet(metrics: dict) -> list[dict]:
                         if k != "address" and isinstance(v, (int, float))
                     },
                 })
-        except Exception:
-            pass
+        except Exception as e:
+            logger.warning(f"[wallet_behavior] rule check failed for {rule.get('type')}: {e}")
+            try:
+                from app.worker import _record_cycle_error
+                _record_cycle_error(
+                    error_type="data_layer__classify_wallet_rule_check_failure",
+                    error_message=str(e)[:500],
+                    cycle_phase="wallet_behavior",
+                )
+            except Exception:
+                pass
     return tags
 
 
@@ -297,7 +306,16 @@ def run_behavioral_classification(batch_size: int = 2000) -> dict:
 
             classified += 1
         except Exception as e:
-            logger.debug(f"Behavioral classification failed for {address}: {e}")
+            logger.warning(f"Behavioral classification failed for {address}: {e}")
+            try:
+                from app.worker import _record_cycle_error
+                _record_cycle_error(
+                    error_type="data_layer_run_behavioral_classification_failure",
+                    error_message=str(e)[:500],
+                    cycle_phase="wallet_behavior",
+                )
+            except Exception:
+                pass
 
     logger.info(
         f"Behavioral classification complete: {classified} wallets, "

--- a/app/data_layer/wallet_expansion.py
+++ b/app/data_layer/wallet_expansion.py
@@ -143,8 +143,19 @@ async def run_wallet_graph_expansion(
         finally:
             try:
                 track_api_call(provider="etherscan", endpoint="account/tokentx", caller="data_layer.wallet_expansion", status=_status, latency_ms=int((time.monotonic() - _t0) * 1000))
-            except Exception:
-                pass
+            except asyncio.CancelledError:
+                raise
+            except Exception as e:
+                logger.warning(f"[wallet_expansion] track_api_call failed: {e}")
+                try:
+                    from app.worker import _record_cycle_error
+                    _record_cycle_error(
+                        error_type="data_layer_fetch_tokentx_track_api_call_failure",
+                        error_message=str(e)[:500],
+                        cycle_phase="wallet_expansion",
+                    )
+                except Exception:
+                    pass
         if resp.status_code == 429 or "Max rate limit" in resp.text:
             _api_errors += 1
             raise httpx.HTTPStatusError(
@@ -410,8 +421,19 @@ async def run_multi_source_seeding() -> dict:
                         finally:
                             try:
                                 track_api_call(provider="etherscan", endpoint="token/tokenholderlist", caller="data_layer.wallet_expansion", status=_status, latency_ms=int((time.monotonic() - _t0) * 1000))
-                            except Exception:
-                                pass
+                            except asyncio.CancelledError:
+                                raise
+                            except Exception as e:
+                                logger.warning(f"[wallet_expansion] track_api_call failed: {e}")
+                                try:
+                                    from app.worker import _record_cycle_error
+                                    _record_cycle_error(
+                                        error_type="data_layer_run_multi_source_seeding_track_api_call_failure",
+                                        error_message=str(e)[:500],
+                                        cycle_phase="wallet_expansion",
+                                    )
+                                except Exception:
+                                    pass
                         if resp.status_code != 200:
                             continue
                         data = resp.json()
@@ -430,11 +452,33 @@ async def run_multi_source_seeding() -> dict:
                                     _rowcount = await asyncio.to_thread(_inner_th)
                                     if _rowcount > 0:
                                         holder_count += 1
-                                except Exception:
-                                    pass
+                                except asyncio.CancelledError:
+                                    raise
+                                except Exception as e:
+                                    logger.warning(f"[wallet_expansion] top_holder insert failed: {e}")
+                                    try:
+                                        from app.worker import _record_cycle_error
+                                        _record_cycle_error(
+                                            error_type="data_layer_run_multi_source_seeding_top_holder_insert_failure",
+                                            error_message=str(e)[:500],
+                                            cycle_phase="wallet_expansion",
+                                        )
+                                    except Exception:
+                                        pass
                         await asyncio.sleep(0.2)
-                    except Exception:
-                        pass
+                    except asyncio.CancelledError:
+                        raise
+                    except Exception as e:
+                        logger.warning(f"[wallet_expansion] top_holders contract loop failed: {e}")
+                        try:
+                            from app.worker import _record_cycle_error
+                            _record_cycle_error(
+                                error_type="data_layer_run_multi_source_seeding_top_holders_loop_failure",
+                                error_message=str(e)[:500],
+                                cycle_phase="wallet_expansion",
+                            )
+                        except Exception:
+                            pass
             results["sources"]["top_holders"] = holder_count
             results["total_new"] += holder_count
             logger.error(f"[wallet_seeding] top_holders: inserted={holder_count}")

--- a/app/data_layer/wallet_presence_scanner.py
+++ b/app/data_layer/wallet_presence_scanner.py
@@ -158,8 +158,19 @@ async def run_wallet_presence_scan() -> dict:
         from app.data_layer.provenance_scaling import attest_data_batch
         if total_presences > 0:
             await asyncio.to_thread(attest_data_batch, "wallet_chain_presence", [{"presences": total_presences, "mode": "B"}])
-    except Exception:
-        pass
+    except asyncio.CancelledError:
+        raise
+    except Exception as e:
+        logger.warning(f"[wallet_presence] attestation failed: {e}")
+        try:
+            from app.worker import _record_cycle_error
+            _record_cycle_error(
+                error_type="data_layer_run_wallet_presence_scan_attestation_failure",
+                error_message=str(e)[:500],
+                cycle_phase="wallet_presence_scanner",
+            )
+        except Exception:
+            pass
 
     # SUMMARY
     presence_parts = ", ".join(f"{c}={n}" for c, n in presences_by_chain.items())

--- a/app/data_layer/yield_collector.py
+++ b/app/data_layer/yield_collector.py
@@ -272,8 +272,19 @@ async def run_yield_collection() -> dict:
         if snapshots:
             await asyncio.to_thread(attest_data_batch, "yield_snapshots", [{"pools": len(snapshots)}])
             await link_batch_to_proof("yield_snapshots", "yield_snapshots")
+    except asyncio.CancelledError:
+        raise
     except Exception as e:
-        logger.debug(f"Yield provenance failed: {e}")
+        logger.warning(f"Yield provenance failed: {e}")
+        try:
+            from app.worker import _record_cycle_error
+            _record_cycle_error(
+                error_type="data_layer_run_yield_collection_provenance_failure",
+                error_message=str(e)[:500],
+                cycle_phase="yield_collector",
+            )
+        except Exception:
+            pass
 
     logger.info(
         f"Yield collection complete: {len(snapshots)} snapshots from "

--- a/tools/audit/bare_except_audit.py
+++ b/tools/audit/bare_except_audit.py
@@ -1,0 +1,490 @@
+#!/usr/bin/env python3
+"""
+Bare-except audit (Wave C / V9.12 Class 2).
+
+Walks the AST of every Python file under a given root and emits a structured
+report of every `except` block. Classifies each block so the conversion Wave
+can target the `debug_only` cohort (the V9.12 Class 2 silent-failure pattern).
+
+Background
+----------
+V9.12 Class 2 ("silent-except-on-debug") names a bug class where `except
+Exception` blocks absorb errors and only `logger.debug(...)` them. At debug
+log level (filtered in production) the failure is invisible: no metric, no
+`cycle_errors` row, no operator visibility. The April 12 cluster outage was
+caused by three of these in the orphaned actor_classification chain.
+
+Usage
+-----
+    python tools/audit/bare_except_audit.py app/                 # CSV to stdout
+    python tools/audit/bare_except_audit.py app/collectors/      # subsystem
+    python tools/audit/bare_except_audit.py app/ --summary       # summary only
+    python tools/audit/bare_except_audit.py app/ --classification debug_only
+
+CI gate
+-------
+    python tools/audit/bare_except_audit.py app/ \
+        --max-debug-only 10 --fail-on-regression
+
+Exit codes:
+    0  — all checks passed (no thresholds set, or thresholds met)
+    1  — a threshold check failed (CI gate hit)
+    2  — usage / IO error
+"""
+
+import argparse
+import ast
+import csv
+import os
+import sys
+from pathlib import Path
+from typing import Optional
+
+
+CLASSIFICATIONS = (
+    "debug_only",
+    "info_log",
+    "warn_log",
+    "error_log",
+    "cycle_errors_write",
+    "reraise",
+    "return_error_sentinel",
+    "complex",
+    "bare_except",          # `except:` or `except BaseException:` — Rule 6
+)
+
+
+# ---------------------------------------------------------------------------
+# AST helpers
+# ---------------------------------------------------------------------------
+
+def _parent_map(tree: ast.AST) -> dict[int, ast.AST]:
+    """Build {id(child): parent} map by walking the tree once."""
+    parents: dict[int, ast.AST] = {}
+    for parent in ast.walk(tree):
+        for child in ast.iter_child_nodes(parent):
+            parents[id(child)] = parent
+    return parents
+
+
+def _enclosing_function(node: ast.AST, parents: dict[int, ast.AST]) -> Optional[ast.AST]:
+    """Return the nearest enclosing FunctionDef or AsyncFunctionDef, or None."""
+    cur: Optional[ast.AST] = parents.get(id(node))
+    while cur is not None:
+        if isinstance(cur, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            return cur
+        cur = parents.get(id(cur))
+    return None
+
+
+def _attr_chain_name(node: ast.AST) -> Optional[str]:
+    """Return the rightmost attribute name in an attribute chain, or the Name."""
+    if isinstance(node, ast.Attribute):
+        return node.attr
+    if isinstance(node, ast.Name):
+        return node.id
+    return None
+
+
+def _is_logger_call(call: ast.Call, level: str) -> bool:
+    """True iff the Call looks like `<something>.<level>(...)` — typically
+    `logger.debug(...)` or `log.debug(...)`. Also matches bare `<level>(...)`
+    if `level` is something like `print`."""
+    f = call.func
+    if isinstance(f, ast.Attribute) and f.attr == level:
+        return True
+    if level == "print" and isinstance(f, ast.Name) and f.id == "print":
+        return True
+    return False
+
+
+def _is_record_cycle_error_call(call: ast.Call) -> bool:
+    """Match any reference to _record_cycle_error / record_cycle_error.
+    The function may be imported under either name."""
+    f = call.func
+    name = _attr_chain_name(f)
+    return name in {"_record_cycle_error", "record_cycle_error"}
+
+
+def _is_sentinel_return(stmt: ast.AST) -> bool:
+    """True iff stmt is `return X` where X is None, an empty container,
+    a constant zero/False, or a missing return value."""
+    if not isinstance(stmt, ast.Return):
+        return False
+    v = stmt.value
+    if v is None:
+        return True
+    if isinstance(v, ast.Constant) and v.value in (None, 0, 0.0, False, "", b""):
+        return True
+    if isinstance(v, (ast.List, ast.Tuple, ast.Set)) and not v.elts:
+        return True
+    if isinstance(v, ast.Dict) and not v.keys:
+        return True
+    # `return -1` — UnaryOp wrapping a 0/1 constant is sentinel-ish
+    if (isinstance(v, ast.UnaryOp) and isinstance(v.op, ast.USub)
+            and isinstance(v.operand, ast.Constant)
+            and v.operand.value in (0, 1, 0.0, 1.0)):
+        return True
+    return False
+
+
+def _body_has(body: list[ast.AST], predicate) -> bool:
+    """True iff any top-level statement in body matches predicate.
+    Does not descend into nested functions / class bodies."""
+    for stmt in body:
+        if isinstance(stmt, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+            continue
+        for node in ast.walk(stmt):
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+                # don't recurse — but ast.walk already yielded; skip via predicate
+                continue
+            if predicate(node):
+                return True
+    return False
+
+
+def _has_raise(body: list[ast.AST]) -> bool:
+    """True iff body re-raises (at top level, not buried in try/except).
+    A bare `raise` or `raise X` counts. We allow `raise` inside `if/else`
+    blocks in the body, but not inside nested try/except handlers."""
+    def walk(stmts: list[ast.AST]) -> bool:
+        for s in stmts:
+            if isinstance(s, ast.Raise):
+                return True
+            if isinstance(s, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+                continue
+            if isinstance(s, ast.If):
+                if walk(s.body) or walk(s.orelse):
+                    return True
+            elif isinstance(s, (ast.For, ast.While, ast.AsyncFor, ast.With, ast.AsyncWith)):
+                if walk(s.body):
+                    return True
+            elif isinstance(s, ast.Try):
+                # a raise inside a nested try's handler is not the same as
+                # this except block re-raising. only count raises in the try body.
+                if walk(s.body):
+                    return True
+        return False
+    return walk(body)
+
+
+def _has_cycle_errors_write(body: list[ast.AST]) -> bool:
+    for stmt in body:
+        for node in ast.walk(stmt):
+            if isinstance(node, ast.Call) and _is_record_cycle_error_call(node):
+                return True
+    return False
+
+
+def _logger_call_levels(body: list[ast.AST]) -> set[str]:
+    """Return set of logger levels used at the top level of body."""
+    levels = set()
+    for stmt in body:
+        for node in ast.walk(stmt):
+            if not isinstance(node, ast.Call):
+                continue
+            f = node.func
+            if isinstance(f, ast.Attribute):
+                if f.attr in {"debug", "info", "warning", "warn",
+                              "error", "exception", "critical"}:
+                    levels.add(f.attr)
+            elif isinstance(f, ast.Name) and f.id == "print":
+                levels.add("print")
+    return levels
+
+
+def _is_only_pass_or_comment(body: list[ast.AST]) -> bool:
+    """True iff body is empty, only `pass`, or only ellipsis."""
+    if not body:
+        return True
+    for stmt in body:
+        if isinstance(stmt, ast.Pass):
+            continue
+        if (isinstance(stmt, ast.Expr) and isinstance(stmt.value, ast.Constant)
+                and stmt.value.value is Ellipsis):
+            continue
+        return False
+    return True
+
+
+def _statement_kind(stmt: ast.AST) -> str:
+    """Tag a single body statement so we can compose a body classification."""
+    if isinstance(stmt, ast.Pass):
+        return "pass"
+    if (isinstance(stmt, ast.Expr) and isinstance(stmt.value, ast.Constant)
+            and stmt.value.value is Ellipsis):
+        return "pass"
+    if isinstance(stmt, ast.Return):
+        return "sentinel_return" if _is_sentinel_return(stmt) else "value_return"
+    if isinstance(stmt, ast.Raise):
+        return "raise"
+    if isinstance(stmt, ast.Continue):
+        return "continue"
+    if isinstance(stmt, ast.Break):
+        return "break"
+    if isinstance(stmt, ast.Expr) and isinstance(stmt.value, ast.Call):
+        f = stmt.value.func
+        if isinstance(f, ast.Attribute):
+            if f.attr in {"debug", "info", "warning", "warn",
+                          "error", "exception", "critical"}:
+                return f"log_{f.attr}"
+            if _is_record_cycle_error_call(stmt.value):
+                return "cycle_errors_write"
+        if isinstance(f, ast.Name):
+            if f.id == "print":
+                return "log_debug"
+            if f.id in {"_record_cycle_error", "record_cycle_error"}:
+                return "cycle_errors_write"
+        return "expr_call"
+    return "other"
+
+
+# ---------------------------------------------------------------------------
+# Classification
+# ---------------------------------------------------------------------------
+
+def classify(handler: ast.ExceptHandler) -> str:
+    """Apply the rules from the audit spec to one ExceptHandler."""
+    body = handler.body
+
+    # Rule 6: bare `except:` or `except BaseException:` — always flag.
+    exc_type = handler.type
+    if exc_type is None:
+        return "bare_except"
+    if isinstance(exc_type, ast.Name) and exc_type.id == "BaseException":
+        return "bare_except"
+
+    # cycle_errors_write takes precedence over everything else.
+    if _has_cycle_errors_write(body):
+        return "cycle_errors_write"
+
+    # reraise next.
+    if _has_raise(body):
+        return "reraise"
+
+    # Empty / pass body — debug_only (silent absorber).
+    if _is_only_pass_or_comment(body):
+        return "debug_only"
+
+    levels = _logger_call_levels(body)
+    kinds = [_statement_kind(s) for s in body]
+    non_trivial = [
+        k for k in kinds
+        if k not in {"pass", "sentinel_return", "continue", "break"}
+    ]
+
+    # Body that's purely sentinel-returning (no logging at all) →
+    # return_error_sentinel.
+    if not levels and all(
+            k in {"pass", "sentinel_return", "continue", "break"} for k in kinds):
+        # If the body is JUST a sentinel return / continue / break, that is the
+        # explicit "swallow and produce a default" pattern.
+        if any(k in {"sentinel_return", "continue", "break"} for k in kinds):
+            return "return_error_sentinel"
+        return "debug_only"
+
+    # Single-level logger usage with optional sentinel return / pass.
+    log_only_kinds = {
+        f"log_{lv}" for lv in {"debug", "info", "warning", "warn",
+                               "error", "exception", "critical"}
+    } | {"sentinel_return", "pass", "continue", "break"}
+
+    if all(k in log_only_kinds for k in kinds):
+        # Pick the highest-severity logger level present.
+        if "debug" in levels and not (levels - {"debug"}):
+            return "debug_only"
+        # If only print() is used, treat as debug_only.
+        if levels == {"print"}:
+            return "debug_only"
+        if "debug" in levels and levels.issubset({"debug", "print"}):
+            return "debug_only"
+        if "info" in levels and levels.issubset({"info", "debug", "print"}):
+            return "info_log"
+        if levels & {"warning", "warn"} and not (levels & {"error", "exception", "critical"}):
+            return "warn_log"
+        if levels & {"error", "exception", "critical"}:
+            return "error_log"
+
+    # Anything more elaborate (manual cleanup, fallback logic, retries, etc.)
+    # needs human review.
+    return "complex"
+
+
+# ---------------------------------------------------------------------------
+# File walk
+# ---------------------------------------------------------------------------
+
+def _body_preview(handler: ast.ExceptHandler, src_lines: list[str]) -> str:
+    """One-line preview of the first 1-2 statements of the except body."""
+    if not handler.body:
+        return ""
+    first = handler.body[0]
+    end = getattr(handler.body[-1], "end_lineno", handler.body[-1].lineno)
+    start = first.lineno
+    snippet_lines = src_lines[start - 1: min(end, start + 1)]
+    snippet = " ".join(s.strip() for s in snippet_lines)
+    snippet = snippet.replace("\n", " ").replace("\r", " ")
+    if len(snippet) > 160:
+        snippet = snippet[:157] + "..."
+    return snippet
+
+
+def audit_file(path: Path) -> list[dict]:
+    """Return a list of finding dicts for one file."""
+    try:
+        src = path.read_text(encoding="utf-8")
+        tree = ast.parse(src, filename=str(path))
+    except (SyntaxError, UnicodeDecodeError) as e:
+        print(f"# audit: skip {path}: {e}", file=sys.stderr)
+        return []
+
+    parents = _parent_map(tree)
+    src_lines = src.splitlines()
+    findings = []
+
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.ExceptHandler):
+            continue
+        fn = _enclosing_function(node, parents)
+        is_async = isinstance(fn, ast.AsyncFunctionDef)
+        fn_name = fn.name if fn is not None else "<module>"
+        err_var = node.name or ""
+        classification = classify(node)
+        first_is_return = (
+            bool(node.body)
+            and isinstance(node.body[0], ast.Return)
+        )
+        findings.append({
+            "path": str(path),
+            "line": node.lineno,
+            "function": fn_name,
+            "classification": classification,
+            "is_async": "1" if is_async else "0",
+            "error_var": err_var,
+            "first_is_return": "1" if first_is_return else "0",
+            "body_preview": _body_preview(node, src_lines),
+        })
+    return findings
+
+
+def walk_root(root: Path) -> list[dict]:
+    findings = []
+    if root.is_file() and root.suffix == ".py":
+        return audit_file(root)
+    for path in sorted(root.rglob("*.py")):
+        # Skip __pycache__ and similar.
+        if any(part.startswith(".") or part == "__pycache__" for part in path.parts):
+            continue
+        findings.extend(audit_file(path))
+    return findings
+
+
+# ---------------------------------------------------------------------------
+# Output
+# ---------------------------------------------------------------------------
+
+def write_csv(findings: list[dict], out) -> None:
+    fieldnames = [
+        "path", "line", "function", "classification",
+        "is_async", "error_var", "first_is_return", "body_preview",
+    ]
+    writer = csv.DictWriter(out, fieldnames=fieldnames)
+    writer.writeheader()
+    for f in findings:
+        writer.writerow(f)
+
+
+def summary(findings: list[dict]) -> dict[str, int]:
+    counts = {c: 0 for c in CLASSIFICATIONS}
+    for f in findings:
+        counts[f["classification"]] = counts.get(f["classification"], 0) + 1
+    counts["TOTAL"] = len(findings)
+    return counts
+
+
+def print_summary(counts: dict[str, int], out=sys.stdout) -> None:
+    print("# bare-except audit summary", file=out)
+    print(f"#   total: {counts['TOTAL']}", file=out)
+    for c in CLASSIFICATIONS:
+        print(f"#   {c:<24} {counts.get(c, 0)}", file=out)
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+def main() -> int:
+    p = argparse.ArgumentParser(description="Audit bare-except blocks (V9.12 Class 2).")
+    p.add_argument("root", help="Directory or .py file to audit (e.g. app/, app/collectors/)")
+    p.add_argument("--summary", action="store_true",
+                   help="Print summary counts only (no CSV body)")
+    p.add_argument("--classification", default=None,
+                   help="Filter to one classification (e.g. debug_only)")
+    p.add_argument("--max-debug-only", type=int, default=None,
+                   help="CI gate: fail if debug_only count exceeds this number")
+    p.add_argument("--fail-on-regression", action="store_true",
+                   help="CI gate: combined with --max-debug-only, exit 1 if exceeded")
+    p.add_argument("--baseline", default=None,
+                   help="Path to a previous audit CSV; report deltas relative to it")
+    args = p.parse_args()
+
+    root = Path(args.root)
+    if not root.exists():
+        print(f"audit: root '{root}' not found", file=sys.stderr)
+        return 2
+
+    findings = walk_root(root)
+
+    if args.classification:
+        if args.classification not in CLASSIFICATIONS:
+            print(
+                f"audit: unknown classification '{args.classification}'. "
+                f"valid: {', '.join(CLASSIFICATIONS)}",
+                file=sys.stderr,
+            )
+            return 2
+        findings = [f for f in findings if f["classification"] == args.classification]
+
+    counts = summary(findings)
+
+    if args.summary:
+        print_summary(counts)
+    else:
+        write_csv(findings, sys.stdout)
+        print_summary(counts, out=sys.stderr)
+
+    # Baseline regression report (printed to stderr; doesn't affect exit code
+    # on its own — combine with --fail-on-regression for CI use).
+    if args.baseline:
+        try:
+            with open(args.baseline) as fh:
+                base_rows = list(csv.DictReader(fh))
+            base_counts = {c: 0 for c in CLASSIFICATIONS}
+            for r in base_rows:
+                base_counts[r["classification"]] = base_counts.get(r["classification"], 0) + 1
+            print("# baseline delta", file=sys.stderr)
+            for c in CLASSIFICATIONS:
+                delta = counts.get(c, 0) - base_counts.get(c, 0)
+                if delta:
+                    sign = "+" if delta > 0 else ""
+                    print(f"#   {c:<24} {sign}{delta}", file=sys.stderr)
+        except OSError as e:
+            print(f"audit: could not read baseline: {e}", file=sys.stderr)
+
+    # CI gate.
+    if args.max_debug_only is not None:
+        debug_only = counts.get("debug_only", 0)
+        if debug_only > args.max_debug_only:
+            print(
+                f"audit: debug_only={debug_only} exceeds threshold "
+                f"{args.max_debug_only}",
+                file=sys.stderr,
+            )
+            if args.fail_on_regression:
+                return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/audit/bare_except_audit.py
+++ b/tools/audit/bare_except_audit.py
@@ -47,6 +47,7 @@ CLASSIFICATIONS = (
     "warn_log",
     "error_log",
     "cycle_errors_write",
+    "cycle_errors_protective_wrapper",  # inner `except: pass` around _record_cycle_error itself
     "reraise",
     "return_error_sentinel",
     "complex",
@@ -243,7 +244,46 @@ def _statement_kind(stmt: ast.AST) -> str:
 # Classification
 # ---------------------------------------------------------------------------
 
-def classify(handler: ast.ExceptHandler) -> str:
+def _is_protective_cycle_error_wrapper(handler: ast.ExceptHandler,
+                                       parents: dict[int, ast.AST]) -> bool:
+    """Detect the spec-mandated defensive wrapper pattern around
+    ``_record_cycle_error`` itself:
+
+        try:
+            from app.worker import _record_cycle_error
+            _record_cycle_error(...)
+        except Exception:
+            pass
+
+    The inner ``except Exception: pass`` is intentional — error logging must
+    never break the calling function. Without this exemption, every Wave-C
+    conversion would inflate the ``debug_only`` count by one and tip over
+    the CI gate.
+
+    Match condition:
+      - except body is exactly ``pass`` (or ``...``)
+      - parent ast.Try's body contains a call to ``_record_cycle_error``
+    """
+    body = handler.body
+    if len(body) != 1:
+        return False
+    only = body[0]
+    is_pass = isinstance(only, ast.Pass)
+    is_ellipsis = (
+        isinstance(only, ast.Expr)
+        and isinstance(only.value, ast.Constant)
+        and only.value.value is Ellipsis
+    )
+    if not (is_pass or is_ellipsis):
+        return False
+    parent = parents.get(id(handler))
+    if not isinstance(parent, ast.Try):
+        return False
+    return _has_cycle_errors_write(parent.body)
+
+
+def classify(handler: ast.ExceptHandler,
+             parents: dict[int, ast.AST]) -> str:
     """Apply the rules from the audit spec to one ExceptHandler."""
     body = handler.body
 
@@ -261,6 +301,13 @@ def classify(handler: ast.ExceptHandler) -> str:
     # reraise next.
     if _has_raise(body):
         return "reraise"
+
+    # Spec-mandated protective wrapper around _record_cycle_error itself.
+    # Detected before the pass-body check so it doesn't get miscounted as
+    # debug_only — the wrapper is intentional defensive code, not a V9.12
+    # Class 2 silent absorber.
+    if _is_protective_cycle_error_wrapper(handler, parents):
+        return "cycle_errors_protective_wrapper"
 
     # Empty / pass body — debug_only (silent absorber).
     if _is_only_pass_or_comment(body):
@@ -349,7 +396,7 @@ def audit_file(path: Path) -> list[dict]:
         is_async = isinstance(fn, ast.AsyncFunctionDef)
         fn_name = fn.name if fn is not None else "<module>"
         err_var = node.name or ""
-        classification = classify(node)
+        classification = classify(node, parents)
         first_is_return = (
             bool(node.body)
             and isinstance(node.body[0], ast.Return)


### PR DESCRIPTION
**Merge order: 6 of 7** (Wave A/B/C tonight). Merge after PR 5 lands. Verify before proceeding to PR 7.

## Why

Wave C Phase 2 — convert `debug_only` / bare-except patterns in `app/data_layer/` to structured `cycle_errors` writes. This is the universal-risk-data-layer surface: catalog, registry, attestations, profile builders. High blast radius — needs the cluster-domain freshness check before continuing.

## What

- 92 conversions across 31 files in `app/data_layer/`.
- Diff: +1140 / -151 LOC.

## Verification (after Railway redeploys Scoring-Worker, wait ~15 min for full enrichment cycle)

```bash
PAGER=cat psql "$DATABASE_URL" -c "SELECT domain, NOW() - MAX(cycle_timestamp) AS staleness FROM state_attestations WHERE domain IN ('actors','divergence_signals','provenance') GROUP BY domain ORDER BY staleness;"
PAGER=cat psql "$DATABASE_URL" -c "SELECT cycle_phase, error_type, COUNT(*) FROM cycle_errors WHERE occurred_at > NOW() - INTERVAL '20 min' GROUP BY 1,2 ORDER BY 3 DESC LIMIT 15;"
```

**Pass:** `actors` and `divergence_signals` stay fresh (<2h); no error flood.
**Fail:** previously-fresh cluster domains regress to stale, OR major error flood from data_layer modules.

If fail: STOP, do not proceed to PR 7.

https://claude.ai/code/session_01XuHuGXV2AyY8q7H4ECEFjk

---
_Generated by [Claude Code](https://claude.ai/code/session_01XuHuGXV2AyY8q7H4ECEFjk)_