### PR TITLE
audit(collectors): convert 148 debug_only blocks to structured cycle_errors writes (13 deferred)

### DIFF
--- a/app/collectors/bridge_collector.py
+++ b/app/collectors/bridge_collector.py
@@ -209,7 +209,16 @@ def fetch_bridge_volume(bridge_id: int) -> dict | None:
         if resp.status_code == 200:
             return resp.json()
     except Exception as e:
-        logger.debug(f"Bridge volume fetch failed for ID {bridge_id}: {e}")
+        logger.warning(f"Bridge volume fetch failed for ID {bridge_id}: {e}")
+        try:
+            from app.worker import _record_cycle_error
+            _record_cycle_error(
+                error_type="collectors_fetch_bridge_volume_failure",
+                error_message=str(e)[:500],
+                cycle_phase="bridge_collector",
+            )
+        except Exception:
+            pass
     return None
 
 
@@ -254,7 +263,16 @@ def _automate_bridge_contract_age(entity: dict, static: dict) -> dict:
                     automated["contract_age_days"] = max(age_days, static_age)
                     logger.info(f"BRI contract age {entity['slug']}: {age_days} days")
     except Exception as e:
-        logger.debug(f"BRI contract age failed for {entity['slug']}: {e}")
+        logger.warning(f"BRI contract age failed for {entity['slug']}: {e}")
+        try:
+            from app.worker import _record_cycle_error
+            _record_cycle_error(
+                error_type="collectors__automate_bridge_contract_age_failure",
+                error_message=str(e)[:500],
+                cycle_phase="bridge_collector",
+            )
+        except Exception:
+            pass
 
     return automated
 
@@ -329,7 +347,16 @@ def _automate_bridge_bounty(entity: dict, static: dict) -> dict:
             # Keep static value if Immunefi didn't find it
             automated["bug_bounty_size"] = static.get("bug_bounty_size", 0)
     except Exception as e:
-        logger.debug(f"BRI Immunefi fetch failed for {slug}: {e}")
+        logger.warning(f"BRI Immunefi fetch failed for {slug}: {e}")
+        try:
+            from app.worker import _record_cycle_error
+            _record_cycle_error(
+                error_type="collectors__automate_bridge_bounty_failure",
+                error_message=str(e)[:500],
+                cycle_phase="bridge_collector",
+            )
+        except Exception:
+            pass
 
     return automated
 

--- a/app/collectors/bridge_monitors.py
+++ b/app/collectors/bridge_monitors.py
@@ -69,7 +69,16 @@ def _wormhole_message_stats(hours: int = 24) -> dict:
             "success_rate": round(success_rate, 2),
         }
     except Exception as e:
-        logger.debug(f"Wormhole adapter failed: {e}")
+        logger.warning(f"Wormhole adapter failed: {e}")
+        try:
+            from app.worker import _record_cycle_error
+            _record_cycle_error(
+                error_type="collectors__wormhole_message_stats_failure",
+                error_message=str(e)[:500],
+                cycle_phase="bridge_monitors",
+            )
+        except Exception:
+            pass
         return {}
 
 
@@ -109,7 +118,16 @@ def _axelar_message_stats(hours: int = 24) -> dict:
             "success_rate": round(success_rate, 2),
         }
     except Exception as e:
-        logger.debug(f"Axelar adapter failed: {e}")
+        logger.warning(f"Axelar adapter failed: {e}")
+        try:
+            from app.worker import _record_cycle_error
+            _record_cycle_error(
+                error_type="collectors__axelar_message_stats_failure",
+                error_message=str(e)[:500],
+                cycle_phase="bridge_monitors",
+            )
+        except Exception:
+            pass
         return {}
 
 
@@ -177,7 +195,16 @@ def _defillama_bridge_uptime(bridge_slug: str) -> dict:
 
         return {}
     except Exception as e:
-        logger.debug(f"DeFiLlama bridge volume check failed for {bridge_slug}: {e}")
+        logger.warning(f"DeFiLlama bridge volume check failed for {bridge_slug}: {e}")
+        try:
+            from app.worker import _record_cycle_error
+            _record_cycle_error(
+                error_type="collectors__defillama_bridge_uptime_failure",
+                error_message=str(e)[:500],
+                cycle_phase="bridge_monitors",
+            )
+        except Exception:
+            pass
         return {}
 
 
@@ -311,7 +338,18 @@ async def run_bridge_monitoring() -> list[dict]:
                 {"slug": r["bridge_slug"], "rate": r["success_rate"]}
                 for r in scored
             ])
-    except Exception:
-        pass
+    except asyncio.CancelledError:
+        raise
+    except Exception as e:
+        logger.warning(f"run bridge monitoring failed: {e}")
+        try:
+            from app.worker import _record_cycle_error
+            _record_cycle_error(
+                error_type="collectors_run_bridge_monitoring_failure",
+                error_message=str(e)[:500],
+                cycle_phase="bridge_monitors",
+            )
+        except Exception:
+            pass
 
     return results

--- a/app/collectors/cex_collector.py
+++ b/app/collectors/cex_collector.py
@@ -171,7 +171,16 @@ def fetch_exchange_data(coingecko_id: str) -> dict | None:
         if resp.status_code == 200:
             return resp.json()
     except Exception as e:
-        logger.debug(f"CoinGecko exchange fetch failed for {coingecko_id}: {e}")
+        logger.warning(f"CoinGecko exchange fetch failed for {coingecko_id}: {e}")
+        try:
+            from app.worker import _record_cycle_error
+            _record_cycle_error(
+                error_type="collectors_fetch_exchange_data_failure",
+                error_message=str(e)[:500],
+                cycle_phase="cex_collector",
+            )
+        except Exception:
+            pass
     return None
 
 
@@ -282,9 +291,17 @@ def _automate_cex_reserve_dashboard(entity: dict, static: dict) -> dict:
             automated["realtime_reserve_dashboard"] = 80  # dashboard exists
         else:
             automated["realtime_reserve_dashboard"] = 20
-    except Exception:
-        # Keep static value on failure
-        pass
+    except Exception as e:
+        logger.warning(f"automate cex reserve dashboard failed: {e}")
+        try:
+            from app.worker import _record_cycle_error
+            _record_cycle_error(
+                error_type="collectors__automate_cex_reserve_dashboard_failure",
+                error_message=str(e)[:500],
+                cycle_phase="cex_collector",
+            )
+        except Exception:
+            pass
 
     return automated
 
@@ -341,7 +358,16 @@ def extract_cex_raw_values(entity: dict, hacks_cache: list = None) -> dict:
                 static_score = static.get(comp_id, 0)
                 raw[comp_id] = max(live_score, static_score)
     except Exception as e:
-        logger.debug(f"CXRI regulatory check failed for {slug}: {e}")
+        logger.warning(f"CXRI regulatory check failed for {slug}: {e}")
+        try:
+            from app.worker import _record_cycle_error
+            _record_cycle_error(
+                error_type="collectors_extract_cex_raw_values_failure",
+                error_message=str(e)[:500],
+                cycle_phase="cex_collector",
+            )
+        except Exception:
+            pass
 
     return raw
 

--- a/app/collectors/clustered_concentration.py
+++ b/app/collectors/clustered_concentration.py
@@ -342,8 +342,19 @@ async def collect_clustered_concentration() -> dict:
                     "clustered_gini": metrics["clustered_gini"],
                     "divergence_score": metrics["divergence_score"],
                 }], str(coin_id))
