### PR TITLE
fix(observability): auto-detect caller in track_api_call

### DIFF
--- a/app/api_usage_tracker.py
+++ b/app/api_usage_tracker.py
@@ -17,6 +17,8 @@ Usage:
 """
 
 import logging
+import os
+import sys
 import threading
 import time
 from collections import defaultdict
@@ -24,6 +26,42 @@ from datetime import datetime, timezone
 from typing import Optional
 
 logger = logging.getLogger(__name__)
+
+
+def _resolve_caller() -> str:
+    """Resolve caller name from the calling frame's __name__.
+
+    Walks two frames up (this helper -> track_api_call -> caller),
+    reads the calling module's __name__ from f_globals, and strips the
+    leading "app." prefix so callers render as "data_layer.peg_monitor"
+    instead of "app.data_layer.peg_monitor".
+
+    Falls back to the basename of the source file (without .py), and
+    finally to "unknown". The whole helper is wrapped in try/except —
+    a tracking failure can never break an API call.
+    """
+    try:
+        # sys._getframe(2) — skip _resolve_caller and track_api_call frames
+        frame = sys._getframe(2)
+        try:
+            name = frame.f_globals.get("__name__")
+            if isinstance(name, str) and name:
+                if name.startswith("app."):
+                    return name[len("app."):]
+                return name
+            # Fallback: filename basename without .py
+            filename = frame.f_globals.get("__file__")
+            if isinstance(filename, str) and filename:
+                base = os.path.basename(filename)
+                if base.endswith(".py"):
+                    base = base[:-3]
+                if base:
+                    return base
+        finally:
+            del frame  # avoid reference cycle
+    except Exception:
+        pass
+    return "unknown"
 
 # Buffer for batched writes
 _buffer: list[dict] = []
@@ -49,7 +87,7 @@ _counters_lock = threading.Lock()
 def track_api_call(
     provider: str,
     endpoint: str,
-    caller: str = "unknown",
+    caller: Optional[str] = None,
     status: Optional[int] = None,
     latency_ms: Optional[int] = None,
     count: int = 1,
@@ -60,11 +98,16 @@ def track_api_call(
     Args:
         provider: API provider name (coingecko, etherscan, defillama, etc.)
         endpoint: API endpoint path
-        caller: Module/collector that made the call
+        caller: Module/collector that made the call. If None (default), the
+            calling module is auto-detected via stack frame inspection (the
+            "app." prefix is stripped). Pass an explicit string to override.
         status: HTTP response status code
         latency_ms: Response time in milliseconds
         count: Number of calls (for batch tracking)
     """
+    if caller is None:
+        caller = _resolve_caller()
+
     now = time.time()
     now_dt = datetime.now(timezone.utc)
     current_hour = now_dt.replace(minute=0, second=0, microsecond=0)

