### PR TITLE
fix(mempool): replace SystemExit(1) with graceful return on rate limit

### DIFF
--- a/app/data_layer/mempool_watcher.py
+++ b/app/data_layer/mempool_watcher.py
@@ -577,9 +577,18 @@ async def run_watcher(chain: str = "ethereum") -> None:
             if consecutive_failures >= 20:
                 logger.critical(
                     f"[mempool_watcher] {consecutive_failures} consecutive failures — "
-                    f"exiting to trigger restart. Last: {type(e).__name__}: {e}"
+                    f"disabling watcher (non-critical telemetry). Last: {type(e).__name__}: {e}"
                 )
-                raise SystemExit(1)
+                try:
+                    from app.worker import _record_cycle_error
+                    _record_cycle_error(
+                        error_type="mempool_watcher_disabled",
+                        error_message=f"{consecutive_failures} consecutive failures. Last: {type(e).__name__}: {e}"[:500],
+                        cycle_phase="mempool_watcher",
+                    )
+                except Exception:
+                    pass
+                return
             elif consecutive_failures >= 5:
                 logger.error(
                     f"[mempool_watcher] failure #{consecutive_failures} after {elapsed}s: "


### PR DESCRIPTION
## Problem

Mempool watcher called `raise SystemExit(1)` after 20 consecutive WebSocket failures. This killed the **entire worker process** — scoring, enrichment, everything — because one telemetry WebSocket got rate-limited by Alchemy (HTTP 429).

Production crash at 2026-05-09 21:29:11:
```
websockets.exceptions.InvalidStatus: server rejected WebSocket connection: HTTP 429
...
raise SystemExit(1)
```

## Fix

Replace `raise SystemExit(1)` with `return` (graceful task exit). The mempool watcher is non-critical telemetry — it must never take down the scoring worker.

Also writes to `cycle_errors` with `error_type="mempool_watcher_disabled"` so the failure is visible to the alerter and ops dashboard.

The cancellation watchdog (PR #72) independently handles process-level issues if the event loop actually wedges.

https://claude.ai/code/session_011bTVc5haorCZgtCtxzJmtq

---
_Generated by [Claude Code](https://claude.ai/code/session_011bTVc5haorCZgtCtxzJmtq)_