-            except Exception:
-                pass
+            except asyncio.CancelledError:
+                raise
+            except Exception as e:
+                logger.warning(f"collect clustered concentration failed: {e}")
+                try:
+                    from app.worker import _record_cycle_error
+                    _record_cycle_error(
+                        error_type="collectors_collect_clustered_concentration_failure",
+                        error_message=str(e)[:500],
+                        cycle_phase="clustered_concentration",
+                    )
+                except Exception:
+                    pass
 
             elapsed = time.time() - t0
             logger.info(

--- a/app/collectors/coingecko.py
+++ b/app/collectors/coingecko.py
@@ -5,6 +5,8 @@ Collects price, volume, market cap, and ticker data.
 Produces peg_stability, liquidity, and market_activity components.
 """
 
+import asyncio
+
 import os
 import statistics
 import logging
@@ -77,8 +79,19 @@ async def fetch_current(client: httpx.AsyncClient, coingecko_id: str) -> dict:
                 status=_status,
                 latency_ms=int((_time.monotonic() - _t0) * 1000),
             )
-        except Exception:
-            pass
+        except asyncio.CancelledError:
+            raise
+        except Exception as e:
+            logger.warning(f"fetch current failed: {e}")
+            try:
+                from app.worker import _record_cycle_error
+                _record_cycle_error(
+                    error_type="collectors_fetch_current_failure",
+                    error_message=str(e)[:500],
+                    cycle_phase="coingecko",
+                )
+            except Exception:
+                pass
 
 
 async def fetch_price_history(client: httpx.AsyncClient, coingecko_id: str, days: int = 7) -> list[float]:
@@ -107,8 +120,19 @@ async def fetch_price_history(client: httpx.AsyncClient, coingecko_id: str, days
                 status=_status,
                 latency_ms=int((_time.monotonic() - _t0) * 1000),
             )
-        except Exception:
-            pass
+        except asyncio.CancelledError:
+            raise
+        except Exception as e:
+            logger.warning(f"fetch price history failed: {e}")
+            try:
+                from app.worker import _record_cycle_error
+                _record_cycle_error(
+                    error_type="collectors_fetch_price_history_failure",
+                    error_message=str(e)[:500],
+                    cycle_phase="coingecko",
+                )
+            except Exception:
+                pass
 
 
 # =============================================================================

--- a/app/collectors/coingecko_resolver.py
+++ b/app/collectors/coingecko_resolver.py
@@ -48,8 +48,17 @@ def fetch_coins_list() -> list[dict]:
                 data = json.loads(CACHE_PATH.read_text())
                 logger.info(f"CoinGecko coins list loaded from cache ({len(data)} coins, {age/3600:.1f}h old)")
                 return data
-            except Exception:
-                pass
+            except Exception as e:
+                logger.warning(f"fetch coins list failed: {e}")
+                try:
+                    from app.worker import _record_cycle_error
+                    _record_cycle_error(
+                        error_type="collectors_fetch_coins_list_failure",
+                        error_message=str(e)[:500],
+                        cycle_phase="coingecko_resolver",
+                    )
+                except Exception:
+                    pass
 
     # Fetch from API
     logger.info("Fetching CoinGecko coins list (include_platform=true)...")

--- a/app/collectors/collateral_coverage.py
+++ b/app/collectors/collateral_coverage.py
@@ -306,7 +306,17 @@ def collect_coverage_and_markets():
                         desc,
                         severity,
                     ))
-                except Exception:
+                except Exception as e:
+                    logger.warning(f"collect coverage and markets failed: {e}")
+                    try:
+                        from app.worker import _record_cycle_error
+                        _record_cycle_error(
+                            error_type="collectors_collect_coverage_and_markets_failure",
+                            error_message=str(e)[:500],
+                            cycle_phase="collateral_coverage",
+                        )
+                    except Exception:
+                        pass
                     pass  # May conflict on same-day re-run
 
             logger.info(f"  {slug}: coverage {ratio:.1f}% "

--- a/app/collectors/contract_dependencies.py
+++ b/app/collectors/contract_dependencies.py
@@ -107,7 +107,16 @@ def _fetch_internal_txs(contract_address: str) -> list[dict]:
             return []
         return data.get("result", [])
     except Exception as e:
-        logger.debug(f"Etherscan internal txs failed for {contract_address}: {e}")
+        logger.warning(f"Etherscan internal txs failed for {contract_address}: {e}")
+        try:
+            from app.worker import _record_cycle_error
+            _record_cycle_error(
+                error_type="collectors__fetch_internal_txs_failure",
+                error_message=str(e)[:500],
+                cycle_phase="contract_dependencies",
+            )
+        except Exception:
+            pass
         return []
 
 
@@ -135,8 +144,17 @@ def _fetch_etherscan_label(address: str) -> str | None:
         results = data.get("result", [])
         if results and isinstance(results, list) and results[0].get("ContractName"):
             return results[0]["ContractName"]
-    except Exception:
-        pass
+    except Exception as e:
+        logger.warning(f"fetch etherscan label failed: {e}")
+        try:
+            from app.worker import _record_cycle_error
+            _record_cycle_error(
+                error_type="collectors__fetch_etherscan_label_failure",
+                error_message=str(e)[:500],
+                cycle_phase="contract_dependencies",
+            )
+        except Exception:
+            pass
     return None
 
 
@@ -286,8 +304,17 @@ def _detect_dependencies(entity: dict) -> list[dict]:
             if label:
                 dep["depends_on_label"] = label
                 dep["depends_on_type"] = _classify_by_label(label)
-        except Exception:
-            pass
+        except Exception as e:
+            logger.warning(f"detect dependencies failed: {e}")
+            try:
+                from app.worker import _record_cycle_error
+                _record_cycle_error(
+                    error_type="collectors__detect_dependencies_failure",
+                    error_message=str(e)[:500],
+                    cycle_phase="contract_dependencies",
+                )
+            except Exception:
+                pass
 
     return list(dependencies.values())
 
@@ -350,8 +377,17 @@ def _reconcile_dependencies(entity: dict, current_deps: list[dict], results: dic
                     "depends_on": dep["depends_on_address"],
                     "chain": dep["depends_on_chain"],
                 }], str(entity_id))
-            except Exception:
-                pass
+            except Exception as e:
+                logger.warning(f"reconcile dependencies failed: {e}")
+                try:
+                    from app.worker import _record_cycle_error
+                    _record_cycle_error(
+                        error_type="collectors__reconcile_dependencies_failure",
+                        error_message=str(e)[:500],
+                        cycle_phase="contract_dependencies",
+                    )
+                except Exception:
+                    pass
 
         results["dependencies_found"] += 1
 
@@ -426,8 +462,17 @@ def _store_daily_snapshot(entity: dict, current_deps: list[dict], results: dict)
             "snapshot_date": today.isoformat(),
             "dependency_count": len(dep_addresses),
         }], str(entity_id))
-    except Exception:
-        pass
+    except Exception as e:
+        logger.warning(f"store daily snapshot failed: {e}")
+        try:
+            from app.worker import _record_cycle_error
+            _record_cycle_error(
+                error_type="collectors__store_daily_snapshot_failure",
+                error_message=str(e)[:500],
+                cycle_phase="contract_dependencies",
+            )
+        except Exception:
+            pass
 
     results["snapshots_stored"] += 1
 

--- a/app/collectors/contract_upgrades.py
+++ b/app/collectors/contract_upgrades.py
@@ -70,7 +70,16 @@ def _get_etherscan_bytecode(address: str) -> str | None:
         if result and result != "0x":
             return result
     except Exception as e:
-        logger.debug(f"Etherscan bytecode fetch failed for {address}: {e}")
+        logger.warning(f"Etherscan bytecode fetch failed for {address}: {e}")
+        try:
+            from app.worker import _record_cycle_error
+            _record_cycle_error(
+                error_type="collectors__get_etherscan_bytecode_failure",
+                error_message=str(e)[:500],
+                cycle_phase="contract_upgrades",
+            )
+        except Exception:
+            pass
     return None
 
 
@@ -94,7 +103,16 @@ def _rpc_get_code(rpc_url: str, address: str) -> str | None:
         if result and result != "0x":
             return result
     except Exception as e:
-        logger.debug(f"RPC eth_getCode failed for {address}: {e}")
+        logger.warning(f"RPC eth_getCode failed for {address}: {e}")
+        try:
+            from app.worker import _record_cycle_error
+            _record_cycle_error(
+                error_type="collectors__rpc_get_code_failure",
+                error_message=str(e)[:500],
+                cycle_phase="contract_upgrades",
+            )
+        except Exception:
+            pass
     return None
 
 
@@ -320,8 +338,17 @@ def _record_upgrade(
             "current_implementation": impl_address,
             "upgrade_detected_at": now.isoformat(),
         }], str(target["entity_id"]))
-    except Exception as ae:
-        logger.debug(f"Contract upgrade attestation failed: {ae}")
+    except Exception as e:
+        logger.warning(f"Contract upgrade attestation failed: {ae}")
+        try:
+            from app.worker import _record_cycle_error
+            _record_cycle_error(
+                error_type="collectors__record_upgrade_failure",
+                error_message=str(e)[:500],
+                cycle_phase="contract_upgrades",
+            )
+        except Exception:
+            pass
 
     logger.warning(
         f"CONTRACT UPGRADE DETECTED: {target['entity_symbol']} "

--- a/app/collectors/dao_collector.py
+++ b/app/collectors/dao_collector.py
@@ -149,7 +149,16 @@ def fetch_snapshot_governance_data(space_id: str) -> dict:
                     raw["proposal_pass_rate"] = 75.0  # Conservative default
 
     except Exception as e:
-        logger.debug(f"Snapshot governance data failed for {space_id}: {e}")
+        logger.warning(f"Snapshot governance data failed for {space_id}: {e}")
+        try:
+            from app.worker import _record_cycle_error
+            _record_cycle_error(
+                error_type="collectors_fetch_snapshot_governance_data_failure",
+                error_message=str(e)[:500],
+                cycle_phase="dao_collector",
+            )
+        except Exception:
+            pass
 
     time.sleep(0.5)
 
@@ -206,7 +215,16 @@ def fetch_snapshot_governance_data(space_id: str) -> dict:
                     raw["delegate_count"] = len(voter_vp)
 
     except Exception as e:
-        logger.debug(f"Snapshot voter data failed for {space_id}: {e}")
+        logger.warning(f"Snapshot voter data failed for {space_id}: {e}")
+        try:
+            from app.worker import _record_cycle_error
+            _record_cycle_error(
+                error_type="collectors_fetch_snapshot_governance_data_failure",
+                error_message=str(e)[:500],
+                cycle_phase="dao_collector",
+            )
+        except Exception:
+            pass
 
     time.sleep(0.5)
     return raw
@@ -253,7 +271,16 @@ def fetch_dao_treasury(protocol_slug: str) -> dict:
                 raw["treasury_size_usd"] = total
                 raw["treasury_diversification"] = (stablecoin_total / total) * 100
     except Exception as e:
-        logger.debug(f"Treasury fetch failed for {protocol_slug}: {e}")
+        logger.warning(f"Treasury fetch failed for {protocol_slug}: {e}")
+        try:
+            from app.worker import _record_cycle_error
+            _record_cycle_error(
+                error_type="collectors_fetch_dao_treasury_failure",
+                error_message=str(e)[:500],
+                cycle_phase="dao_collector",
+            )
+        except Exception:
+            pass
     return raw
 
 
@@ -281,7 +308,16 @@ def import_psi_governance_components(protocol_slug: str) -> dict:
             if "governance_proposals_90d" in psi_raw:
                 raw["proposal_frequency_90d"] = raw.get("proposal_frequency_90d") or psi_raw["governance_proposals_90d"]
     except Exception as e:
-        logger.debug(f"PSI governance import failed for {protocol_slug}: {e}")
+        logger.warning(f"PSI governance import failed for {protocol_slug}: {e}")
+        try:
+            from app.worker import _record_cycle_error
+            _record_cycle_error(
+                error_type="collectors_import_psi_governance_components_failure",
+                error_message=str(e)[:500],
+                cycle_phase="dao_collector",
+            )
+        except Exception:
+            pass
     return raw
 
 
@@ -466,7 +502,16 @@ def _automate_dao_multisig(entity: dict, static: dict) -> dict:
                                 f"= {config_score:.0f}"
                             )
     except Exception as e:
-        logger.debug(f"DAO multisig read failed for {entity['slug']}: {e}")
+        logger.warning(f"DAO multisig read failed for {entity['slug']}: {e}")
+        try:
+            from app.worker import _record_cycle_error
+            _record_cycle_error(
+                error_type="collectors__automate_dao_multisig_failure",
+                error_message=str(e)[:500],
+                cycle_phase="dao_collector",
+            )
+        except Exception:
+            pass
 
     return automated
 
@@ -511,7 +556,16 @@ def _automate_dao_timelock(entity: dict, static: dict) -> dict:
                         break
             time.sleep(0.15)
     except Exception as e:
-        logger.debug(f"DAO timelock read failed for {entity['slug']}: {e}")
+        logger.warning(f"DAO timelock read failed for {entity['slug']}: {e}")
+        try:
+            from app.worker import _record_cycle_error
+            _record_cycle_error(
+                error_type="collectors__automate_dao_timelock_failure",
+                error_message=str(e)[:500],
+                cycle_phase="dao_collector",
+            )
+        except Exception:
+            pass
 
     return automated
 
@@ -582,7 +636,16 @@ def _automate_dao_transparency(entity: dict, static: dict) -> dict:
             static_prf = static.get("public_reporting_frequency", 20)
             automated["public_reporting_frequency"] = max(prf_score, static_prf)
     except Exception as e:
-        logger.debug(f"DAO transparency automation failed for {entity['slug']}: {e}")
+        logger.warning(f"DAO transparency automation failed for {entity['slug']}: {e}")
+        try:
+            from app.worker import _record_cycle_error
+            _record_cycle_error(
+                error_type="collectors__automate_dao_transparency_failure",
+                error_message=str(e)[:500],
+                cycle_phase="dao_collector",
+            )
+        except Exception:
+            pass
 
     return automated
 
@@ -696,7 +759,16 @@ def _automate_dao_audit_cadence(entity: dict, static: dict) -> dict:
             if found_auditors:
                 logger.info(f"DAO audit Parallel Search {slug}: found {found_auditors}")
     except Exception as e:
-        logger.debug(f"DAO audit Parallel Search failed for {slug}: {e}")
+        logger.warning(f"DAO audit Parallel Search failed for {slug}: {e}")
+        try:
+            from app.worker import _record_cycle_error
+            _record_cycle_error(
+                error_type="collectors__automate_dao_audit_cadence_failure",
+                error_message=str(e)[:500],
+                cycle_phase="dao_collector",
+            )
+        except Exception:
+            pass
 
     # Also check known audit pages directly (supplements search results)
     for url in audit_urls:
@@ -719,7 +791,16 @@ def _automate_dao_audit_cadence(entity: dict, static: dict) -> dict:
                 found_years.add(int(y))
 
         except Exception as e:
-            logger.debug(f"DAO audit page fetch failed for {url}: {e}")
+            logger.warning(f"DAO audit page fetch failed for {url}: {e}")
+            try:
+                from app.worker import _record_cycle_error
+                _record_cycle_error(
+                    error_type="collectors__automate_dao_audit_cadence_failure",
+                    error_message=str(e)[:500],
+                    cycle_phase="dao_collector",
+                )
+            except Exception:
+                pass
             continue
 
     if not found_auditors:

--- a/app/collectors/defillama.py
+++ b/app/collectors/defillama.py
@@ -11,6 +11,8 @@ Also provides shared utility functions used by Circle 7 collectors:
 - fetch_defillama_protocol_detail(): full protocol detail
 """
 
+import asyncio
+
 import logging
 import time
 from typing import Any
@@ -68,8 +70,19 @@ async def fetch_stablecoin_data(client: httpx.AsyncClient, coingecko_id: str) ->
                 status=_status,
                 latency_ms=int((time.monotonic() - _t0) * 1000),
             )
-        except Exception:
-            pass
+        except asyncio.CancelledError:
+            raise
+        except Exception as e:
+            logger.warning(f"fetch stablecoin data failed: {e}")
+            try:
+                from app.worker import _record_cycle_error
+                _record_cycle_error(
+                    error_type="collectors_fetch_stablecoin_data_failure",
+                    error_message=str(e)[:500],
+                    cycle_phase="defillama",
+                )
+            except Exception:
+                pass
 
 
 async def fetch_lending_yields(client: httpx.AsyncClient, symbol: str) -> dict:
@@ -118,8 +131,19 @@ async def fetch_lending_yields(client: httpx.AsyncClient, symbol: str) -> dict:
                 status=_status,
                 latency_ms=int((time.monotonic() - _t0) * 1000),
             )
-        except Exception:
-            pass
+        except asyncio.CancelledError:
+            raise
+        except Exception as e:
+            logger.warning(f"fetch lending yields failed: {e}")
+            try:
+                from app.worker import _record_cycle_error
+                _record_cycle_error(
+                    error_type="collectors_fetch_lending_yields_failure",
+                    error_message=str(e)[:500],
+                    cycle_phase="defillama",
+                )
+            except Exception:
+                pass
 
 
 async def collect_defillama_components(
@@ -251,8 +275,17 @@ def fetch_defillama_hacks() -> list[dict]:
                 status=_status,
                 latency_ms=int((time.monotonic() - _t0) * 1000),
             )
-        except Exception:
-            pass
+        except Exception as e:
+            logger.warning(f"fetch defillama hacks failed: {e}")
+            try:
+                from app.worker import _record_cycle_error
+                _record_cycle_error(
+                    error_type="collectors_fetch_defillama_hacks_failure",
+                    error_message=str(e)[:500],
+                    cycle_phase="defillama",
+                )
+            except Exception:
+                pass
 
 
 def filter_hacks_by_name(hacks: list[dict], name: str) -> list[dict]:
@@ -409,8 +442,17 @@ def fetch_defillama_treasury(protocol: str) -> dict:
                 status=_status,
                 latency_ms=int((time.monotonic() - _t0) * 1000),
             )
-        except Exception:
-            pass
+        except Exception as e:
+            logger.warning(f"fetch defillama treasury failed: {e}")
+            try:
+                from app.worker import _record_cycle_error
+                _record_cycle_error(
+                    error_type="collectors_fetch_defillama_treasury_failure",
+                    error_message=str(e)[:500],
+                    cycle_phase="defillama",
+                )
+            except Exception:
+                pass
 
     return result
 
@@ -461,8 +503,17 @@ def fetch_defillama_fees(protocol: str) -> dict:
                 status=_status,
                 latency_ms=int((time.monotonic() - _t0) * 1000),
             )
-        except Exception:
-            pass
+        except Exception as e:
+            logger.warning(f"fetch defillama fees failed: {e}")
+            try:
+                from app.worker import _record_cycle_error
+                _record_cycle_error(
+                    error_type="collectors_fetch_defillama_fees_failure",
+                    error_message=str(e)[:500],
+                    cycle_phase="defillama",
+                )
+            except Exception:
+                pass
 
     return result
 
@@ -506,5 +557,14 @@ def fetch_defillama_protocol_detail(protocol: str) -> dict:
                 status=_status,
                 latency_ms=int((time.monotonic() - _t0) * 1000),
             )
-        except Exception:
-            pass
+        except Exception as e:
+            logger.warning(f"fetch defillama protocol detail failed: {e}")
+            try:
+                from app.worker import _record_cycle_error
+                _record_cycle_error(
+                    error_type="collectors_fetch_defillama_protocol_detail_failure",
+                    error_message=str(e)[:500],
+                    cycle_phase="defillama",
+                )
+            except Exception:
+                pass