--- a/tests/test_api_usage_tracker_caller.py
+++ b/tests/test_api_usage_tracker_caller.py
@@ -1,0 +1,99 @@
+"""
+Tests for caller auto-resolution in app.api_usage_tracker.track_api_call.
+
+These tests inspect the in-memory _buffer directly (without flushing to DB),
+so they can run without a database connection.
+"""
+
+import sys
+import pytest
+
+from app import api_usage_tracker
+from app.api_usage_tracker import _resolve_caller, track_api_call
+
+
+@pytest.fixture(autouse=True)
+def _reset_buffer():
+    """Clear the buffer (and counters) before and after every test."""
+    with api_usage_tracker._buffer_lock:
+        api_usage_tracker._buffer.clear()
+    with api_usage_tracker._counters_lock:
+        api_usage_tracker._counters.clear()
+    yield
+    with api_usage_tracker._buffer_lock:
+        api_usage_tracker._buffer.clear()
+    with api_usage_tracker._counters_lock:
+        api_usage_tracker._counters.clear()
+
+
+def _last_entry() -> dict:
+    """Pop the most recent buffered tracking entry."""
+    with api_usage_tracker._buffer_lock:
+        assert api_usage_tracker._buffer, "no entries were buffered"
+        return api_usage_tracker._buffer[-1]
+
+
+def test_explicit_caller_preserved():
+    """An explicit caller= argument must be passed through unchanged."""
+    track_api_call("test_provider", "/test", caller="explicit_caller_value")
+    entry = _last_entry()
+    assert entry["caller"] == "explicit_caller_value"
+    assert entry["provider"] == "test_provider"
+    assert entry["endpoint"] == "/test"
+
+
+def _helper_that_calls_track():
+    """Local helper that calls track_api_call without caller=.
+
+    The auto-resolved caller should reflect this test module, not "unknown".
+    """
+    track_api_call("test_provider", "/auto")
+
+
+def test_auto_caller_from_module():
+    """When caller is omitted, it should be resolved from the calling frame."""
+    _helper_that_calls_track()
+    entry = _last_entry()
+    caller = entry["caller"]
+    # The caller may be the test module name (e.g. "tests.test_api_usage_tracker_caller"
+    # or "test_api_usage_tracker_caller"), or the file basename — but never
+    # "unknown" for a normal in-process call.
+    assert caller != "unknown", f"auto caller resolved to 'unknown' (got {caller!r})"
+    assert isinstance(caller, str) and caller, "caller should be a non-empty string"
+    # We don't pin the exact module path because pytest may run this either
+    # as 'tests.test_api_usage_tracker_caller' or 'test_api_usage_tracker_caller'
+    # depending on rootdir and configuration. Just assert it mentions this file.
+    assert "test_api_usage_tracker_caller" in caller, (
+        f"expected caller to reference this test module, got {caller!r}"
+    )
+
+
+def test_auto_caller_strips_app_prefix(monkeypatch):
+    """_resolve_caller() must strip the leading 'app.' prefix."""
+
+    class _FakeFrame:
+        def __init__(self):
+            self.f_globals = {
+                "__name__": "app.data_layer.peg_monitor",
+                "__file__": "/some/path/app/data_layer/peg_monitor.py",
+            }
+
+    fake_frame = _FakeFrame()
+
+    def fake_getframe(depth):
+        # _resolve_caller calls sys._getframe(2); accept any depth here.
+        return fake_frame
+
+    monkeypatch.setattr(sys, "_getframe", fake_getframe)
+    assert _resolve_caller() == "data_layer.peg_monitor"
+
+
+def test_auto_caller_falls_back_on_failure(monkeypatch):
+    """If frame inspection raises, _resolve_caller must return 'unknown'."""
+
+    def boom(depth):
+        raise RuntimeError("simulated frame access failure")
+
+    monkeypatch.setattr(sys, "_getframe", boom)
+    # Must not propagate — must return the sentinel.
+    assert _resolve_caller() == "unknown"

--- a/tools/sql/verify_caller_resolution.sql
+++ b/tools/sql/verify_caller_resolution.sql
@@ -1,0 +1,75 @@
+-- =============================================================================
+-- verify_caller_resolution.sql
+-- =============================================================================
+-- Post-deploy verification for the track_api_call caller auto-resolution fix.
+--
+-- Background
+-- ----------
+-- Before this fix, 54 of 101 track_api_call() sites in app/ omitted the
+-- caller= kwarg, so they all collapsed into the "unknown" bucket inside
+-- api_usage_hourly.callers (JSONB) and the realtime top_callers list.
+-- That made the [api_hotspots_24h] worker diagnostic useless for finding
+-- hot collectors.
+--
+-- After deploy, _resolve_caller() walks the stack and records the calling
+-- module's __name__ (with the "app." prefix stripped). New rows should show
+-- values like "data_layer.peg_monitor", "collectors.coingecko", etc.
+--
+-- Latency notes
+-- -------------
+-- - The in-memory buffer flushes every ~5 s (background flusher) or 50 entries.
+-- - The hourly rollup is updated on every flush, so api_usage_hourly should
+--   reflect new rows within ~1 minute of deploy.
+-- - The "unknown" bucket will not vanish instantly: hourly rows already
+--   written before deploy are not rewritten. Expect the bucket share to
+--   trend toward 0 over the hour following deploy and stay near 0 going
+--   forward (modulo a small residual from third-party / external code paths
+--   where __name__ truly cannot be resolved).
+--
+-- "Fix is working" looks like:
+--   * Query 1: unknown_pct in the most recent hour is < ~5 % (vs ~50 % before).
+--   * Query 2: top callers in the last 24 h include real module paths
+--     (data_layer.*, collectors.*, services.*) — not just "unknown".
+-- =============================================================================
+
+
+-- -----------------------------------------------------------------------------
+-- Query 1: per-hour size of the "unknown" caller bucket vs total calls
+-- across the last 24 h. Expect the unknown share to fall sharply at the
+-- deploy boundary and stay near zero afterwards.
+-- -----------------------------------------------------------------------------
+SELECT
+    h.hour,
+    h.provider,
+    h.total_calls,
+    COALESCE((h.callers ->> 'unknown')::bigint, 0)               AS unknown_calls,
+    h.total_calls - COALESCE((h.callers ->> 'unknown')::bigint, 0) AS resolved_calls,
+    ROUND(
+        100.0
+        * COALESCE((h.callers ->> 'unknown')::bigint, 0)
+        / NULLIF(h.total_calls, 0),
+        2
+    ) AS unknown_pct
+FROM api_usage_hourly AS h
+WHERE h.hour >= NOW() - INTERVAL '24 hours'
+ORDER BY h.hour DESC, h.total_calls DESC;
+
+
+-- -----------------------------------------------------------------------------
+-- Query 2: top 20 distinct caller keys across the last 24 h, with totals.
+-- After deploy, the table should be dominated by resolved module paths
+-- (e.g. "data_layer.peg_monitor", "collectors.coingecko") rather than the
+-- single "unknown" row that used to swallow everything.
+-- -----------------------------------------------------------------------------
+SELECT
+    kv.key                          AS caller,
+    SUM(kv.value::bigint)           AS total_calls,
+    COUNT(DISTINCT h.provider)      AS providers_seen,
+    MIN(h.hour)                     AS first_seen,
+    MAX(h.hour)                     AS last_seen
+FROM api_usage_hourly AS h
+CROSS JOIN LATERAL jsonb_each_text(h.callers) AS kv
+WHERE h.hour >= NOW() - INTERVAL '24 hours'
+GROUP BY kv.key
+ORDER BY total_calls DESC
+LIMIT 20;


