### PR TITLE
fix(bri): persist + expose aggregation provenance; render confidence on dashboard

### DIFF
--- a/app/collectors/bridge_collector.py
+++ b/app/collectors/bridge_collector.py
@@ -502,13 +502,18 @@ async def store_bridge_score(result: dict) -> None:
     raw_canonical = json.dumps(raw_for_storage, sort_keys=True, default=str)
     inputs_hash = "0x" + hashlib.sha256(raw_canonical.encode()).hexdigest()
 
+    aggregation_params = (BRI_V01_DEFINITION.get("aggregation") or {}).get("params", {}) or {}
+
     await execute_async("""
         INSERT INTO generic_index_scores
             (index_id, entity_slug, entity_name, overall_score,
              category_scores, component_scores, raw_values,
              formula_version, inputs_hash, confidence, confidence_tag,
-             component_coverage, components_populated, components_total, missing_categories)
-        VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+             component_coverage, components_populated, components_total, missing_categories,
+             aggregation_method, aggregation_params, aggregation_formula_version,
+             effective_category_weights, coverage, withheld)
+        VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s,
+                %s, %s, %s, %s, %s, %s)
         ON CONFLICT (index_id, entity_slug, scored_date)
         DO UPDATE SET
             entity_name = EXCLUDED.entity_name,
@@ -523,6 +528,12 @@ async def store_bridge_score(result: dict) -> None:
             components_populated = EXCLUDED.components_populated,
             components_total = EXCLUDED.components_total,
             missing_categories = EXCLUDED.missing_categories,
+            aggregation_method = EXCLUDED.aggregation_method,
+            aggregation_params = EXCLUDED.aggregation_params,
+            aggregation_formula_version = EXCLUDED.aggregation_formula_version,
+            effective_category_weights = EXCLUDED.effective_category_weights,
+            coverage = EXCLUDED.coverage,
+            withheld = EXCLUDED.withheld,
             computed_at = NOW()
     """, (
         "bri", slug, result["entity_name"], result["overall_score"],
@@ -536,6 +547,12 @@ async def store_bridge_score(result: dict) -> None:
         result.get("components_populated"),
         result.get("components_total"),
         json.dumps(result.get("missing_categories") or []),
+        result.get("aggregation_method"),
+        json.dumps(aggregation_params),
+        result.get("aggregation_formula_version"),
+        json.dumps(result.get("effective_category_weights") or {}),
+        result.get("coverage"),
+        bool(result.get("withheld")),
     ))
 
 

--- a/app/server.py
+++ b/app/server.py
@@ -6209,7 +6209,9 @@ async def circle7_scores(index_id: str):
             entity_slug, entity_name, overall_score,
             category_scores, component_scores, confidence, confidence_tag,
             component_coverage, components_populated, components_total,
-            missing_categories, scored_date, computed_at
+            missing_categories, scored_date, computed_at,
+            aggregation_method, aggregation_params, aggregation_formula_version,
+            effective_category_weights, coverage, withheld
         FROM generic_index_scores
         WHERE index_id = %s
         ORDER BY entity_slug, computed_at DESC
@@ -6286,6 +6288,12 @@ async def circle7_scores(index_id: str):
             "components_populated": populated,
             "components_total": total,
             "scored_date": str(r["scored_date"]),
+            "aggregation_method": r.get("aggregation_method"),
+            "aggregation_params": _parse_jsonb(r.get("aggregation_params")),
+            "aggregation_formula_version": r.get("aggregation_formula_version"),
+            "effective_category_weights": _parse_jsonb(r.get("effective_category_weights")),
+            "coverage": float(r["coverage"]) if r.get("coverage") is not None else None,
+            "withheld": bool(r.get("withheld")) if r.get("withheld") is not None else False,
         })
 
     return {
@@ -6307,7 +6315,9 @@ async def circle7_score_detail(index_id: str, entity_slug: str):
                category_scores, component_scores, raw_values,
                formula_version, inputs_hash, confidence, confidence_tag,
                component_coverage, components_populated, components_total,
-               missing_categories, scored_date, computed_at
+               missing_categories, scored_date, computed_at,
+               aggregation_method, aggregation_params, aggregation_formula_version,
+               effective_category_weights, coverage, withheld
         FROM generic_index_scores
         WHERE index_id = %s AND entity_slug = %s
         ORDER BY computed_at DESC LIMIT 1
@@ -6387,6 +6397,12 @@ async def circle7_score_detail(index_id: str, entity_slug: str):
         "components_total": total,
         "scored_date": str(row["scored_date"]),
         "computed_at": str(row["computed_at"]),
+        "aggregation_method": row.get("aggregation_method"),
+        "aggregation_params": _parse_jsonb(row.get("aggregation_params")),
+        "aggregation_formula_version": row.get("aggregation_formula_version"),
+        "effective_category_weights": _parse_jsonb(row.get("effective_category_weights")),
+        "coverage": float(row["coverage"]) if row.get("coverage") is not None else None,
+        "withheld": bool(row.get("withheld")) if row.get("withheld") is not None else False,
     }
 
 

