### PR TITLE
fix(surveillance): add ethena and pendle to contract registry

### DIFF
--- a/app/config/contract_registry.json
+++ b/app/config/contract_registry.json
@@ -60,6 +60,18 @@
       "multisig": {"address": "0xa3C5A1e09150B75ff251c1a7815A07182c3de2FB", "chain": "ethereum", "type": "gnosis_safe"},
       "core_contract": {"address": "0xF403C135812408BFbE8713b5A23a04b3D48AAE31", "chain": "ethereum"}
     },
+    "ethena": {
+      "governance_timelock": null,
+      "multisig": {"address": "0x3e4C1137b8D2e0E5E2E1A84ced641B2F5F83e971", "chain": "ethereum", "type": "gnosis_safe"},
+      "core_contract": {"address": "0x4c9EDD5852cd905f086C759E8383e09bff1E68B3", "chain": "ethereum"},
+      "staking_contract": {"address": "0x9D39A5DE30e57443BfF2A8307A4256c8797A3497", "chain": "ethereum"}
+    },
+    "pendle": {
+      "governance_timelock": {"address": "0x8270400d528C34E1596EF367eeDEc99080A1B592", "chain": "ethereum"},
+      "multisig": null,
+      "core_contract": {"address": "0x888888888889758F76e7103c6CbF23ABbF58F946", "chain": "ethereum"},
+      "market_factory": {"address": "0x27b1dAcd74688aF24a64BD3C9C1B143118740784", "chain": "ethereum"}
+    },
     "drift": {
       "governance_timelock": null,
       "multisig": null,

--- a/app/data_layer/contract_surveillance.py
+++ b/app/data_layer/contract_surveillance.py
@@ -269,19 +269,14 @@ async def run_contract_surveillance() -> dict:
             with open(registry_path) as f:
                 registry = _json.load(f)
             for slug, contracts in registry.get("protocols", {}).items():
-                core = contracts.get("core_contract")
-                if core and core.get("address"):
+                for key, entry in contracts.items():
+                    if not isinstance(entry, dict) or not entry.get("address"):
+                        continue
+                    suffix = f"_{key}" if key != "core_contract" else ""
                     contracts_to_scan.append({
-                        "entity_id": slug,
-                        "chain": core.get("chain", "ethereum"),
-                        "contract_address": core["address"],
-                    })
-                timelock = contracts.get("governance_timelock")
-                if timelock and timelock.get("address"):
-                    contracts_to_scan.append({
-                        "entity_id": f"{slug}_timelock",
-                        "chain": timelock.get("chain", "ethereum"),
-                        "contract_address": timelock["address"],
+                        "entity_id": f"{slug}{suffix}",
+                        "chain": entry.get("chain", "ethereum"),
+                        "contract_address": entry["address"],
                     })
     except asyncio.CancelledError:
         raise


### PR DESCRIPTION
Dashboard showed "Unmonitored: ethena, pendle" on Security Scanning panel. Both are scored entities (Ethena = USDe in SII, Pendle in PSI).\n\n**Contracts added:**\n- Ethena: USDe token, sUSDe staking, multisig\n- Pendle: PendleRouter V2, PendleMarketFactory, governance timelock\n\n**Also generalized** the registry scanner in `contract_surveillance.py` to iterate all dict entries with an `address` field, not just hardcoded `core_contract`/`governance_timelock` keys.\n\nhttps://claude.ai/code/session_011bTVc5haorCZgtCtxzJmtq

---
_Generated by [Claude Code](https://claude.ai/code/session_011bTVc5haorCZgtCtxzJmtq)_