### PR DESCRIPTION
## Summary

- Fixes the `caller="unknown"` collapse in `app/api_usage_tracker.py`: of 101 `track_api_call()` sites in `app/`, 54 omit `caller=`, so they all bucketed into `"unknown"` in `api_usage_hourly.callers` (JSONB) and the realtime `top_callers` list. That made the `[api_hotspots_24h]` worker diagnostic useless for identifying hot collectors.
- Adds a `_resolve_caller()` helper that walks one frame up via `sys._getframe(2)`, reads `__name__` from `f_globals`, and strips the leading `"app."` prefix so callers render as `data_layer.peg_monitor` instead of `app.data_layer.peg_monitor`. Falls back to the basename of `__file__` (without `.py`), then to `"unknown"`. The entire helper is wrapped in `try/except` so a tracking failure can never break an API call.
- Default arg flips from `caller: str = "unknown"` to `caller: Optional[str] = None`. The 47 call sites that pass `caller=` explicitly are unchanged; the 54 that don't now resolve automatically. **No call sites were touched.**

## Files changed

- `app/api_usage_tracker.py` — adds `_resolve_caller()` and auto-resolution branch in `track_api_call`.
- `tests/test_api_usage_tracker_caller.py` — 4 new tests covering explicit pass-through, auto-resolve from module, `app.` prefix stripping, and graceful fallback when frame inspection raises.
- `tools/sql/verify_caller_resolution.sql` — post-deploy verification queries:
  1. Per-hour size of the `unknown` bucket vs total calls in the last 24h. Should trend toward zero after the deploy boundary.
  2. Top 20 distinct caller keys across the last 24h via `jsonb_each_text`. Should surface real module paths (`data_layer.*`, `collectors.*`, `services.*`).

## Test plan

- [x] `pytest tests/test_api_usage_tracker_caller.py -v` — 4/4 pass.
- [x] `pytest tests/ -q` — no new regressions. Pre-existing failures are environmental (missing `pydantic` / `eth_hash`, no live API server, no DB) and unrelated.
- [x] REPL smoke test: `track_api_call("test_provider", "/test")` with no `caller=` resolves to `"__main__"`, not `"unknown"`.
- [x] `git diff --name-only main...HEAD` — only the 3 expected files; no call-site edits.
- [ ] After deploy, run `tools/sql/verify_caller_resolution.sql` against prod and confirm the `unknown` share drops to <~5% in the most recent hour and Query 2 surfaces real module paths.

https://claude.ai/code/session_012nqLMPS48ZaiqgbmdeHpSn

---
_Generated by [Claude Code](https://claude.ai/code/session_012nqLMPS48ZaiqgbmdeHpSn)_