--- a/app/collectors/dex_pools.py
+++ b/app/collectors/dex_pools.py
@@ -95,7 +95,16 @@ def get_protocol_pools(protocol_slug: str, network: str = "eth") -> list:
             })
         return pools
     except Exception as e:
-        logger.debug(f"get_protocol_pools failed for {protocol_slug}: {e}")
+        logger.warning(f"get_protocol_pools failed for {protocol_slug}: {e}")
+        try:
+            from app.worker import _record_cycle_error
+            _record_cycle_error(
+                error_type="collectors_get_protocol_pools_failure",
+                error_message=str(e)[:500],
+                cycle_phase="dex_pools",
+            )
+        except Exception:
+            pass
         return []
 
 
@@ -120,7 +129,16 @@ def get_pool_ohlcv(network: str, pool_address: str, timeframe: str = "day", days
         data = resp.json()
         return data.get("data", {}).get("attributes", {}).get("ohlcv_list", [])
     except Exception as e:
-        logger.debug(f"get_pool_ohlcv failed for {pool_address}: {e}")
+        logger.warning(f"get_pool_ohlcv failed for {pool_address}: {e}")
+        try:
+            from app.worker import _record_cycle_error
+            _record_cycle_error(
+                error_type="collectors_get_pool_ohlcv_failure",
+                error_message=str(e)[:500],
+                cycle_phase="dex_pools",
+            )
+        except Exception:
+            pass
         return []
 
 
@@ -150,7 +168,16 @@ def get_pool_tokens(network: str, pool_address: str) -> dict:
             "reserve_in_usd": float(attrs.get("reserve_in_usd", 0) or 0),
         }
     except Exception as e:
-        logger.debug(f"get_pool_tokens failed for {pool_address}: {e}")
+        logger.warning(f"get_pool_tokens failed for {pool_address}: {e}")
+        try:
+            from app.worker import _record_cycle_error
+            _record_cycle_error(
+                error_type="collectors_get_pool_tokens_failure",
+                error_message=str(e)[:500],
+                cycle_phase="dex_pools",
+            )
+        except Exception:
+            pass
         return {}
 
 
@@ -216,7 +243,16 @@ def compute_position_liquidity(protocol_slug: str) -> dict:
             "score": round(score, 2),
         }
     except Exception as e:
-        logger.debug(f"compute_position_liquidity failed for {protocol_slug}: {e}")
+        logger.warning(f"compute_position_liquidity failed for {protocol_slug}: {e}")
+        try:
+            from app.worker import _record_cycle_error
+            _record_cycle_error(
+                error_type="collectors_compute_position_liquidity_failure",
+                error_message=str(e)[:500],
+                cycle_phase="dex_pools",
+            )
+        except Exception:
+            pass
         return {}
 
 
@@ -264,8 +300,17 @@ def compute_collateral_diversity(protocol_slug: str) -> dict:
                 (protocol_slug,),
             )
             has_stablecoin = row and row.get("cnt", 0) > 0
-        except Exception:
-            pass
+        except Exception as e:
+            logger.warning(f"compute collateral diversity failed: {e}")
+            try:
+                from app.worker import _record_cycle_error
+                _record_cycle_error(
+                    error_type="collectors_compute_collateral_diversity_failure",
+                    error_message=str(e)[:500],
+                    cycle_phase="dex_pools",
+                )
+            except Exception:
+                pass
 
         # Normalize: more diverse + lower concentration = higher score
         diversity_score = min(100, unique_count * 15)  # 7+ tokens = 100
@@ -279,7 +324,16 @@ def compute_collateral_diversity(protocol_slug: str) -> dict:
             "score": round(score, 2),
         }
     except Exception as e:
-        logger.debug(f"compute_collateral_diversity failed for {protocol_slug}: {e}")
+        logger.warning(f"compute_collateral_diversity failed for {protocol_slug}: {e}")
+        try:
+            from app.worker import _record_cycle_error
+            _record_cycle_error(
+                error_type="collectors_compute_collateral_diversity_failure",
+                error_message=str(e)[:500],
+                cycle_phase="dex_pools",
+            )
+        except Exception:
+            pass
         return {}
 
 

--- a/app/collectors/enforcement_history.py
+++ b/app/collectors/enforcement_history.py
@@ -79,7 +79,16 @@ def _search_courtlistener(search_term: str) -> list[dict]:
                 "absolute_url": f"https://www.courtlistener.com{item.get('absolute_url', '')}",
             })
     except Exception as e:
-        logger.debug(f"CourtListener search failed for '{search_term}': {e}")
+        logger.warning(f"CourtListener search failed for '{search_term}': {e}")
+        try:
+            from app.worker import _record_cycle_error
+            _record_cycle_error(
+                error_type="collectors__search_courtlistener_failure",
+                error_message=str(e)[:500],
+                cycle_phase="enforcement_history",
+            )
+        except Exception:
+            pass
     return results
 
 
@@ -121,7 +130,16 @@ def _search_sec_edgar(search_term: str) -> list[dict]:
                 "absolute_url": f"https://efts.sec.gov/LATEST/search-index?q={search_term}",
             })
     except Exception as e:
-        logger.debug(f"SEC EDGAR search failed for '{search_term}': {e}")
+        logger.warning(f"SEC EDGAR search failed for '{search_term}': {e}")
+        try:
+            from app.worker import _record_cycle_error
+            _record_cycle_error(
+                error_type="collectors__search_sec_edgar_failure",
+                error_message=str(e)[:500],
+                cycle_phase="enforcement_history",
+            )
+        except Exception:
+            pass
     return results
 
 
@@ -237,7 +255,16 @@ def collect_enforcement_records() -> dict:
                         )
 
                     except Exception as e:
-                        logger.debug(f"Failed to store enforcement record: {e}")
+                        logger.warning(f"Failed to store enforcement record: {e}")
+                        try:
+                            from app.worker import _record_cycle_error
+                            _record_cycle_error(
+                                error_type="collectors_collect_enforcement_records_failure",
+                                error_message=str(e)[:500],
+                                cycle_phase="enforcement_history",
+                            )
+                        except Exception:
+                            pass
 
             # Attest per entity
             if new_records > 0:
@@ -248,13 +275,31 @@ def collect_enforcement_records() -> dict:
                         "new_records": new_records,
                         "scanned_at": datetime.now(timezone.utc).isoformat(),
                     }])
-                except Exception as ae:
-                    logger.debug(f"Enforcement attestation failed: {ae}")
+                except Exception as e:
+                    logger.warning(f"Enforcement attestation failed: {ae}")
+                    try:
+                        from app.worker import _record_cycle_error
+                        _record_cycle_error(
+                            error_type="collectors_collect_enforcement_records_failure",
+                            error_message=str(e)[:500],
+                            cycle_phase="enforcement_history",
+                        )
+                    except Exception:
+                        pass
 
             logger.info(f"ENFORCEMENT SCAN: {symbol} found {new_records} new records")
 
         except Exception as e:
-            logger.debug(f"Enforcement scan failed for {symbol}: {e}")
+            logger.warning(f"Enforcement scan failed for {symbol}: {e}")
+            try:
+                from app.worker import _record_cycle_error
+                _record_cycle_error(
+                    error_type="collectors_collect_enforcement_records_failure",
+                    error_message=str(e)[:500],
+                    cycle_phase="enforcement_history",
+                )
+            except Exception:
+                pass
 
     summary = {
         "entities_scanned": entities_scanned,

--- a/app/collectors/etherscan.py
+++ b/app/collectors/etherscan.py
@@ -162,8 +162,19 @@ async def fetch_token_balance(
                 status=_status,
                 latency_ms=int((_time.monotonic() - _t0) * 1000),
             )
-        except Exception:
-            pass
+        except asyncio.CancelledError:
+            raise
+        except Exception as e:
+            logger.warning(f"fetch token balance failed: {e}")
+            try:
+                from app.worker import _record_cycle_error
+                _record_cycle_error(
+                    error_type="collectors_fetch_token_balance_failure",
+                    error_message=str(e)[:500],
+                    cycle_phase="etherscan",
+                )
+            except Exception:
+                pass
 
 
 # =============================================================================
@@ -210,8 +221,19 @@ async def fetch_token_holder_count(
                 status=_status,
                 latency_ms=int((_time.monotonic() - _t0) * 1000),
             )
-        except Exception:
-            pass
+        except asyncio.CancelledError:
+            raise
+        except Exception as e:
+            logger.warning(f"fetch token holder count failed: {e}")
+            try:
+                from app.worker import _record_cycle_error
+                _record_cycle_error(
+                    error_type="collectors_fetch_token_holder_count_failure",
+                    error_message=str(e)[:500],
+                    cycle_phase="etherscan",
+                )
+            except Exception:
+                pass
 
 
 async def collect_holder_distribution(
@@ -393,8 +415,19 @@ async def _estimate_total_supply(stablecoin_id: str, holder_balances: list[dict]
         )
         if row and row.get("market_cap"):
             return float(row["market_cap"])
-    except Exception:
-        pass
+    except asyncio.CancelledError:
+        raise
+    except Exception as e:
+        logger.warning(f"estimate total supply failed: {e}")
+        try:
+            from app.worker import _record_cycle_error
+            _record_cycle_error(
+                error_type="collectors__estimate_total_supply_failure",
+                error_message=str(e)[:500],
+                cycle_phase="etherscan",
+            )
+        except Exception:
+            pass
 
     SUPPLY_ESTIMATES = {
         "usdc": 45_000_000_000,

--- a/app/collectors/exchange_health.py
+++ b/app/collectors/exchange_health.py
@@ -119,8 +119,19 @@ async def _ensure_health_table():
             CREATE INDEX IF NOT EXISTS idx_exchange_health_slug_time
             ON exchange_health_checks (exchange_slug, checked_at DESC)
         """)
+    except asyncio.CancelledError:
+        raise
     except Exception as e:
-        logger.debug(f"Table creation skipped (may already exist): {e}")
+        logger.warning(f"Table creation skipped (may already exist): {e}")
+        try:
+            from app.worker import _record_cycle_error
+            _record_cycle_error(
+                error_type="collectors__ensure_health_table_failure",
+                error_message=str(e)[:500],
+                cycle_phase="exchange_health",
+            )
+        except Exception:
+            pass
 
 
 async def store_health_checks(results: list[dict]):
@@ -294,7 +305,18 @@ async def run_exchange_health_monitoring() -> list[dict]:
                     for r in results
                 ]
             )
-    except Exception:
-        pass
+    except asyncio.CancelledError:
+        raise
+    except Exception as e:
+        logger.warning(f"run exchange health monitoring failed: {e}")
+        try:
+            from app.worker import _record_cycle_error
+            _record_cycle_error(
+                error_type="collectors_run_exchange_health_monitoring_failure",
+                error_message=str(e)[:500],
+                cycle_phase="exchange_health",
+            )
+        except Exception:
+            pass
 
     return results

--- a/app/collectors/flows.py
+++ b/app/collectors/flows.py
@@ -431,7 +431,19 @@ async def collect_flows_components(
         if components:
             _attest_records = [{"id": c.get("component_id"), "score": c.get("normalized_score")} for c in components]
             await _fl.run_in_executor(None, attest_state, "flows", _attest_records, stablecoin_id)
-    except Exception:
+    except asyncio.CancelledError:
+        raise
+    except Exception as e:
+        logger.warning(f"collect flows components failed: {e}")
+        try:
+            from app.worker import _record_cycle_error
+            _record_cycle_error(
+                error_type="collectors_collect_flows_components_failure",
+                error_message=str(e)[:500],
+                cycle_phase="flows",
+            )
+        except Exception:
+            pass
         pass  # attestation is non-critical
 
     return components

--- a/app/collectors/governance_events.py
+++ b/app/collectors/governance_events.py
@@ -248,7 +248,16 @@ def fetch_tally_events(org_slug: str, since_days: int = 90) -> list[dict]:
                     filtered.append(node)
             return filtered
     except Exception as e:
-        logger.debug(f"Tally fetch failed for {org_slug}: {e}")
+        logger.warning(f"Tally fetch failed for {org_slug}: {e}")
+        try:
+            from app.worker import _record_cycle_error
+            _record_cycle_error(
+                error_type="collectors_fetch_tally_events_failure",
+                error_message=str(e)[:500],
+                cycle_phase="governance_events",
+            )
+        except Exception:
+            pass
     return []
 
 

--- a/app/collectors/governance_proposals.py
+++ b/app/collectors/governance_proposals.py
@@ -404,8 +404,17 @@ def _upsert_proposal(proposal: dict, protocol_id: int, protocol_slug: str, resul
                 "protocol_slug": protocol_slug,
                 "body_hash": body_hash,
             }], str(protocol_id))
-        except Exception:
-            pass
+        except Exception as e:
+            logger.warning(f"upsert proposal failed: {e}")
+            try:
+                from app.worker import _record_cycle_error
+                _record_cycle_error(
+                    error_type="collectors__upsert_proposal_failure",
+                    error_message=str(e)[:500],
+                    cycle_phase="governance_proposals",
+                )
+            except Exception:
+                pass
 
         results["proposals_captured"] += 1
     else:
@@ -491,8 +500,19 @@ async def collect_governance_proposals() -> dict:
                 for proposal in proposals:
                     try:
                         await asyncio.to_thread(_upsert_proposal, proposal, protocol_id, protocol_slug, results)
+                    except asyncio.CancelledError:
+                        raise
                     except Exception as e:
-                        logger.debug(f"Failed to upsert proposal: {e}")
+                        logger.warning(f"Failed to upsert proposal: {e}")
+                        try:
+                            from app.worker import _record_cycle_error
+                            _record_cycle_error(
+                                error_type="collectors_collect_governance_proposals_failure",
+                                error_message=str(e)[:500],
+                                cycle_phase="governance_proposals",
+                            )
+                        except Exception:
+                            pass
 
             except Exception as e:
                 error_msg = f"{protocol_slug}/{source_cfg.get('type')}: {e}"

--- a/app/collectors/lst_collector.py
+++ b/app/collectors/lst_collector.py
@@ -124,7 +124,16 @@ def fetch_lst_market_data(coingecko_id: str) -> dict | None:
         if resp.status_code == 200:
             return resp.json()
     except Exception as e:
-        logger.debug(f"CoinGecko LST fetch failed for {coingecko_id}: {e}")
+        logger.warning(f"CoinGecko LST fetch failed for {coingecko_id}: {e}")
+        try:
+            from app.worker import _record_cycle_error
+            _record_cycle_error(
+                error_type="collectors_fetch_lst_market_data_failure",
+                error_message=str(e)[:500],
+                cycle_phase="lst_collector",
+            )
+        except Exception:
+            pass
     return None
 
 
@@ -140,7 +149,16 @@ def fetch_eth_price() -> float | None:
         if resp.status_code == 200:
             return resp.json().get("ethereum", {}).get("usd")
     except Exception as e:
-        logger.debug(f"ETH price fetch failed: {e}")
+        logger.warning(f"ETH price fetch failed: {e}")
+        try:
+            from app.worker import _record_cycle_error
+            _record_cycle_error(
+                error_type="collectors_fetch_eth_price_failure",
+                error_message=str(e)[:500],
+                cycle_phase="lst_collector",
+            )
+        except Exception:
+            pass
     return None
 
 
@@ -222,7 +240,16 @@ def fetch_defillama_all_pools() -> list:
         if resp.status_code == 200:
             return resp.json().get("data", [])
     except Exception as e:
-        logger.debug(f"DeFiLlama bulk pool fetch failed: {e}")
+        logger.warning(f"DeFiLlama bulk pool fetch failed: {e}")
+        try:
+            from app.worker import _record_cycle_error
+            _record_cycle_error(
+                error_type="collectors_fetch_defillama_all_pools_failure",
+                error_message=str(e)[:500],
+                cycle_phase="lst_collector",
+            )
+        except Exception:
+            pass
     return []
 
 
@@ -257,7 +284,16 @@ def fetch_defillama_pool_data(symbol: str) -> dict:
                 chains = set(p.get("chain", "") for p in matching if p.get("chain"))
                 raw["cross_chain_liquidity"] = len(chains)
     except Exception as e:
-        logger.debug(f"DeFiLlama pool data failed for {symbol}: {e}")
+        logger.warning(f"DeFiLlama pool data failed for {symbol}: {e}")
+        try:
+            from app.worker import _record_cycle_error
+            _record_cycle_error(
+                error_type="collectors_fetch_defillama_pool_data_failure",
+                error_message=str(e)[:500],
+                cycle_phase="lst_collector",
+            )
+        except Exception:
+            pass
     return raw
 
 
@@ -299,7 +335,16 @@ def fetch_rated_data(protocol_slug: str) -> dict:
                 # 1 - HHI approximation: if single operator has share s, diversity ≈ 1 - s²
                 raw["operator_diversity_hhi"] = 1.0 - (share ** 2)
     except Exception as e:
-        logger.debug(f"Rated.network fetch failed for {protocol_slug}: {e}")
+        logger.warning(f"Rated.network fetch failed for {protocol_slug}: {e}")
+        try:
+            from app.worker import _record_cycle_error
+            _record_cycle_error(
+                error_type="collectors_fetch_rated_data_failure",
+                error_message=str(e)[:500],
+                cycle_phase="lst_collector",
+            )
+        except Exception:
+            pass
     return raw
 
 

--- a/app/collectors/morpho_blue.py
+++ b/app/collectors/morpho_blue.py
@@ -214,7 +214,16 @@ def _parse_market(raw: dict[str, Any]) -> dict[str, Any] | None:
             "borrow_assets_usd": _f(state.get("borrowAssetsUsd")),
         }
     except Exception as e:
-        logger.debug(f"Morpho market parse error: {e}")
+        logger.warning(f"Morpho market parse error: {e}")
+        try:
+            from app.worker import _record_cycle_error
+            _record_cycle_error(
+                error_type="collectors__parse_market_failure",
+                error_message=str(e)[:500],
+                cycle_phase="morpho_blue",
+            )
+        except Exception:
+            pass
         return None
 
 
@@ -316,7 +325,16 @@ def _write_exposure_row(
         )
         return True
     except Exception as e:
-        logger.debug(f"Failed to write morpho exposure {token_symbol}/{chain}: {e}")
+        logger.warning(f"Failed to write morpho exposure {token_symbol}/{chain}: {e}")
+        try:
+            from app.worker import _record_cycle_error
+            _record_cycle_error(
+                error_type="collectors__write_exposure_row_failure",
+                error_message=str(e)[:500],
+                cycle_phase="morpho_blue",
+            )
+        except Exception:
+            pass
         return False
 
 

--- a/app/collectors/offline.py
+++ b/app/collectors/offline.py
@@ -108,7 +108,16 @@ def _get_attestation_freshness(stablecoin_id: str, expected_freq_days: int) -> d
                 score = normalize_inverse_linear(days_since, 0, expected_freq_days * 2)
                 return {"days_since": days_since, "score": score, "source": "scraped"}
         except Exception as e:
-            logger.debug(f"Could not parse scraped data for {stablecoin_id}: {e}")
+            logger.warning(f"Could not parse scraped data for {stablecoin_id}: {e}")
+            try:
+                from app.worker import _record_cycle_error
+                _record_cycle_error(
+                    error_type="collectors__get_attestation_freshness_failure",
+                    error_message=str(e)[:500],
+                    cycle_phase="offline",
+                )
+            except Exception:
+                pass
     
     # Fallback: use expected frequency as estimate
     return {

--- a/app/collectors/on_chain_cda.py
+++ b/app/collectors/on_chain_cda.py
@@ -152,7 +152,16 @@ def _store_on_chain_reading(reading: dict):
                 ),
             )
     except Exception as e:
-        logger.debug(f"On-chain CDA store failed for {reading.get('asset_symbol')}: {e}")
+        logger.warning(f"On-chain CDA store failed for {reading.get('asset_symbol')}: {e}")
+        try:
+            from app.worker import _record_cycle_error
+            _record_cycle_error(
+                error_type="collectors__store_on_chain_reading_failure",
+                error_message=str(e)[:500],
+                cycle_phase="on_chain_cda",
+            )
+        except Exception:
+            pass
 
 
 async def run_on_chain_cda_verification() -> dict:

--- a/app/collectors/parameter_history.py
+++ b/app/collectors/parameter_history.py
@@ -61,7 +61,16 @@ def _eth_call_sync(contract: str, data: str, chain: str = "ethereum") -> str:
             if result and result != "0x":
                 return result
         except Exception as e:
-            logger.debug(f"RPC eth_call failed for {contract}: {e}")
+            logger.warning(f"RPC eth_call failed for {contract}: {e}")
+            try:
+                from app.worker import _record_cycle_error
+                _record_cycle_error(
+                    error_type="collectors__eth_call_sync_failure",
+                    error_message=str(e)[:500],
+                    cycle_phase="parameter_history",
+                )
+            except Exception:
+                pass
 
     # Etherscan fallback (ethereum only)
     if chain == "ethereum":
@@ -84,7 +93,16 @@ def _eth_call_sync(contract: str, data: str, chain: str = "ethereum") -> str:
                 if result and result != "0x":
                     return result
             except Exception as e:
-                logger.debug(f"Etherscan eth_call fallback failed: {e}")
+                logger.warning(f"Etherscan eth_call fallback failed: {e}")
+                try:
+                    from app.worker import _record_cycle_error
+                    _record_cycle_error(
+                        error_type="collectors__eth_call_sync_failure",
+                        error_message=str(e)[:500],
+                        cycle_phase="parameter_history",
+                    )
+                except Exception:
+                    pass
 
     return "0x"
 
@@ -249,8 +267,19 @@ async def _get_concurrent_scores(protocol_slug: str, asset_symbol: str | None) -
         )
         if psi_row:
             context["concurrent_psi_score"] = float(psi_row["overall_score"])
-    except Exception:
-        pass
+    except asyncio.CancelledError:
+        raise
+    except Exception as e:
+        logger.warning(f"get concurrent scores failed: {e}")
+        try:
+            from app.worker import _record_cycle_error
+            _record_cycle_error(
+                error_type="collectors__get_concurrent_scores_failure",
+                error_message=str(e)[:500],
+                cycle_phase="parameter_history",
+            )
+        except Exception:
+            pass
 
     if not asset_symbol:
         return context
@@ -265,8 +294,19 @@ async def _get_concurrent_scores(protocol_slug: str, asset_symbol: str | None) -
         )
         if sii_row:
             context["concurrent_sii_score"] = float(sii_row["overall_score"])
-    except Exception:
-        pass
+    except asyncio.CancelledError:
+        raise
+    except Exception as e:
+        logger.warning(f"get concurrent scores failed: {e}")
+        try:
+            from app.worker import _record_cycle_error
+            _record_cycle_error(
+                error_type="collectors__get_concurrent_scores_failure",
+                error_message=str(e)[:500],
+                cycle_phase="parameter_history",
+            )
+        except Exception:
+            pass
 
     # 7-day SII trend
     try:
@@ -281,8 +321,19 @@ async def _get_concurrent_scores(protocol_slug: str, asset_symbol: str | None) -
             first = float(trend_rows[0]["overall_score"])
             last = float(trend_rows[-1]["overall_score"])
             context["sii_trend_7d"] = round(last - first, 2)
-    except Exception:
-        pass
+    except asyncio.CancelledError:
+        raise
+    except Exception as e:
+        logger.warning(f"get concurrent scores failed: {e}")
+        try:
+            from app.worker import _record_cycle_error
+            _record_cycle_error(
+                error_type="collectors__get_concurrent_scores_failure",
+                error_message=str(e)[:500],
+                cycle_phase="parameter_history",
+            )
+        except Exception:
+            pass
 
     # Hours since last SII change (>1 point move)
     try:
@@ -300,8 +351,19 @@ async def _get_concurrent_scores(protocol_slug: str, asset_symbol: str | None) -
                     move_date, datetime.min.time(), tzinfo=timezone.utc
                 )
                 context["hours_since_last_sii_change"] = round(delta.total_seconds() / 3600, 2)
-    except Exception:
-        pass
+    except asyncio.CancelledError:
+        raise
+    except Exception as e:
+        logger.warning(f"get concurrent scores failed: {e}")
+        try:
+            from app.worker import _record_cycle_error
+            _record_cycle_error(
+                error_type="collectors__get_concurrent_scores_failure",
+                error_message=str(e)[:500],
+                cycle_phase="parameter_history",
+            )
+        except Exception:
+            pass
 
     # Determine change context
     trend = context.get("sii_trend_7d")
@@ -378,8 +440,19 @@ async def _handle_parameter_change(
             "change_context": score_ctx["change_context"],
             "changed_at": now.isoformat(),
         }], str(protocol_id))
-    except Exception:
-        pass
+    except asyncio.CancelledError:
+        raise
+    except Exception as e:
+        logger.warning(f"handle parameter change failed: {e}")
+        try:
+            from app.worker import _record_cycle_error
+            _record_cycle_error(
+                error_type="collectors__handle_parameter_change_failure",
+                error_message=str(e)[:500],
+                cycle_phase="parameter_history",
+            )
+        except Exception:
+            pass
 
     logger.info(
         f"PARAMETER CHANGE: {protocol_slug} {param_spec['parameter_name']} "
@@ -443,8 +516,19 @@ async def _store_daily_snapshot(protocol_slug: str, protocol_id: int, results: d
             "snapshot_date": today.isoformat(),
             "parameter_count": len(param_dict),
         }], str(protocol_id))
-    except Exception:
-        pass
+    except asyncio.CancelledError:
+        raise
+    except Exception as e:
+        logger.warning(f"store daily snapshot failed: {e}")
+        try:
+            from app.worker import _record_cycle_error
+            _record_cycle_error(
+                error_type="collectors__store_daily_snapshot_failure",
+                error_message=str(e)[:500],
+                cycle_phase="parameter_history",
+            )
+        except Exception:
+            pass
 
     results["snapshots_stored"] += 1
 
@@ -537,8 +621,19 @@ async def check_parameter_changes() -> dict:
 
                     await asyncio.sleep(0.3)  # Rate limit RPC calls
 
+                except asyncio.CancelledError:
+                    raise
                 except Exception as e:
-                    logger.debug(f"Parameter read failed: {protocol_slug}/{spec['parameter_key']}: {e}")
+                    logger.warning(f"Parameter read failed: {protocol_slug}/{spec['parameter_key']}: {e}")
+                    try:
+                        from app.worker import _record_cycle_error
+                        _record_cycle_error(
+                            error_type="collectors_check_parameter_changes_failure",
+                            error_message=str(e)[:500],
+                            cycle_phase="parameter_history",
+                        )
+                    except Exception:
+                        pass
 
             results["protocols_checked"] += 1
 
@@ -565,8 +660,19 @@ async def collect_parameter_history() -> dict:
     for protocol_slug in PROTOCOL_PARAMETER_REGISTRY:
         try:
             await _store_daily_snapshot(protocol_slug, 0, results)
+        except asyncio.CancelledError:
+            raise
         except Exception as e:
-            logger.debug(f"Parameter snapshot failed for {protocol_slug}: {e}")
+            logger.warning(f"Parameter snapshot failed for {protocol_slug}: {e}")
+            try:
+                from app.worker import _record_cycle_error
+                _record_cycle_error(
+                    error_type="collectors_collect_parameter_history_failure",
+                    error_message=str(e)[:500],
+                    cycle_phase="parameter_history",
+                )
+            except Exception:
+                pass
 
     logger.info(
         f"Parameter history: protocols={results['protocols_checked']} "

--- a/app/collectors/parent_company_financials.py
+++ b/app/collectors/parent_company_financials.py
@@ -69,7 +69,16 @@ def _fetch_company_facts(cik: str) -> dict | None:
             return None
         return resp.json()
     except Exception as e:
-        logger.debug(f"SEC EDGAR fetch failed for CIK {cik}: {e}")
+        logger.warning(f"SEC EDGAR fetch failed for CIK {cik}: {e}")
+        try:
+            from app.worker import _record_cycle_error
+            _record_cycle_error(
+                error_type="collectors__fetch_company_facts_failure",
+                error_message=str(e)[:500],
+                cycle_phase="parent_company_financials",
+            )
+        except Exception:
+            pass
         return None
 
 
@@ -258,7 +267,16 @@ def collect_parent_financials() -> dict:
                 quarters_stored += 1
 
         except Exception as e:
-            logger.debug(f"Parent company financials failed for {company.get('company_name')}: {e}")
+            logger.warning(f"Parent company financials failed for {company.get('company_name')}: {e}")
+            try:
+                from app.worker import _record_cycle_error
+                _record_cycle_error(
+                    error_type="collectors_collect_parent_financials_failure",
+                    error_message=str(e)[:500],
+                    cycle_phase="parent_company_financials",
+                )
+            except Exception:
+                pass
 
     # Attest batch
     if quarters_stored > 0:
@@ -269,8 +287,17 @@ def collect_parent_financials() -> dict:
                 "quarters_stored": quarters_stored,
                 "date": date.today().isoformat(),
             }])
-        except Exception as ae:
-            logger.debug(f"Parent company financials attestation failed: {ae}")
+        except Exception as e:
+            logger.warning(f"Parent company financials attestation failed: {ae}")
+            try:
+                from app.worker import _record_cycle_error
+                _record_cycle_error(
+                    error_type="collectors_collect_parent_financials_failure",
+                    error_message=str(e)[:500],
+                    cycle_phase="parent_company_financials",
+                )
+            except Exception:
+                pass
 
     summary = {
         "companies_checked": companies_checked,

--- a/app/collectors/pool_wallet_collector.py
+++ b/app/collectors/pool_wallet_collector.py
@@ -93,8 +93,19 @@ async def _fetch_top_holders_multichain(
                 ]
 
             # Status != 1 — try Etherscan fallback
+        except asyncio.CancelledError:
+            raise
         except Exception as e:
-            logger.debug(f"Blockscout holder fetch failed for {contract[:10]}… on {chain}: {e}")
+            logger.warning(f"Blockscout holder fetch failed for {contract[:10]}… on {chain}: {e}")
+            try:
+                from app.worker import _record_cycle_error
+                _record_cycle_error(
+                    error_type="collectors__fetch_top_holders_multichain_failure",
+                    error_message=str(e)[:500],
+                    cycle_phase="pool_wallet_collector",
+                )
+            except Exception:
+                pass
 
     # Fallback: Etherscan V2 (uses shared Etherscan budget)
     if chain == "ethereum":
@@ -126,8 +137,19 @@ async def _fetch_top_holders_multichain(
                 if h.get("TokenHolderAddress") or h.get("address")
             ]
         return []
+    except asyncio.CancelledError:
+        raise
     except Exception as e:
-        logger.debug(f"Etherscan holder fetch fallback failed for {contract[:10]}… on {chain}: {e}")
+        logger.warning(f"Etherscan holder fetch fallback failed for {contract[:10]}… on {chain}: {e}")
+        try:
+            from app.worker import _record_cycle_error
+            _record_cycle_error(
+                error_type="collectors__fetch_top_holders_multichain_failure",
+                error_message=str(e)[:500],
+                cycle_phase="pool_wallet_collector",
+            )
+        except Exception:
+            pass
         return []
 
 
@@ -213,8 +235,19 @@ async def run_pool_wallet_collection(max_pages_per_pool: int = 30) -> dict:
                             addr_lower, contract.lower(),
                         ))
                         pool_discovered += 1
+                    except asyncio.CancelledError:
+                        raise
                     except Exception as e:
-                        logger.debug(f"  Failed to upsert pool wallet {addr_lower[:10]}…: {e}")
+                        logger.warning(f"  Failed to upsert pool wallet {addr_lower[:10]}…: {e}")
+                        try:
+                            from app.worker import _record_cycle_error
+                            _record_cycle_error(
+                                error_type="collectors_run_pool_wallet_collection_failure",
+                                error_message=str(e)[:500],
+                                cycle_phase="pool_wallet_collector",
+                            )
+                        except Exception:
+                            pass
 
                     # Seed into wallet_graph.wallets if new
                     if addr_lower not in existing_addrs:
@@ -230,8 +263,19 @@ async def run_pool_wallet_collection(max_pages_per_pool: int = 30) -> dict:
                             ))
                             existing_addrs.add(addr_lower)
                             pool_seeded += 1
+                        except asyncio.CancelledError:
+                            raise
                         except Exception as e:
-                            logger.debug(f"  Failed to seed wallet {addr_lower[:10]}…: {e}")
+                            logger.warning(f"  Failed to seed wallet {addr_lower[:10]}…: {e}")
+                            try:
+                                from app.worker import _record_cycle_error
+                                _record_cycle_error(
+                                    error_type="collectors_run_pool_wallet_collection_failure",
+                                    error_message=str(e)[:500],
+                                    cycle_phase="pool_wallet_collector",
+                                )
+                            except Exception:
+                                pass
 
             logger.info(
                 f"  {label}: {pool_discovered} holders stored, "
@@ -261,8 +305,19 @@ async def run_pool_wallet_collection(max_pages_per_pool: int = 30) -> dict:
                 "seeded": total_seeded,
                 "protocols": list(by_protocol.keys()),
             }])
+    except asyncio.CancelledError:
+        raise
     except Exception as e:
-        logger.debug(f"Pool wallet attestation skipped: {e}")
+        logger.warning(f"Pool wallet attestation skipped: {e}")
+        try:
+            from app.worker import _record_cycle_error
+            _record_cycle_error(
+                error_type="collectors_run_pool_wallet_collection_failure",
+                error_message=str(e)[:500],
+                cycle_phase="pool_wallet_collector",
+            )
+        except Exception:
+            pass
 
     return {
         "pools_processed": pools_processed,

--- a/app/collectors/psi_collector.py
+++ b/app/collectors/psi_collector.py
@@ -85,8 +85,17 @@ def get_solana_program_authority(program_id: str) -> dict | None:
                     status=_status,
                     latency_ms=int((time.monotonic() - _t0) * 1000),
                 )
-            except Exception:
-                pass
+            except Exception as e:
+                logger.warning(f"get solana program authority failed: {e}")
+                try:
+                    from app.worker import _record_cycle_error
+                    _record_cycle_error(
+                        error_type="collectors_get_solana_program_authority_failure",
+                        error_message=str(e)[:500],
+                        cycle_phase="psi_collector",
+                    )
+                except Exception:
+                    pass
         data = resp.json()
         account = data.get("result", {}).get("value")
         if not account:
@@ -124,8 +133,17 @@ def get_solana_program_authority(program_id: str) -> dict | None:
                             status=_status2,
                             latency_ms=int((time.monotonic() - _t1) * 1000),
                         )
-                    except Exception:
-                        pass
+                    except Exception as e:
+                        logger.warning(f"get solana program authority failed: {e}")
+                        try:
+                            from app.worker import _record_cycle_error
+                            _record_cycle_error(
+                                error_type="collectors_get_solana_program_authority_failure",
+                                error_message=str(e)[:500],
+                                cycle_phase="psi_collector",
+                            )
+                        except Exception:
+                            pass
                 pd_data = pd_resp.json()
                 pd_account = pd_data.get("result", {}).get("value")
                 if pd_account:
@@ -323,8 +341,17 @@ def fetch_protocol_data(slug):
                 status=_status,
                 latency_ms=int((time.monotonic() - _t0) * 1000),
             )
-        except Exception:
-            pass
+        except Exception as e:
+            logger.warning(f"fetch protocol data failed: {e}")
+            try:
+                from app.worker import _record_cycle_error
+                _record_cycle_error(
+                    error_type="collectors_fetch_protocol_data_failure",
+                    error_message=str(e)[:500],
+                    cycle_phase="psi_collector",
+                )
+            except Exception:
+                pass
 
 
 def fetch_fees_data(slug):
@@ -352,8 +379,17 @@ def fetch_fees_data(slug):
                 status=_status,
                 latency_ms=int((time.monotonic() - _t0) * 1000),
             )
-        except Exception:
-            pass
+        except Exception as e:
+            logger.warning(f"fetch fees data failed: {e}")
+            try:
+                from app.worker import _record_cycle_error
+                _record_cycle_error(
+                    error_type="collectors_fetch_fees_data_failure",
+                    error_message=str(e)[:500],
+                    cycle_phase="psi_collector",
+                )
+            except Exception:
+                pass
     return None
 
 
@@ -380,8 +416,17 @@ def fetch_treasury_data(slug):
                 status=_status,
                 latency_ms=int((time.monotonic() - _t0) * 1000),
             )
-        except Exception:
-            pass
+        except Exception as e:
+            logger.warning(f"fetch treasury data failed: {e}")
+            try:
+                from app.worker import _record_cycle_error
+                _record_cycle_error(
+                    error_type="collectors_fetch_treasury_data_failure",
+                    error_message=str(e)[:500],
+                    cycle_phase="psi_collector",
+                )
+            except Exception:
+                pass
     return None
 
 
@@ -458,8 +503,17 @@ def fetch_coingecko_token(gecko_id):
                 status=_status,
                 latency_ms=int((time.monotonic() - _t0) * 1000),
             )
-        except Exception:
-            pass
+        except Exception as e:
+            logger.warning(f"fetch coingecko token failed: {e}")
+            try:
+                from app.worker import _record_cycle_error
+                _record_cycle_error(
+                    error_type="collectors_fetch_coingecko_token_failure",
+                    error_message=str(e)[:500],
+                    cycle_phase="psi_collector",
+                )
+            except Exception:
+                pass
     return None
 
 
@@ -506,8 +560,17 @@ def fetch_snapshot_proposals(space_id):
                 status=_status,
                 latency_ms=int((time.monotonic() - _t0) * 1000),
             )
-        except Exception:
-            pass
+        except Exception as e:
+            logger.warning(f"fetch snapshot proposals failed: {e}")
+            try:
+                from app.worker import _record_cycle_error
+                _record_cycle_error(
+                    error_type="collectors_fetch_snapshot_proposals_failure",
+                    error_message=str(e)[:500],
+                    cycle_phase="psi_collector",
+                )
+            except Exception:
+                pass
     return None
 
 
@@ -735,7 +798,16 @@ def score_protocol(slug):
         from app.collectors.governance_detector import compute_governance_stability
         raw_values["governance_stability"] = compute_governance_stability(slug)
     except Exception as e:
-        logger.debug(f"governance_stability unavailable for {slug}: {e}")
+        logger.warning(f"governance_stability unavailable for {slug}: {e}")
+        try:
+            from app.worker import _record_cycle_error
+            _record_cycle_error(
+                error_type="collectors_score_protocol_failure",
+                error_message=str(e)[:500],
+                cycle_phase="psi_collector",
+            )
+        except Exception:
+            pass
 
     # Collateral coverage ratio — pre-computed by collect_coverage_and_markets()
     try:
@@ -755,14 +827,32 @@ def score_protocol(slug):
                 float(coverage_row["collateral_coverage_ratio"])
             )
     except Exception as e:
-        logger.debug(f"collateral_coverage_ratio unavailable for {slug}: {e}")
+        logger.warning(f"collateral_coverage_ratio unavailable for {slug}: {e}")
+        try:
+            from app.worker import _record_cycle_error
+            _record_cycle_error(
+                error_type="collectors_score_protocol_failure",
+                error_message=str(e)[:500],
+                cycle_phase="psi_collector",
+            )
+        except Exception:
+            pass
 
     # Market listing velocity — pre-computed from market snapshots
     try:
         from app.collectors.collateral_coverage import compute_market_listing_velocity
         raw_values["market_listing_velocity"] = compute_market_listing_velocity(slug)
     except Exception as e:
-        logger.debug(f"market_listing_velocity unavailable for {slug}: {e}")
+        logger.warning(f"market_listing_velocity unavailable for {slug}: {e}")
+        try:
+            from app.worker import _record_cycle_error
+            _record_cycle_error(
+                error_type="collectors_score_protocol_failure",
+                error_message=str(e)[:500],
+                cycle_phase="psi_collector",
+            )
+        except Exception:
+            pass
 
     result = score_entity(PSI_V01_DEFINITION, raw_values)
     result["protocol_slug"] = slug
@@ -826,7 +916,16 @@ def get_scoring_protocols():
             if row["slug"] not in protocols:
                 protocols.append(row["slug"])
     except Exception as e:
-        logger.debug(f"Could not fetch promoted protocols from backlog: {e}")
+        logger.warning(f"Could not fetch promoted protocols from backlog: {e}")
+        try:
+            from app.worker import _record_cycle_error
+            _record_cycle_error(
+                error_type="collectors_get_scoring_protocols_failure",
+                error_message=str(e)[:500],
+                cycle_phase="psi_collector",
+            )
+        except Exception:
+            pass
     return protocols
 
 
@@ -840,7 +939,16 @@ def _get_sii_score_map():
         """)
         return {row["symbol"].upper(): float(row["overall_score"]) for row in rows if row.get("overall_score")}
     except Exception as e:
-        logger.debug(f"Could not fetch SII scores: {e}")
+        logger.warning(f"Could not fetch SII scores: {e}")
+        try:
+            from app.worker import _record_cycle_error
+            _record_cycle_error(
+                error_type="collectors__get_sii_score_map_failure",
+                error_message=str(e)[:500],
+                cycle_phase="psi_collector",
+            )
+        except Exception:
+            pass
         return {}
 
 
@@ -877,7 +985,16 @@ def store_treasury_holdings(slug, token_holdings):
                 sii_score,
             ))
         except Exception as e:
-            logger.debug(f"Failed to store holding {sym} for {slug}: {e}")
+            logger.warning(f"Failed to store holding {sym} for {slug}: {e}")
+            try:
+                from app.worker import _record_cycle_error
+                _record_cycle_error(
+                    error_type="collectors_store_treasury_holdings_failure",
+                    error_message=str(e)[:500],
+                    cycle_phase="psi_collector",
+                )
+            except Exception:
+                pass
 
 
 # =========================================================================
@@ -969,8 +1086,17 @@ def fetch_protocol_pools():
                 status=_status,
                 latency_ms=int((time.monotonic() - _t0) * 1000),
             )
-        except Exception:
-            pass
+        except Exception as e:
+            logger.warning(f"fetch protocol pools failed: {e}")
+            try:
+                from app.worker import _record_cycle_error
+                _record_cycle_error(
+                    error_type="collectors_fetch_protocol_pools_failure",
+                    error_message=str(e)[:500],
+                    cycle_phase="psi_collector",
+                )
+            except Exception:
+                pass
     return []
 
 
@@ -1114,7 +1240,16 @@ def collect_collateral_exposure():
             ))
             stored += 1
         except Exception as e:
-            logger.debug(f"Failed to store collateral {row['token_symbol']} for {row['protocol_slug']}: {e}")
+            logger.warning(f"Failed to store collateral {row['token_symbol']} for {row['protocol_slug']}: {e}")
+            try:
+                from app.worker import _record_cycle_error
+                _record_cycle_error(
+                    error_type="collectors_collect_collateral_exposure_failure",
+                    error_message=str(e)[:500],
+                    cycle_phase="psi_collector",
+                )
+            except Exception:
+                pass
 
     logger.info(f"Collateral exposure: stored {stored} aggregated rows from {len(matched_pools)} pool matches")
     return list(agg.values())
