### PR TITLE
audit(ops): convert 24 debug_only blocks to structured cycle_errors writes

### DIFF
--- a/app/ops/entity_views.py
+++ b/app/ops/entity_views.py
@@ -410,7 +410,16 @@ def _protocol_scores(psi: dict) -> dict:
         confidence = conf.get("confidence")
         confidence_tag = conf.get("tag")
     except Exception as e:
-        logger.debug(f"PSI confidence computation failed: {e}")
+        logger.warning(f"PSI confidence computation failed: {e}")
+        try:
+            from app.worker import _record_cycle_error
+            _record_cycle_error(
+                error_type="ops_protocol_scores_psi_confidence_failure",
+                error_message=str(e)[:500],
+                cycle_phase="ops_entity_views",
+            )
+        except Exception:
+            pass
 
     return {
         "overall_score": _f(psi.get("overall_score")),

--- a/app/ops/routes.py
+++ b/app/ops/routes.py
@@ -511,8 +511,17 @@ def _compute_milestones():
             "met": False,
             "auto": True,
         })
-    except Exception:
-        pass
+    except Exception as e:
+        logger.warning(f"compute_milestones renderer placeholder failed: {e}")
+        try:
+            from app.worker import _record_cycle_error
+            _record_cycle_error(
+                error_type="ops_compute_milestones_renderer_failure",
+                error_message=str(e)[:500],
+                cycle_phase="ops_routes_compute_milestones",
+            )
+        except Exception:
+            pass
 
     # 2. API external requests/day
     try:
@@ -1230,8 +1239,19 @@ async def scan_governance(request: Request, background_tasks: BackgroundTasks, t
         body = {}
         try:
             body = await request.json()
-        except Exception:
-            pass
+        except asyncio.CancelledError:
+            raise
+        except Exception as e:
+            logger.warning(f"scan_governance request body parse failed: {e}")
+            try:
+                from app.worker import _record_cycle_error
+                _record_cycle_error(
+                    error_type="ops_scan_governance_body_parse_failure",
+                    error_message=str(e)[:500],
+                    cycle_phase="ops_routes_scan_governance",
+                )
+            except Exception:
+                pass
         days_back = body.get("days_back", 14) if body else 14
         tid = body.get("target_id", target_id) if body else target_id
 
@@ -1299,8 +1319,19 @@ async def scan_investor_content_endpoint(request: Request, background_tasks: Bac
         body = {}
         try:
             body = await request.json()
-        except Exception:
-            pass
+        except asyncio.CancelledError:
+            raise
+        except Exception as e:
+            logger.warning(f"scan_investor_content_endpoint request body parse failed: {e}")
+            try:
+                from app.worker import _record_cycle_error
+                _record_cycle_error(
+                    error_type="ops_scan_investor_content_body_parse_failure",
+                    error_message=str(e)[:500],
+                    cycle_phase="ops_routes_scan_investor_content",
+                )
+            except Exception:
+                pass
         investor_id = body.get("investor_id") if body else None
 
         async def _run_investor_scan():
@@ -1622,7 +1653,16 @@ async def state_growth(request: Request, days: int = Query(default=14, ge=1, le=
                 else:
                     logger.info("Dashboard reconciliation: pulse and pg_stat agree within 5%")
         except Exception as reconcile_err:
-            logger.debug(f"Dashboard reconciliation skipped: {reconcile_err}")
+            logger.warning(f"Dashboard reconciliation skipped: {reconcile_err}")
+            try:
+                from app.worker import _record_cycle_error
+                _record_cycle_error(
+                    error_type="ops_state_growth_reconciliation_failure",
+                    error_message=str(reconcile_err)[:500],
+                    cycle_phase="ops_routes_state_growth",
+                )
+            except Exception:
+                pass
 
         return {
             "days": day_entries,
@@ -1721,8 +1761,19 @@ async def coverage_report(request: Request):
             """) or []
             # Invert: find which v1 categories are missing for each stablecoin
             # This is approximate — just report totals
-        except Exception:
-            pass
+        except asyncio.CancelledError:
+            raise
+        except Exception as e:
+            logger.warning(f"coverage_report SII gap query failed: {e}")
+            try:
+                from app.worker import _record_cycle_error
+                _record_cycle_error(
+                    error_type="ops_coverage_report_sii_gap_query_failure",
+                    error_message=str(e)[:500],
+                    cycle_phase="ops_routes_coverage_report",
+                )
+            except Exception:
+                pass
 
         # PSI coverage
         psi_discovered = await fetch_one_async(
@@ -1874,8 +1925,19 @@ async def protocol_deep_dive(slug: str, request: Request):
                 WHERE protocol_slug = %s
                 ORDER BY usd_value DESC
             """, (slug,)) or []
-        except Exception:
-            pass
+        except asyncio.CancelledError:
+            raise
+        except Exception as e:
+            logger.warning(f"protocol_deep_dive treasury query failed for {slug}: {e}")
+            try:
+                from app.worker import _record_cycle_error
+                _record_cycle_error(
+                    error_type="ops_protocol_deep_dive_treasury_query_failure",
+                    error_message=str(e)[:500],
+                    cycle_phase="ops_routes_protocol_deep_dive",
+                )
+            except Exception:
+                pass
 
         collateral = []
         try:
@@ -1885,8 +1947,19 @@ async def protocol_deep_dive(slug: str, request: Request):
                 WHERE protocol_slug = %s
                 ORDER BY tvl_usd DESC
             """, (slug,)) or []
-        except Exception:
-            pass
+        except asyncio.CancelledError:
+            raise
+        except Exception as e:
+            logger.warning(f"protocol_deep_dive collateral query failed for {slug}: {e}")
+            try:
+                from app.worker import _record_cycle_error
+                _record_cycle_error(
+                    error_type="ops_protocol_deep_dive_collateral_query_failure",
+                    error_message=str(e)[:500],
+                    cycle_phase="ops_routes_protocol_deep_dive",
+                )
+            except Exception:
+                pass
 
         # CQI matrix row for this protocol
         cqi_row = []
@@ -1915,8 +1988,19 @@ async def protocol_deep_dive(slug: str, request: Request):
                         "cqi_confidence": cqi_c["confidence"],
                     })
             cqi_row.sort(key=lambda x: x.get("cqi_score", 0), reverse=True)
+        except asyncio.CancelledError:
+            raise
         except Exception as e:
-            logger.debug(f"CQI matrix row failed for {slug}: {e}")
+            logger.warning(f"CQI matrix row failed for {slug}: {e}")
+            try:
+                from app.worker import _record_cycle_error
+                _record_cycle_error(
+                    error_type="ops_protocol_deep_dive_cqi_matrix_failure",
+                    error_message=str(e)[:500],
+                    cycle_phase="ops_routes_protocol_deep_dive",
+                )
+            except Exception:
+                pass
 
         # Discovery signals
         discovery_signals = []
@@ -1927,8 +2011,19 @@ async def protocol_deep_dive(slug: str, request: Request):
                 WHERE entity_type = 'protocol' AND entity_id = %s
                 ORDER BY discovered_at DESC LIMIT 10
             """, (slug,)) or []
-        except Exception:
-            pass
+        except asyncio.CancelledError:
+            raise
+        except Exception as e:
+            logger.warning(f"protocol_deep_dive discovery_signals query failed for {slug}: {e}")
+            try:
+                from app.worker import _record_cycle_error
+                _record_cycle_error(
+                    error_type="ops_protocol_deep_dive_discovery_signals_failure",
+                    error_message=str(e)[:500],
+                    cycle_phase="ops_routes_protocol_deep_dive",
+                )
+            except Exception:
+                pass
 
         # score_to_grade removed — numerical scores only
 
@@ -2535,8 +2630,19 @@ async def abm_generate_guide(campaign_id: int, request: Request):
                     rj = json.dumps(data, sort_keys=True, default=str)
                     rh = hashlib.sha256(rj.encode()).hexdigest()[:16]
                     report_hashes.append({"coin": coin, "hash": rh})
-            except Exception:
-                pass
+            except asyncio.CancelledError:
+                raise
+            except Exception as e:
+                logger.warning(f"abm_generate_guide report hash failed for {coin}: {e}")
+                try:
+                    from app.worker import _record_cycle_error
+                    _record_cycle_error(
+                        error_type="ops_abm_generate_guide_report_hash_failure",
+                        error_message=str(e)[:500],
+                        cycle_phase="ops_routes_abm_generate_guide",
+                    )
+                except Exception:
+                    pass
 
         # Build the guide markdown
         lines = []
@@ -2993,8 +3099,19 @@ async def playground_compute(request: Request):
         )
         if recent and recent["cnt"] >= 10:
             return JSONResponse({"error": "Rate limit exceeded (10 submissions per hour)"}, status_code=429)
-    except Exception:
-        pass
+    except asyncio.CancelledError:
+        raise
+    except Exception as e:
+        logger.warning(f"playground_compute rate-limit query failed: {e}")
+        try:
+            from app.worker import _record_cycle_error
+            _record_cycle_error(
+                error_type="ops_playground_compute_rate_limit_failure",
+                error_message=str(e)[:500],
+                cycle_phase="ops_routes_playground_compute",
+            )
+        except Exception:
+            pass
 
     cqi = await asyncio.to_thread(compute_aggregate_cqi, portfolio)
     stress = await asyncio.to_thread(compute_stress_scenarios, portfolio)

--- a/app/ops/tools/alerter.py
+++ b/app/ops/tools/alerter.py
@@ -44,6 +44,7 @@ async def _get_daily_count() -> int:
 
 
 async def _increment_daily_count():
+    import asyncio
     try:
         await execute_async("""
             INSERT INTO alert_rate_limit (day, count, last_sent_at)
@@ -52,8 +53,19 @@ async def _increment_daily_count():
                 count = alert_rate_limit.count + 1,
                 last_sent_at = NOW()
         """)
-    except Exception:
-        pass
+    except asyncio.CancelledError:
+        raise
+    except Exception as e:
+        logger.warning(f"alerter: _increment_daily_count failed: {e}")
+        try:
+            from app.worker import _record_cycle_error
+            _record_cycle_error(
+                error_type="ops_alerter_increment_daily_count_failure",
+                error_message=str(e)[:500],
+                cycle_phase="ops_alerter",
+            )
+        except Exception:
+            pass
 
 
 async def _claim_daily_slot(cap: int) -> bool:
@@ -128,13 +140,25 @@ async def send_alert(alert_type: str, message: str, context: dict = None, severi
             logger.error(f"Alert send failed ({ch['channel']}): {e}")
 
     # Always log the alert
+    import asyncio
     try:
         await execute_async(
             "INSERT INTO ops_alert_log (alert_type, channel, message, context) VALUES (%s, %s, %s, %s)",
             (alert_type, "telegram" if sent_any else "log_only", message, json.dumps(context or {}, default=str)),
         )
-    except Exception:
-        pass
+    except asyncio.CancelledError:
+        raise
+    except Exception as e:
+        logger.warning(f"alerter: send_alert log insert failed: {e}")
+        try:
+            from app.worker import _record_cycle_error
+            _record_cycle_error(
+                error_type="ops_alerter_send_alert_log_insert_failure",
+                error_message=str(e)[:500],
+                cycle_phase="ops_alerter",
+            )
+        except Exception:
+            pass
 
     return sent_any
 

--- a/app/ops/tools/health_checker.py
+++ b/app/ops/tools/health_checker.py
@@ -583,8 +583,19 @@ async def run_all_checks():
     # Prune records older than 7 days
     try:
         await execute_async("DELETE FROM ops_health_checks WHERE checked_at < NOW() - INTERVAL '7 days'")
-    except Exception:
-        pass
+    except asyncio.CancelledError:
+        raise
+    except Exception as e:
+        logger.warning(f"health_checker: prune old records failed: {e}")
+        try:
+            from app.worker import _record_cycle_error
+            _record_cycle_error(
+                error_type="ops_health_checker_prune_failure",
+                error_message=str(e)[:500],
+                cycle_phase="ops_health_checker",
+            )
+        except Exception:
+            pass
 
     return results
 

--- a/app/ops/tools/milestone_checker.py
+++ b/app/ops/tools/milestone_checker.py
@@ -35,7 +35,17 @@ def _check_seed_triggers() -> dict:
             "SELECT COUNT(DISTINCT description) as cnt FROM api_keys WHERE description ILIKE '%renderer%'"
         )
         renderer_count = row["cnt"] if row else 0
-    except Exception:
+    except Exception as e:
+        logger.warning(f"milestone_checker: renderer count query failed: {e}")
+        try:
+            from app.worker import _record_cycle_error
+            _record_cycle_error(
+                error_type="ops_milestone_seed_renderer_count_failure",
+                error_message=str(e)[:500],
+                cycle_phase="ops_milestone_checker",
+            )
+        except Exception:
+            pass
         renderer_count = None
     milestones.append({
         "name": "8+ renderers live",
@@ -55,8 +65,17 @@ def _check_seed_triggers() -> dict:
                AND api_key_id IS NOT NULL"""
         )
         api_daily = row["cnt"] if row else 0
-    except Exception:
-        pass
+    except Exception as e:
+        logger.warning(f"milestone_checker: api_daily query failed: {e}")
+        try:
+            from app.worker import _record_cycle_error
+            _record_cycle_error(
+                error_type="ops_milestone_seed_api_daily_failure",
+                error_message=str(e)[:500],
+                cycle_phase="ops_milestone_checker",
+            )
+        except Exception:
+            pass
     milestones.append({
         "name": "API >500 external requests/day",
         "target": 500,
@@ -75,8 +94,17 @@ def _check_seed_triggers() -> dict:
                AND response IS NOT NULL AND response != ''"""
         )
         citations = row["cnt"] if row else 0
-    except Exception:
-        pass
+    except Exception as e:
+        logger.warning(f"milestone_checker: citations query failed: {e}")
+        try:
+            from app.worker import _record_cycle_error
+            _record_cycle_error(
+                error_type="ops_milestone_seed_citations_failure",
+                error_message=str(e)[:500],
+                cycle_phase="ops_milestone_checker",
+            )
+        except Exception:
+            pass
     milestones.append({
         "name": "Protocol teams citing scores",
         "target": 1,
@@ -105,8 +133,17 @@ def _check_seed_triggers() -> dict:
                AND pipeline_stage IN ('evaluating', 'trying', 'binding')"""
         )
         pilots = row["cnt"] if row else 0
-    except Exception:
-        pass
+    except Exception as e:
+        logger.warning(f"milestone_checker: pilots query failed: {e}")
+        try:
+            from app.worker import _record_cycle_error
+            _record_cycle_error(
+                error_type="ops_milestone_seed_pilots_failure",
+                error_message=str(e)[:500],
+                cycle_phase="ops_milestone_checker",
+            )
+        except Exception:
+            pass
     milestones.append({
         "name": "DAO pilot in conversation",
         "target": 1,
@@ -142,8 +179,17 @@ def _check_kill_signals() -> dict:
                AND api_key_id IS NOT NULL"""
         )
         api_daily = row["cnt"] if row else 0
-    except Exception:
-        pass
+    except Exception as e:
+        logger.warning(f"milestone_checker: kill_signal api_daily query failed: {e}")
+        try:
+            from app.worker import _record_cycle_error
+            _record_cycle_error(
+                error_type="ops_milestone_kill_api_daily_failure",
+                error_message=str(e)[:500],
+                cycle_phase="ops_milestone_checker",
+            )
+        except Exception:
+            pass
 
     protocol_refs = 0
     try:
@@ -152,8 +198,17 @@ def _check_kill_signals() -> dict:
                WHERE response IS NOT NULL AND response != ''"""
         )
         protocol_refs = row["cnt"] if row else 0
-    except Exception:
-        pass
+    except Exception as e:
+        logger.warning(f"milestone_checker: kill_signal protocol_refs query failed: {e}")
+        try:
+            from app.worker import _record_cycle_error
+            _record_cycle_error(
+                error_type="ops_milestone_kill_protocol_refs_failure",
+                error_message=str(e)[:500],
+                cycle_phase="ops_milestone_checker",
+            )
+        except Exception:
+            pass
 
     signals.append({
         "name": "M6: <100 API calls/day + no protocol references",
@@ -178,8 +233,17 @@ def _check_kill_signals() -> dict:
                AND api_key_id IS NOT NULL"""
         )
         cda_consumers = row["cnt"] if row else 0
-    except Exception:
-        pass
+    except Exception as e:
+        logger.warning(f"milestone_checker: cda_consumers query failed: {e}")
+        try:
+            from app.worker import _record_cycle_error
+            _record_cycle_error(
+                error_type="ops_milestone_kill_cda_consumers_failure",
+                error_message=str(e)[:500],
+                cycle_phase="ops_milestone_checker",
+            )
+        except Exception:
+            pass
 
     signals.append({
         "name": "M9: CDA zero external consumers + no AI citations",
@@ -231,8 +295,17 @@ def _check_adoption_metrics() -> dict:
                AND api_key_id IS NOT NULL"""
         )
         api_daily = row["cnt"] if row else 0
-    except Exception:
-        pass
+    except Exception as e:
+        logger.warning(f"milestone_checker: adoption api_daily query failed: {e}")
+        try:
+            from app.worker import _record_cycle_error
+            _record_cycle_error(
+                error_type="ops_milestone_adoption_api_daily_failure",
+                error_message=str(e)[:500],
+                cycle_phase="ops_milestone_checker",
+            )
+        except Exception:
+            pass
     metrics.append({
         "name": "External API lookups/day",
         "current": api_daily,
@@ -255,8 +328,17 @@ def _check_adoption_metrics() -> dict:
                AND api_key_id IS NOT NULL"""
         )
         repeat_consumers = row["cnt"] if row else 0
-    except Exception:
-        pass
+    except Exception as e:
+        logger.warning(f"milestone_checker: repeat_consumers query failed: {e}")
+        try:
+            from app.worker import _record_cycle_error
+            _record_cycle_error(
+                error_type="ops_milestone_adoption_repeat_consumers_failure",
+                error_message=str(e)[:500],
+                cycle_phase="ops_milestone_checker",
+            )
+        except Exception:
+            pass
     metrics.append({
         "name": "Repeat consumers (>30 days)",
         "current": repeat_consumers,
@@ -301,8 +383,17 @@ def _check_adoption_metrics() -> dict:
                AND channel IN ('aave_forum', 'morpho_forum', 'cow_forum', 'ens_forum')"""
         )
         pulse_citations = row["cnt"] if row else 0
-    except Exception:
-        pass
+    except Exception as e:
+        logger.warning(f"milestone_checker: pulse_citations query failed: {e}")
+        try:
+            from app.worker import _record_cycle_error
+            _record_cycle_error(
+                error_type="ops_milestone_adoption_pulse_citations_failure",
+                error_message=str(e)[:500],
+                cycle_phase="ops_milestone_checker",
+            )
+        except Exception:
+            pass
     metrics.append({
         "name": "Pulse cited in governance",
         "current": pulse_citations,


### PR DESCRIPTION
## Summary

Converts V9.12 Class 2 silent-except-on-debug blocks in `app/ops/` (Wave C continuation) to structured error handling. Each except block now upgrades `debug` -> `warning`, writes a `cycle_errors` row, and re-raises `asyncio.CancelledError` on async paths (Rule 7).

## Files touched

- `app/ops/entity_views.py` (1)
- `app/ops/routes.py` (11)
- `app/ops/tools/alerter.py` (2)
- `app/ops/tools/health_checker.py` (1)
- `app/ops/tools/milestone_checker.py` (9)

**Total: 24 blocks converted**

## Deferred (2)

These are NOT broad `except Exception:` handlers — they are narrow specific-type handlers used for legitimate fallback control flow. Per the conservative-conversion rule, leaving them alone:

- `app/ops/tools/drafter.py:53` — `except FileNotFoundError: pass` (intentional skip when worldview dir does not exist)
- `app/ops/tools/oracle_monitor.py:259` — `except (ValueError, OSError): pass` (intentional skip on malformed Etherscan timestamp)

## Conventions followed

- Rule 6: No `BaseException` catches added or modified.
- Rule 7: Every `await` / `asyncio.to_thread` site gets `except asyncio.CancelledError: raise` BEFORE the broad `Exception` handler.
- `cycle_phase` strings tied to function context (`ops_routes_<func>`, `ops_milestone_checker`, etc.).
- `logger.warning` (not `error`) — these remain recoverable failures.
- Existing log message content preserved.

## Test plan

- [ ] Audit confirms 0 remaining broad `debug_only` blocks in `app/ops/` (the 2 deferred narrow-type handlers will still appear, which is expected).
- [ ] Syntax check passes for all touched files.

https://claude.ai/code/session_01XuHuGXV2AyY8q7H4ECEFjk

---
_Generated by [Claude Code](https://claude.ai/code/session_01XuHuGXV2AyY8q7H4ECEFjk)_