### PR TITLE
fix(dashboard): enriched 0% metric — correct wallet count queries

### DIFF
--- a/app/data_layer/state_growth.py
+++ b/app/data_layer/state_growth.py
@@ -156,7 +156,8 @@ async def _bulk_row_counts() -> dict[str, int]:
     # pg_stat n_live_tup inflates massively between VACUUM cycles for these.
     TABLE_COUNT_OVERRIDES = {
         "wallet_graph.wallet_risk_scores": "SELECT COUNT(DISTINCT wallet_address) as cnt FROM wallet_graph.wallet_risk_scores",
-        "wallet_graph.wallet_holdings": "SELECT COUNT(DISTINCT wallet_address || token_address) as cnt FROM wallet_graph.wallet_holdings WHERE public.immutable_date(indexed_at) = CURRENT_DATE",
+        "wallet_graph.wallet_holdings": "SELECT COUNT(DISTINCT wallet_address) as cnt FROM wallet_graph.wallet_holdings",
+        "wallet_graph.wallet_edges": "SELECT COUNT(DISTINCT addr) as cnt FROM (SELECT LOWER(from_address) AS addr FROM wallet_graph.wallet_edges UNION SELECT LOWER(to_address) FROM wallet_graph.wallet_edges) sub",
         "component_readings": "SELECT COUNT(DISTINCT stablecoin_id || component_id) as cnt FROM component_readings WHERE collected_at > NOW() - INTERVAL '24 hours'",
         "peg_snapshots_5m": "SELECT COUNT(*) as cnt FROM peg_snapshots_5m",
         "yield_snapshots": "SELECT COUNT(*) as cnt FROM yield_snapshots",


### PR DESCRIPTION
## Problem

Dashboard showed "ENRICHED 0%" permanently. The `fully_enriched_pct` formula is `min(scores, edges, holdings) / total * 100` — conceptually correct but two inputs measured the wrong thing.

## Bug 1: wallet_holdings filtered by CURRENT_DATE

Override query counted `DISTINCT wallet_address || token_address` with `WHERE immutable_date(indexed_at) = CURRENT_DATE`. Before today's first indexing cycle, count = 0. `min()` makes entire result 0. Resets every midnight UTC.

**Fix:** `SELECT COUNT(DISTINCT wallet_address) as cnt FROM wallet_graph.wallet_holdings` — no date filter, counts wallets not wallet+token pairs.

## Bug 2: wallet_edges counted edge rows, not wallets

Used `pg_stat_user_tables.n_live_tup` which counts edge rows (from→to pairs), not unique wallets. Different unit than denominator.

**Fix:** Added override: `SELECT COUNT(DISTINCT addr) FROM (SELECT LOWER(from_address) UNION SELECT LOWER(to_address)) sub`

## Expected result

After deploy, `ENRICHED` should show the actual percentage of wallets that have all three signals (scores + edges + holdings), likely 5-10% based on current data volumes.

https://claude.ai/code/session_011bTVc5haorCZgtCtxzJmtq

---
_Generated by [Claude Code](https://claude.ai/code/session_011bTVc5haorCZgtCtxzJmtq)_