@@ -1224,8 +1359,17 @@ def discover_protocols():
         """)
         for row in already_promoted:
             known_slugs.add(row["slug"])
-    except Exception:
-        pass
+    except Exception as e:
+        logger.warning(f"discover protocols failed: {e}")
+        try:
+            from app.worker import _record_cycle_error
+            _record_cycle_error(
+                error_type="collectors_discover_protocols_failure",
+                error_message=str(e)[:500],
+                cycle_phase="psi_collector",
+            )
+        except Exception:
+            pass
 
     # Aggregate stablecoin TVL per unknown project
     project_exposure = {}  # project_name -> {total_stable_tvl, unscored_tvl, unscored_symbols}
@@ -1306,7 +1450,16 @@ def discover_protocols():
             ))
             discovered += 1
         except Exception as e:
-            logger.debug(f"Failed to upsert protocol backlog for {slug}: {e}")
+            logger.warning(f"Failed to upsert protocol backlog for {slug}: {e}")
+            try:
+                from app.worker import _record_cycle_error
+                _record_cycle_error(
+                    error_type="collectors_discover_protocols_failure",
+                    error_message=str(e)[:500],
+                    cycle_phase="psi_collector",
+                )
+            except Exception:
+                pass
 
     if discovered:
         logger.info(f"Protocol discovery: {discovered} protocols with >${_DISCOVERY_TVL_THRESHOLD / 1e6:.0f}M stablecoin exposure")
@@ -1654,7 +1807,16 @@ def run_psi_scoring():
                         if event_id:
                             logger.info(f"PSI event: {slug} {severity} ({delta:+.1f} pts)")
             except Exception as e:
-                logger.debug(f"PSI event generation error for {slug}: {e}")
+                logger.warning(f"PSI event generation error for {slug}: {e}")
+                try:
+                    from app.worker import _record_cycle_error
+                    _record_cycle_error(
+                        error_type="collectors_run_psi_scoring_failure",
+                        error_message=str(e)[:500],
+                        cycle_phase="psi_collector",
+                    )
+                except Exception:
+                    pass
 
             # Mark promoted backlog protocols as scored after first successful score
             if slug not in TARGET_PROTOCOLS:
@@ -1665,8 +1827,17 @@ def run_psi_scoring():
                             updated_at = NOW()
                         WHERE slug = %s AND enrichment_status = 'promoted'
                     """, (slug,))
-                except Exception:
-                    pass
+                except Exception as e:
+                    logger.warning(f"run psi scoring failed: {e}")
+                    try:
+                        from app.worker import _record_cycle_error
+                        _record_cycle_error(
+                            error_type="collectors_run_psi_scoring_failure",
+                            error_message=str(e)[:500],
+                            cycle_phase="psi_collector",
+                        )
+                    except Exception:
+                        pass
 
     return results
 

--- a/app/collectors/rated_validators.py
+++ b/app/collectors/rated_validators.py
@@ -87,7 +87,16 @@ def _fetch_operator_effectiveness(operator_id: str) -> dict | None:
             return data.get("data", data) if "data" in data else data
         return data[0] if isinstance(data, list) and data else None
     except Exception as e:
-        logger.debug(f"Failed to fetch effectiveness for {operator_id}: {e}")
+        logger.warning(f"Failed to fetch effectiveness for {operator_id}: {e}")
+        try:
+            from app.worker import _record_cycle_error
+            _record_cycle_error(
+                error_type="collectors__fetch_operator_effectiveness_failure",
+                error_message=str(e)[:500],
+                cycle_phase="rated_validators",
+            )
+        except Exception:
+            pass
         return None
 
 
@@ -200,7 +209,16 @@ def collect_validator_performance() -> dict:
                         )
 
         except Exception as e:
-            logger.debug(f"Failed to process operator {operator.get('id')}: {e}")
+            logger.warning(f"Failed to process operator {operator.get('id')}: {e}")
+            try:
+                from app.worker import _record_cycle_error
+                _record_cycle_error(
+                    error_type="collectors_collect_validator_performance_failure",
+                    error_message=str(e)[:500],
+                    cycle_phase="rated_validators",
+                )
+            except Exception:
+                pass
 
     # Attest batch
     if snapshots_stored > 0:
@@ -210,8 +228,17 @@ def collect_validator_performance() -> dict:
                 "snapshot_date": today.isoformat(),
                 "operators_stored": snapshots_stored,
             }])
-        except Exception as ae:
-            logger.debug(f"Validator performance attestation failed: {ae}")
+        except Exception as e:
+            logger.warning(f"Validator performance attestation failed: {ae}")
+            try:
+                from app.worker import _record_cycle_error
+                _record_cycle_error(
+                    error_type="collectors_collect_validator_performance_failure",
+                    error_message=str(e)[:500],
+                    cycle_phase="rated_validators",
+                )
+            except Exception:
+                pass
 
     summary = {
         "operators_checked": operators_checked,

--- a/app/collectors/regulatory_scraper.py
+++ b/app/collectors/regulatory_scraper.py
@@ -105,7 +105,16 @@ def _check_sec_edgar(exchange_names: list[str]) -> dict:
                         for h in hits[:5]
                     ]
         except Exception as e:
-            logger.debug(f"SEC EDGAR search failed for {name}: {e}")
+            logger.warning(f"SEC EDGAR search failed for {name}: {e}")
+            try:
+                from app.worker import _record_cycle_error
+                _record_cycle_error(
+                    error_type="collectors__check_sec_edgar_failure",
+                    error_message=str(e)[:500],
+                    cycle_phase="regulatory_scraper",
+                )
+            except Exception:
+                pass
             continue
 
         # Check enforcement actions separately
@@ -121,8 +130,17 @@ def _check_sec_edgar(exchange_names: list[str]) -> dict:
                 data = resp.json()
                 enforcement_hits = data.get("hits", {}).get("total", {}).get("value", 0)
                 result["enforcement_count"] = max(result["enforcement_count"], enforcement_hits)
-        except Exception:
-            pass
+        except Exception as e:
+            logger.warning(f"check sec edgar failed: {e}")
+            try:
+                from app.worker import _record_cycle_error
+                _record_cycle_error(
+                    error_type="collectors__check_sec_edgar_failure",
+                    error_message=str(e)[:500],
+                    cycle_phase="regulatory_scraper",
+                )
+            except Exception:
+                pass
 
     return result
 
@@ -165,7 +183,16 @@ def _fetch_page_content(url: str) -> str | None:
                 if content and len(content) > 50:
                     return content.lower()
     except Exception as e:
-        logger.debug(f"Parallel Extract failed for {url}: {e}")
+        logger.warning(f"Parallel Extract failed for {url}: {e}")
+        try:
+            from app.worker import _record_cycle_error
+            _record_cycle_error(
+                error_type="collectors__fetch_page_content_failure",
+                error_message=str(e)[:500],
+                cycle_phase="regulatory_scraper",
+            )
+        except Exception:
+            pass
 
     # Fallback to requests
     try:
@@ -173,8 +200,17 @@ def _fetch_page_content(url: str) -> str | None:
         resp = requests.get(url, timeout=15, allow_redirects=True)
         if resp.status_code == 200:
             return resp.text.lower()
-    except Exception:
-        pass
+    except Exception as e:
+        logger.warning(f"fetch page content failed: {e}")
+        try:
+            from app.worker import _record_cycle_error
+            _record_cycle_error(
+                error_type="collectors__fetch_page_content_failure",
+                error_message=str(e)[:500],
+                cycle_phase="regulatory_scraper",
+            )
+        except Exception:
+            pass
 
     return None
 
@@ -242,7 +278,16 @@ def _check_corporate_disclosure(about_url: str, legal_url: str) -> dict:
                     total += 20
 
         except Exception as e:
-            logger.debug(f"Corporate disclosure fetch failed for {url}: {e}")
+            logger.warning(f"Corporate disclosure fetch failed for {url}: {e}")
+            try:
+                from app.worker import _record_cycle_error
+                _record_cycle_error(
+                    error_type="collectors__check_corporate_disclosure_failure",
+                    error_message=str(e)[:500],
+                    cycle_phase="regulatory_scraper",
+                )
+            except Exception:
+                pass
 
     result["score"] = min(100, total)
     return result
@@ -383,8 +428,19 @@ async def check_exchange_regulatory(entity_slug: str, exchange_names: list[str] 
                 CREATE UNIQUE INDEX IF NOT EXISTS idx_reg_check_entity_registry_simple
                 ON regulatory_registry_checks(entity_slug, registry_name)
             """)
-        except Exception:
-            pass
+        except asyncio.CancelledError:
+            raise
+        except Exception as e:
+            logger.warning(f"check exchange regulatory failed: {e}")
+            try:
+                from app.worker import _record_cycle_error
+                _record_cycle_error(
+                    error_type="collectors_check_exchange_regulatory_failure",
+                    error_message=str(e)[:500],
+                    cycle_phase="regulatory_scraper",
+                )
+            except Exception:
+                pass
 
         await execute_async("""
             INSERT INTO regulatory_registry_checks

--- a/app/collectors/sanctions_screening.py
+++ b/app/collectors/sanctions_screening.py
@@ -66,7 +66,16 @@ def _screen_target(target_name: str, target_type: str) -> dict | None:
             return None
         return resp.json()
     except Exception as e:
-        logger.debug(f"OpenSanctions request failed for {target_name}: {e}")
+        logger.warning(f"OpenSanctions request failed for {target_name}: {e}")
+        try:
+            from app.worker import _record_cycle_error
+            _record_cycle_error(
+                error_type="collectors__screen_target_failure",
+                error_message=str(e)[:500],
+                cycle_phase="sanctions_screening",
+            )
+        except Exception:
+            pass
         return None
 
 
@@ -171,7 +180,16 @@ def run_sanctions_screening() -> dict:
                 logger.debug(f"Sanctions clear: {target_name}")
 
         except Exception as e:
-            logger.debug(f"Sanctions screening failed for {target.get('target_name')}: {e}")
+            logger.warning(f"Sanctions screening failed for {target.get('target_name')}: {e}")
+            try:
+                from app.worker import _record_cycle_error
+                _record_cycle_error(
+                    error_type="collectors_run_sanctions_screening_failure",
+                    error_message=str(e)[:500],
+                    cycle_phase="sanctions_screening",
+                )
+            except Exception:
+                pass
 
     # Attest batch
     if targets_screened > 0:
@@ -182,8 +200,17 @@ def run_sanctions_screening() -> dict:
                 "targets_screened": targets_screened,
                 "matches_found": matches_found,
             }])
