### PR TITLE
fix(ops-dashboard): add RPI to scored entities breakdown panel

### DIFF
--- a/frontend/src/pages/OpsDashboard.jsx
+++ b/frontend/src/pages/OpsDashboard.jsx
@@ -1070,6 +1070,10 @@ function StateGrowthPanel() {
                   <Lbl>PSI</Lbl>
                   <div style={{ fontSize: 12, fontFamily: T.mono, color: T.inkMid }}>{ec.psi?.scored || 0}</div>
                 </div>
+                <div>
+                  <Lbl>RPI</Lbl>
+                  <div style={{ fontSize: 12, fontFamily: T.mono, color: T.inkMid }}>{ec.rpi?.scored || 0}</div>
+                </div>
                 {ec.circle7 && Object.entries(ec.circle7).map(([idx, cnt]) => (
                   <div key={idx}>
                     <Lbl>{idx.toUpperCase()}</Lbl>


### PR DESCRIPTION
The scored entities panel showed 123 total but the breakdown only listed 8 indices — RPI's 13 protocols were counted in the total but missing from the display.\n\nAdded RPI row between PSI and Circle-7 indices in `frontend/src/pages/OpsDashboard.jsx`. 4 lines, display-only.\n\nhttps://claude.ai/code/session_011bTVc5haorCZgtCtxzJmtq

---
_Generated by [Claude Code](https://claude.ai/code/session_011bTVc5haorCZgtCtxzJmtq)_