--- a/frontend/src/pages/OpsDashboard.jsx
+++ b/frontend/src/pages/OpsDashboard.jsx
@@ -1788,6 +1788,7 @@ function normalizeScores(indexId, data) {
       name: s.name || s.symbol,
       slug: s.symbol,
       score: s.score,
+      confidence: s.confidence,
       confidence_tag: s.confidence_tag,
       components_populated: s.components_populated,
       components_total: s.components_total,
@@ -1799,6 +1800,7 @@ function normalizeScores(indexId, data) {
       name: p.protocol_name,
       slug: p.protocol_slug,
       score: p.score,
+      confidence: p.confidence,
       confidence_tag: p.confidence_tag,
       components_populated: p.components_populated,
       components_total: p.components_total,
@@ -1810,6 +1812,7 @@ function normalizeScores(indexId, data) {
       name: p.protocol_name,
       slug: p.protocol_slug,
       score: p.score,
+      confidence: p.confidence,
       confidence_tag: p.confidence_tag,
       components_populated: p.components_populated,
       components_total: p.components_total,
@@ -1821,6 +1824,7 @@ function normalizeScores(indexId, data) {
     name: s.name,
     slug: s.entity,
     score: s.score,
+    confidence: s.confidence,
     confidence_tag: s.confidence_tag,
     components_populated: s.components_populated,
     components_total: s.components_total,
@@ -1906,13 +1910,13 @@ function IndexTable({ config, data, loading, error }) {
                   {gradeFromScore(s.score)}
                 </td>
                 <td style={{ padding: "4px 6px", textAlign: "center" }}>
-                  {s.confidence_tag ? (
+                  {s.confidence ? (
                     <span style={{
                       fontSize: 9, padding: "1px 5px", borderRadius: 2,
-                      background: s.confidence_tag === "high" ? "#22c55e18" : s.confidence_tag === "standard" ? "#eab30818" : "#ef444418",
-                      color: s.confidence_tag === "high" ? "#22c55e" : s.confidence_tag === "standard" ? "#eab308" : "#ef4444",
-                      border: `1px solid ${s.confidence_tag === "high" ? "#22c55e33" : s.confidence_tag === "standard" ? "#eab30833" : "#ef444433"}`,
-                    }}>{s.confidence_tag}</span>
+                      background: s.confidence === "high" ? "#22c55e18" : s.confidence === "standard" ? "#eab30818" : "#ef444418",
+                      color: s.confidence === "high" ? "#22c55e" : s.confidence === "standard" ? "#eab308" : "#ef4444",
+                      border: `1px solid ${s.confidence === "high" ? "#22c55e33" : s.confidence === "standard" ? "#eab30833" : "#ef444433"}`,
+                    }}>{s.confidence}</span>
                   ) : <span style={{ color: T.inkFaint }}>—</span>}
                 </td>
                 <td style={{ padding: "4px 6px", textAlign: "right", color: T.inkMid }}>


### PR DESCRIPTION
## Summary

Closes the two non-score-changing transparency gaps identified in the BRI engine renormalization audit (`/tmp/bri_engine_audit.md`).

**Audit headline:** BRI is engine-clean. All 9 published scores match the canonical `coverage_weighted` formula at `cw@0.7` exactly (verified against `docs/methodology/aggregation_impact_analysis.md` Section B). The PSI/LSTI/SII renormalization defect does NOT apply — BRI v0.2.0 explicitly migrated to `coverage_withheld(threshold=0.70)` on 2026-04-21. This PR does not change that. It closes the audit-trail gap so a reader can verify it from the API.

### Gap A — audit trail (`bridge_collector.py`, `server.py`)
- `store_bridge_score` now persists the six migration-084 columns: `aggregation_method`, `aggregation_params`, `aggregation_formula_version`, `effective_category_weights`, `coverage`, `withheld`. Snapshots `aggregation_params` from `BRI_V01_DEFINITION.aggregation.params`, mirroring the SII pattern at `app/worker.py:296`.
- `/api/{index_id}/scores` and `/api/{index_id}/scores/{entity_slug}` (Circle-7 handlers) now SELECT and return those fields. Pattern matches SII's `/api/scores` envelope at `app/server.py:1606-1611`.

### Gap B — confidence rendering (`OpsDashboard.jsx`)
The Confidence column read `confidence_tag` only and rendered `—` for high-coverage rows, because `compute_confidence_tag` returns `tag=None` for ≥80% coverage by design. The `confidence` field (`high` / `standard` / `limited`) was always populated but `normalizeScores` dropped it. Now forwarded and rendered, so high-confidence rows show `high` instead of `—`.

### What this PR does NOT do
- No score values change. No methodology change. No migration. No engine change.
- The remaining audit recommendation (Gap C — methodology disclosure of `incident_history` scope, re: April 18 Kelp/rsETH) is a docs change deferred to a separate PR.

## Test plan

- [ ] After next BRI scoring cycle, `GET /api/bri/scores` returns `aggregation_method: "coverage_withheld"` and `withheld: false` for all 9 entities.
- [ ] `GET /api/bri/scores/layerzero` returns `aggregation_params: {coverage_threshold: 0.70}`, `effective_category_weights` populated.
- [ ] OpsDashboard "Confidence" column renders `high` (green badge) for BRI/PSI/SII rows that previously showed `—`.
- [ ] Existing rows (predating this PR) still render correctly via the legacy fallback in `circle7_scores` — the new fields just return `None` for those rows.
- [ ] Score values unchanged: spot-check one BRI score before/after deploy.

https://claude.ai/code/session_01PYPbVt7c33vp7nWpq25RqC

---
_Generated by [Claude Code](https://claude.ai/code/session_01PYPbVt7c33vp7nWpq25RqC)_