-        except Exception as ae:
-            logger.debug(f"Sanctions screening attestation failed: {ae}")
+        except Exception as e:
+            logger.warning(f"Sanctions screening attestation failed: {ae}")
+            try:
+                from app.worker import _record_cycle_error
+                _record_cycle_error(
+                    error_type="collectors_run_sanctions_screening_failure",
+                    error_message=str(e)[:500],
+                    cycle_phase="sanctions_screening",
+                )
+            except Exception:
+                pass
 
     summary = {
         "targets_screened": targets_screened,

--- a/app/collectors/smart_contract.py
+++ b/app/collectors/smart_contract.py
@@ -135,8 +135,19 @@ async def _fetch_abi(client: httpx.AsyncClient, address: str, chain: str = "ethe
         data = resp.json()
         if data.get("status") == "1" and data.get("result", "").startswith("["):
             return json.loads(data["result"])
+    except asyncio.CancelledError:
+        raise
     except Exception as e:
-        logger.debug(f"ABI fetch failed for {address}: {e}")
+        logger.warning(f"ABI fetch failed for {address}: {e}")
+        try:
+            from app.worker import _record_cycle_error
+            _record_cycle_error(
+                error_type="collectors__fetch_abi_failure",
+                error_message=str(e)[:500],
+                cycle_phase="smart_contract",
+            )
+        except Exception:
+            pass
     return []
 
 
@@ -160,8 +171,19 @@ async def read_timelock_delay(client: httpx.AsyncClient, address: str, chain: st
             delay_seconds = int(result, 16)
             delay_hours = delay_seconds / 3600
             return {"dao_timelock_hours": round(delay_hours, 2)}
+    except asyncio.CancelledError:
+        raise
     except Exception as e:
-        logger.debug(f"read_timelock_delay failed for {address}: {e}")
+        logger.warning(f"read_timelock_delay failed for {address}: {e}")
+        try:
+            from app.worker import _record_cycle_error
+            _record_cycle_error(
+                error_type="collectors_read_timelock_delay_failure",
+                error_message=str(e)[:500],
+                cycle_phase="smart_contract",
+            )
+        except Exception:
+            pass
     return None
 
 
@@ -192,8 +214,19 @@ async def read_multisig_config(client: httpx.AsyncClient, address: str, chain: s
         owner_count = int(hex_data[64:128], 16)
 
         return {"signer_count": owner_count, "threshold": threshold}
+    except asyncio.CancelledError:
+        raise
     except Exception as e:
-        logger.debug(f"read_multisig_config failed for {address}: {e}")
+        logger.warning(f"read_multisig_config failed for {address}: {e}")
+        try:
+            from app.worker import _record_cycle_error
+            _record_cycle_error(
+                error_type="collectors_read_multisig_config_failure",
+                error_message=str(e)[:500],
+                cycle_phase="smart_contract",
+            )
+        except Exception:
+            pass
     return None
 
 
@@ -222,8 +255,19 @@ async def detect_proxy_pattern(client: httpx.AsyncClient, address: str, chain: s
             "implementation": implementation,
             "has_admin": has_admin,
         }
+    except asyncio.CancelledError:
+        raise
     except Exception as e:
-        logger.debug(f"detect_proxy_pattern failed for {address}: {e}")
+        logger.warning(f"detect_proxy_pattern failed for {address}: {e}")
+        try:
+            from app.worker import _record_cycle_error
+            _record_cycle_error(
+                error_type="collectors_detect_proxy_pattern_failure",
+                error_message=str(e)[:500],
+                cycle_phase="smart_contract",
+            )
+        except Exception:
+            pass
     return None
 
 
@@ -253,8 +297,19 @@ async def read_access_control(client: httpx.AsyncClient, address: str, chain: st
             role_count = 2
 
         return {"has_access_control": has_ac, "role_count": role_count}
+    except asyncio.CancelledError:
+        raise
     except Exception as e:
-        logger.debug(f"read_access_control failed for {address}: {e}")
+        logger.warning(f"read_access_control failed for {address}: {e}")
+        try:
+            from app.worker import _record_cycle_error
+            _record_cycle_error(
+                error_type="collectors_read_access_control_failure",
+                error_message=str(e)[:500],
+                cycle_phase="smart_contract",
+            )
+        except Exception:
+            pass
     return None
 
 
@@ -282,8 +337,19 @@ async def detect_emergency_mechanism(client: httpx.AsyncClient, address: str, ch
             "has_emergency_withdraw": has_emergency,
             "has_circuit_breaker": has_circuit,
         }
+    except asyncio.CancelledError:
+        raise
     except Exception as e:
-        logger.debug(f"detect_emergency_mechanism failed for {address}: {e}")
+        logger.warning(f"detect_emergency_mechanism failed for {address}: {e}")
+        try:
+            from app.worker import _record_cycle_error
+            _record_cycle_error(
+                error_type="collectors_detect_emergency_mechanism_failure",
+                error_message=str(e)[:500],
+                cycle_phase="smart_contract",
+            )
+        except Exception:
+            pass
     return None
 
 
@@ -325,8 +391,19 @@ async def read_guardian_set(client: httpx.AsyncClient, address: str, chain: str 
                     count = int(hex_data[64:128], 16)
                     if 0 < count < 200:
                         return {"guardian_count": count}
+    except asyncio.CancelledError:
+        raise
     except Exception as e:
-        logger.debug(f"read_guardian_set failed for {address}: {e}")
+        logger.warning(f"read_guardian_set failed for {address}: {e}")
+        try:
+            from app.worker import _record_cycle_error
+            _record_cycle_error(
+                error_type="collectors_read_guardian_set_failure",
+                error_message=str(e)[:500],
+                cycle_phase="smart_contract",
+            )
+        except Exception:
+            pass
     return None
 
 
@@ -510,8 +587,19 @@ async def collect_governance_reads(client: httpx.AsyncClient) -> list[dict]:
                     })
 
             all_components.extend(entity_components)
+        except asyncio.CancelledError:
+            raise
         except Exception as e:
-            logger.debug(f"Governance reads failed for protocol {slug}: {e}")
+            logger.warning(f"Governance reads failed for protocol {slug}: {e}")
+            try:
+                from app.worker import _record_cycle_error
+                _record_cycle_error(
+                    error_type="collectors_collect_governance_reads_failure",
+                    error_message=str(e)[:500],
+                    cycle_phase="smart_contract",
+                )
+            except Exception:
+                pass
 
     # --- Bridge reads ---
     for slug, contracts in registry.get("bridges", {}).items():
@@ -557,8 +645,19 @@ async def collect_governance_reads(client: httpx.AsyncClient) -> list[dict]:
                 })
 
             all_components.extend(entity_components)
+        except asyncio.CancelledError:
+            raise
         except Exception as e:
-            logger.debug(f"Governance reads failed for bridge {slug}: {e}")
+            logger.warning(f"Governance reads failed for bridge {slug}: {e}")
+            try:
+                from app.worker import _record_cycle_error
+                _record_cycle_error(
+                    error_type="collectors_collect_governance_reads_failure",
+                    error_message=str(e)[:500],
+                    cycle_phase="smart_contract",
+                )
+            except Exception:
+                pass
 
     # Attest
     try:
@@ -569,8 +668,19 @@ async def collect_governance_reads(client: httpx.AsyncClient) -> list[dict]:
                 {"slug": c.get("entity_slug"), "id": c.get("component_id"), "score": c.get("normalized_score")}
                 for c in all_components
             ])
-    except Exception:
-        pass
+    except asyncio.CancelledError:
+        raise
+    except Exception as e:
+        logger.warning(f"collect governance reads failed: {e}")
+        try:
+            from app.worker import _record_cycle_error
+            _record_cycle_error(
+                error_type="collectors_collect_governance_reads_failure",
+                error_message=str(e)[:500],
+                cycle_phase="smart_contract",
+            )
+        except Exception:
+            pass
 
     return all_components
 
@@ -819,7 +929,19 @@ async def collect_smart_contract_components(
         if components:
             _loop = asyncio.get_event_loop()
             await _loop.run_in_executor(None, partial(attest_state, "smart_contracts", [{"id": c.get("component_id"), "score": c.get("normalized_score")} for c in components], entity_id=stablecoin_id))
-    except Exception as ae:
+    except asyncio.CancelledError:
+        raise
+    except Exception as e:
+        logger.warning(f"collect smart contract components failed: {e}")
+        try:
+            from app.worker import _record_cycle_error
+            _record_cycle_error(
+                error_type="collectors_collect_smart_contract_components_failure",
+                error_message=str(e)[:500],
+                cycle_phase="smart_contract",
+            )
+        except Exception:
+            pass
         pass  # attestation is non-critical
 
     return components
@@ -887,8 +1009,19 @@ async def _check_proxy_pattern(
                     impl_verified = await _check_contract_verified(client, impl, api_key)
                     result["implementation_verified"] = impl_verified
 
+    except asyncio.CancelledError:
+        raise
     except Exception as e:
-        logger.debug(f"Proxy check failed for {contract}: {e}")
+        logger.warning(f"Proxy check failed for {contract}: {e}")
+        try:
+            from app.worker import _record_cycle_error
+            _record_cycle_error(
+                error_type="collectors__check_proxy_pattern_failure",
+                error_message=str(e)[:500],
+                cycle_phase="smart_contract",
+            )
+        except Exception:
+            pass
 
     return result
 
@@ -940,8 +1073,19 @@ async def _detect_admin_functions(
                         result["has_timelock"] = True
 
                 result["admin_function_count"] = admin_count
+    except asyncio.CancelledError:
+        raise
     except Exception as e:
-        logger.debug(f"ABI admin detection failed for {contract}: {e}")
+        logger.warning(f"ABI admin detection failed for {contract}: {e}")
+        try:
+            from app.worker import _record_cycle_error
+            _record_cycle_error(
+                error_type="collectors__detect_admin_functions_failure",
+                error_message=str(e)[:500],
+                cycle_phase="smart_contract",
+            )
+        except Exception:
+            pass
 
     return result
 

--- a/app/collectors/solana_program_monitor.py
+++ b/app/collectors/solana_program_monitor.py
@@ -221,11 +221,29 @@ def _check_for_upgrade(slug: str, info: dict) -> bool:
                        VALUES ('protocol', 0, %s, %s, 'solana', %s, %s, NOW())""",
                     (slug, info["program_id"], prev_slot, curr_slot),
                 )
-            except Exception:
-                pass
+            except Exception as e:
+                logger.warning(f"check for upgrade failed: {e}")
+                try:
+                    from app.worker import _record_cycle_error
+                    _record_cycle_error(
+                        error_type="collectors__check_for_upgrade_failure",
+                        error_message=str(e)[:500],
+                        cycle_phase="solana_program_monitor",
+                    )
+                except Exception:
+                    pass
             return True
-    except Exception:
-        pass
+    except Exception as e:
+        logger.warning(f"check for upgrade failed: {e}")
+        try:
+            from app.worker import _record_cycle_error
+            _record_cycle_error(
+                error_type="collectors__check_for_upgrade_failure",
+                error_message=str(e)[:500],
+                cycle_phase="solana_program_monitor",
+            )
+        except Exception:
+            pass
     return False
 
 

--- a/app/collectors/treasury_flows.py
+++ b/app/collectors/treasury_flows.py
@@ -79,15 +79,37 @@ async def _get_known_labels() -> dict:
         from app.collectors.etherscan import KNOWN_HOLDERS
         for addr, label, cat in KNOWN_HOLDERS:
             labels[addr.lower()] = {"label": label, "type": cat}
-    except Exception:
-        pass
+    except asyncio.CancelledError:
+        raise
+    except Exception as e:
+        logger.warning(f"get known labels failed: {e}")
+        try:
+            from app.worker import _record_cycle_error
+            _record_cycle_error(
+                error_type="collectors__get_known_labels_failure",
+                error_message=str(e)[:500],
+                cycle_phase="treasury_flows",
+            )
+        except Exception:
+            pass
     # Overlay treasury registry
     try:
         treasuries = await get_registered_treasuries()
         for t in treasuries:
             labels[t["address"].lower()] = {"label": t["entity_name"], "type": t["entity_type"]}
-    except Exception:
-        pass
+    except asyncio.CancelledError:
+        raise
+    except Exception as e:
+        logger.warning(f"get known labels failed: {e}")
+        try:
+            from app.worker import _record_cycle_error
+            _record_cycle_error(
+                error_type="collectors__get_known_labels_failure",
+                error_message=str(e)[:500],
+                cycle_phase="treasury_flows",
+            )
+        except Exception:
+            pass
     return labels
 
 
@@ -105,8 +127,19 @@ async def _get_token_price_usd(contract_address: str, decimals: int = 18) -> flo
         """, (contract_address,))
         if row and row.get("current_price"):
             return float(row["current_price"])
-    except Exception:
-        pass
+    except asyncio.CancelledError:
+        raise
+    except Exception as e:
+        logger.warning(f"get token price usd failed: {e}")
+        try:
+            from app.worker import _record_cycle_error
+            _record_cycle_error(
+                error_type="collectors__get_token_price_usd_failure",
+                error_message=str(e)[:500],
+                cycle_phase="treasury_flows",
+            )
+        except Exception:
+            pass
     # Check if known stablecoin by contract
     try:
         row = await fetch_one_async(
@@ -115,8 +148,19 @@ async def _get_token_price_usd(contract_address: str, decimals: int = 18) -> flo
         )
         if row:
             return 1.0  # Stablecoin, assume ~$1
-    except Exception:
-        pass
+    except asyncio.CancelledError:
+        raise
+    except Exception as e:
+        logger.warning(f"get token price usd failed: {e}")
+        try:
+            from app.worker import _record_cycle_error
+            _record_cycle_error(
+                error_type="collectors__get_token_price_usd_failure",
+                error_message=str(e)[:500],
+                cycle_phase="treasury_flows",
+            )
+        except Exception:
+            pass
     return 0  # Unknown token, can't price
 
 
@@ -636,4 +680,13 @@ def _store_event(wallet_address: str, event: dict):
                 ))
             conn.commit()
     except Exception as e:
