### PR TITLE
fix(ci): add requests dep so conftest.py imports succeed in oracle-keys-parity gate

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -34,7 +34,7 @@ jobs:
       - uses: actions/setup-python@v5
         with: { python-version: "3.11" }
       - name: Install Python deps
-        run: pip install pytest "eth-hash[pycryptodome]>=0.7.0" psycopg2-binary
+        run: pip install pytest "eth-hash[pycryptodome]>=0.7.0" psycopg2-binary requests
       - name: Python entityId golden vectors
         run: pytest tests/test_oracle_keys.py -v
       - uses: actions/setup-node@v4


### PR DESCRIPTION
## Why

`tests/conftest.py:5` does `import requests`. Pytest's conftest auto-discovery imports it on collection, so the `oracle-keys-parity` job fails before `test_oracle_keys.py` (the golden-vector check) can run. Result: every recent PR shows `oracle-keys-parity: failure` even when the entityId scheme is correct.

## What

One-character-class change: append `requests` to the `Install Python deps` line in the `oracle-keys-parity` job of `.github/workflows/audit.yml`.

## Self-validation

CI on this PR runs the same `oracle-keys-parity` job — if the fix is correct, this PR's `oracle-keys-parity` check goes green. That's the whole verification.

## Followups

After merge, re-run CI on the open PRs (#101–#107) so they pick up green `oracle-keys-parity`.

https://claude.ai/code/session_01XuHuGXV2AyY8q7H4ECEFjk

---
_Generated by [Claude Code](https://claude.ai/code/session_01XuHuGXV2AyY8q7H4ECEFjk)_