-        logger.debug(f"Treasury event store failed (table may not exist yet): {e}")
+        logger.warning(f"Treasury event store failed (table may not exist yet): {e}")
+        try:
+            from app.worker import _record_cycle_error
+            _record_cycle_error(
+                error_type="collectors__store_event_failure",
+                error_message=str(e)[:500],
+                cycle_phase="treasury_flows",
+            )
+        except Exception:
+            pass

--- a/app/collectors/tti_collector.py
+++ b/app/collectors/tti_collector.py
@@ -193,7 +193,16 @@ def fetch_tti_market_data(coingecko_id: str) -> dict | None:
         if resp.status_code == 200:
             return resp.json()
     except Exception as e:
-        logger.debug(f"CoinGecko TTI fetch failed for {coingecko_id}: {e}")
+        logger.warning(f"CoinGecko TTI fetch failed for {coingecko_id}: {e}")
+        try:
+            from app.worker import _record_cycle_error
+            _record_cycle_error(
+                error_type="collectors_fetch_tti_market_data_failure",
+                error_message=str(e)[:500],
+                cycle_phase="tti_collector",
+            )
+        except Exception:
+            pass
     return None
 
 
@@ -324,7 +333,16 @@ def _automate_tti_bug_bounty(entity: dict, static: dict) -> dict:
         else:
             automated["tti_bug_bounty"] = static.get("tti_bug_bounty", 20)
     except Exception as e:
-        logger.debug(f"TTI Immunefi fetch failed for {slug}: {e}")
+        logger.warning(f"TTI Immunefi fetch failed for {slug}: {e}")
+        try:
+            from app.worker import _record_cycle_error
+            _record_cycle_error(
+                error_type="collectors__automate_tti_bug_bounty_failure",
+                error_message=str(e)[:500],
+                cycle_phase="tti_collector",
+            )
+        except Exception:
+            pass
 
     return automated
 
@@ -442,7 +460,16 @@ def _automate_tti_oracle_dependency(entity: dict, static: dict) -> dict:
                     else:
                         automated["oracle_dependency"] = static.get("oracle_dependency", 50)
     except Exception as e:
-        logger.debug(f"TTI oracle dependency check failed for {entity['slug']}: {e}")
+        logger.warning(f"TTI oracle dependency check failed for {entity['slug']}: {e}")
+        try:
+            from app.worker import _record_cycle_error
+            _record_cycle_error(
+                error_type="collectors__automate_tti_oracle_dependency_failure",
+                error_message=str(e)[:500],
+                cycle_phase="tti_collector",
+            )
+        except Exception:
+            pass
 
     return automated
 
@@ -494,7 +521,16 @@ def extract_tti_raw_values(entity: dict, holder_data: dict = None) -> dict:
                     if isinstance(last, dict):
                         raw["tti_tvl"] = raw.get("tti_tvl") or last.get("totalLiquidityUSD", 0)
     except Exception as e:
-        logger.debug(f"DeFiLlama TTI fetch failed for {slug}: {e}")
+        logger.warning(f"DeFiLlama TTI fetch failed for {slug}: {e}")
+        try:
+            from app.worker import _record_cycle_error
+            _record_cycle_error(
+                error_type="collectors_extract_tti_raw_values_failure",
+                error_message=str(e)[:500],
+                cycle_phase="tti_collector",
+            )
+        except Exception:
+            pass
 
     # Etherscan holder data (if contract and holder_cache provided)
     if holder_data:
@@ -536,7 +572,16 @@ def extract_tti_raw_values(entity: dict, holder_data: dict = None) -> dict:
             disclosure_components = map_disclosure_to_components(disclosure_data, static)
             raw.update(disclosure_components)
     except Exception as e:
-        logger.debug(f"TTI disclosure automation failed for {slug}: {e}")
+        logger.warning(f"TTI disclosure automation failed for {slug}: {e}")
+        try:
+            from app.worker import _record_cycle_error
+            _record_cycle_error(
+                error_type="collectors_extract_tti_raw_values_failure",
+                error_message=str(e)[:500],
+                cycle_phase="tti_collector",
+            )
+        except Exception:
+            pass
 
     return raw
 

--- a/app/collectors/vault_collector.py
+++ b/app/collectors/vault_collector.py
@@ -110,7 +110,16 @@ def _fetch_page_text(url: str) -> str | None:
         text = re.sub(r'\s+', ' ', text).strip()
         return text.lower()
     except Exception as e:
-        logger.debug(f"VSRI docs fetch failed for {url}: {e}")
+        logger.warning(f"VSRI docs fetch failed for {url}: {e}")
+        try:
+            from app.worker import _record_cycle_error
+            _record_cycle_error(
+                error_type="collectors__fetch_page_text_failure",
+                error_message=str(e)[:500],
+                cycle_phase="vault_collector",
+            )
+        except Exception:
+            pass
         return None
 
 
@@ -198,8 +207,19 @@ async def score_vault_docs(entity_slug: str) -> dict:
                     evidence_snippet = EXCLUDED.evidence_snippet,
                     scored_at = NOW()
             """, (entity_slug, criterion_id, score, evidence_url, snippet))
+        except asyncio.CancelledError:
+            raise
         except Exception as e:
-            logger.debug(f"VSRI docs evidence store failed: {e}")
+            logger.warning(f"VSRI docs evidence store failed: {e}")
+            try:
+                from app.worker import _record_cycle_error
+                _record_cycle_error(
+                    error_type="collectors_score_vault_docs_failure",
+                    error_message=str(e)[:500],
+                    cycle_phase="vault_collector",
+                )
+            except Exception:
+                pass
 
     _vault_docs_cache[entity_slug] = (time.time(), results)
     if results:
@@ -387,7 +407,16 @@ def _automate_vault_contract_age(entity: dict, static: dict) -> dict:
                     static_age = static.get("vault_contract_age_days", 0)
                     automated["vault_contract_age_days"] = max(age_days, static_age)
     except Exception as e:
-        logger.debug(f"VSRI contract age failed for {entity['slug']}: {e}")
+        logger.warning(f"VSRI contract age failed for {entity['slug']}: {e}")
+        try:
+            from app.worker import _record_cycle_error
+            _record_cycle_error(
+                error_type="collectors__automate_vault_contract_age_failure",
+                error_message=str(e)[:500],
+                cycle_phase="vault_collector",
+            )
+        except Exception:
+            pass
 
     return automated
 
@@ -539,8 +568,19 @@ async def extract_vault_raw_values(entity: dict, all_pools: list[dict]) -> dict:
             )
             if psi_row:
                 raw["underlying_psi_score"] = float(psi_row["overall_score"])
+    except asyncio.CancelledError:
+        raise
     except Exception as e:
-        logger.debug(f"CQI lookup failed for {entity['slug']}: {e}")
+        logger.warning(f"CQI lookup failed for {entity['slug']}: {e}")
+        try:
+            from app.worker import _record_cycle_error
+            _record_cycle_error(
+                error_type="collectors_extract_vault_raw_values_failure",
+                error_message=str(e)[:500],
+                cycle_phase="vault_collector",
+            )
+        except Exception:
+            pass
 
     # Static config
     static = VAULT_STATIC_CONFIG.get(entity["slug"], {})
@@ -594,8 +634,19 @@ async def score_vault(entity: dict, all_pools: list[dict], hacks_cache: list = N
             for comp_id, live_score in docs_scores.items():
                 static_score = static.get(comp_id, 0)
                 raw_values[comp_id] = max(live_score, static_score)
+    except asyncio.CancelledError:
+        raise
     except Exception as e:
-        logger.debug(f"VSRI docs scoring failed for {slug}: {e}")
+        logger.warning(f"VSRI docs scoring failed for {slug}: {e}")
+        try:
+            from app.worker import _record_cycle_error
+            _record_cycle_error(
+                error_type="collectors_score_vault_failure",
+                error_message=str(e)[:500],
+                cycle_phase="vault_collector",
+            )
+        except Exception:
+            pass
 
     result = score_entity(VSRI_V01_DEFINITION, raw_values)
     result["entity_slug"] = slug

--- a/app/collectors/web_research.py
+++ b/app/collectors/web_research.py
@@ -549,7 +549,18 @@ async def run_web_research_collection() -> list[dict]:
                  "component": r["component"], "score": r["score"]}
                 for r in scored
             ])
-    except Exception:
-        pass
+    except asyncio.CancelledError:
+        raise
+    except Exception as e:
+        logger.warning(f"run web research collection failed: {e}")
+        try:
+            from app.worker import _record_cycle_error
+            _record_cycle_error(
+                error_type="collectors_run_web_research_collection_failure",
+                error_message=str(e)[:500],
+                cycle_phase="web_research",
+            )
+        except Exception:
+            pass
 
     return results


### PR DESCRIPTION
**Merge order: 7 of 7** (Wave A/B/C tonight, last PR). Merge after PR 6 lands. Highest blast radius — every SII/PSI score component depends on collectors.

## Why

Wave C Phase 2 — convert `debug_only` / bare-except patterns in `app/collectors/` to structured `cycle_errors` writes. Final and largest layer of the V9.11→V9.12 Class 2 closure.

## What

- 147 net new conversions across files in `app/collectors/` (was 148 pre-rebase; 1 superseded — see below).
- 13 blocks deferred for human review:
  - 9 in `oracle_behavior` (recent commits, manual triage)
  - 3 in `registry` (recent commits, manual triage)
  - 1 narrow except (intentional)

### Rebase note

Rebased against `main` after PR #100 landed (which added always-attest + structured error handling to bridge/cex/dao/dex_pools/lst/tti collectors). Conflicts resolved mechanically:

- `app/collectors/dex_pools.py`: PR's targeted `except Exception` was already converted on `main` to the same pattern — `error_type="dex_pool_data_attestation_failure"`, `cycle_phase="dex_pool_data"`, plus an `else: ran_no_results` empty-run attestation branch. Kept main's version. **One conversion superseded — net 147, not 148.**
- `app/collectors/exchange_health.py` (attestation block): `main` had a silent absorber (`except Exception: pass`) wrapping a `to_thread(attest_state, ...)`. Combined: kept main's `to_thread` wrapper + layered PR's `except asyncio.CancelledError: raise` + structured `cycle_errors_write`. Converted a previously-silent block.
- `app/collectors/governance_proposals.py` (proposal upsert loop): kept main's `to_thread`-wrapped `_upsert_proposal` call + layered PR's `except asyncio.CancelledError: raise` + cycle_errors_write.
- Whitespace-only conflicts in `parameter_history.py`, `vault_collector.py`, `bridge_monitors.py`, `exchange_health.py`, `governance_proposals.py` import sections — kept main's tighter form.

Post-rebase audit (`tools/audit/bare_except_audit.py app/collectors`):
- `debug_only`: 13 (matches deferred count exactly — no silent absorbers re-introduced)
- `cycle_errors_write`: 153 (147 net from this PR + 6 pre-existing on main)
- conflict markers: none, syntax clean across all 35 modified files

## Verification (after Railway redeploys Scoring-Worker, wait ~20 min for fast cycle + enrichment cycle)

```bash
PAGER=cat psql "$DATABASE_URL" -c "SELECT stablecoin_id, overall_score, daily_change, component_count, data_freshness_pct FROM scores WHERE stablecoin_id IN ('usdc','usdt','dai','frax','crvusd') ORDER BY stablecoin_id;"
PAGER=cat psql "$DATABASE_URL" -c "SELECT cycle_phase, error_type, COUNT(*) FROM cycle_errors WHERE occurred_at > NOW() - INTERVAL '30 min' GROUP BY 1,2 ORDER BY 3 DESC LIMIT 25;"
PAGER=cat psql "$DATABASE_URL" -c "SELECT domain, NOW() - MAX(cycle_timestamp) AS staleness FROM state_attestations WHERE domain IN ('sii_components','psi_components','actors','divergence_signals','provenance') GROUP BY domain ORDER BY staleness;"
```

**Pass:** scores within ±5; all 5 listed domains stay fresh; error types are familiar (rate limits, etc.) and not novel.
**Fail:** scores wildly off, `sii_components` stops writing, or novel error types repeating.

If fail: STOP. Report state.

## Final state report (after all 7 merge)

```bash
PAGER=cat psql "$DATABASE_URL" -c "SELECT cycle_phase, error_type, COUNT(*) FROM cycle_errors WHERE occurred_at > NOW() - INTERVAL '1 hour' GROUP BY 1,2 ORDER BY 3 DESC LIMIT 30;"
```

The error-count spike that follows is the V9.12 Class 2 closure receipt — previously-silent failures now visible. Triage of those error types is tomorrow's work, not tonight's.

https://claude.ai/code/session_01XuHuGXV2AyY8q7H4ECEFjk