### PR TITLE
fix(db): remove libpq startup options — incompatible with Neon pooler

### DIFF
--- a/app/database.py
+++ b/app/database.py
@@ -47,6 +47,11 @@ def _warn_if_async_context(helper_name: str) -> None:
 
 _pool: Optional[ThreadedConnectionPool] = None
 
+# Neon's -pooler endpoint is pgbouncer in transaction mode and rejects libpq
+# startup `options` (incl. `-c statement_timeout=...`). We apply the timeout
+# per-transaction via SET LOCAL inside get_conn() instead.
+_STATEMENT_TIMEOUT_MS = 120000  # 120 s query timeout
+
 
 def init_pool(database_url: Optional[str] = None, min_conn: int = 5, max_conn: int = 50):
     """Initialize the connection pool. Call once at startup."""
@@ -61,6 +66,11 @@ def init_pool(database_url: Optional[str] = None, min_conn: int = 5, max_conn: i
         # after PostgreSQL's idle-session timeout. Without this, connections that
         # sit in the pool for >~30 min get closed server-side and the next caller
         # gets a "connection already closed" error.
+        #
+        # NOTE: do NOT pass `options="-c statement_timeout=..."` here — Neon's
+        # -pooler endpoint (pgbouncer, transaction mode) rejects any libpq
+        # startup `options` parameter. Statement timeout is applied per
+        # transaction inside get_conn() via SET LOCAL.
         _pool = ThreadedConnectionPool(
             min_conn, max_conn, url,
             keepalives=1,
@@ -68,7 +78,6 @@ def init_pool(database_url: Optional[str] = None, min_conn: int = 5, max_conn: i
             keepalives_interval=10, # retry probe every 10 s
             keepalives_count=5,     # drop after 5 failed probes
             connect_timeout=10,     # 10s connection timeout
-            options="-c statement_timeout=120000",  # 120 s query timeout
         )
         logger.info(f"Database pool initialized (min={min_conn}, max={max_conn}, keepalives=on)")
     except Exception as e:
@@ -149,6 +158,16 @@ def get_conn():
         raise psycopg2.OperationalError("Database connection unrecoverable after liveness ping failures")
 
     try:
+        # SET LOCAL is scoped to the current transaction, so it survives
+        # pgbouncer transaction-mode multiplexing (unlike a session-level SET).
+        # The liveness-ping SELECT above already opened an implicit transaction,
+        # so SET LOCAL applies for the rest of this checkout.
+        try:
+            _to_cur = conn.cursor()
+            _to_cur.execute("SET LOCAL statement_timeout = %s", (_STATEMENT_TIMEOUT_MS,))
+            _to_cur.close()
+        except Exception as _to_err:
+            logger.warning("Could not SET LOCAL statement_timeout: %s", _to_err)
         yield conn
         conn.commit()
     except Exception as exc:


### PR DESCRIPTION
## Summary
- Production DB pool init has been failing on every Python service since the May 10 Neon migration. Neon's `-pooler` endpoint is pgbouncer in transaction mode and rejects any libpq startup `options` parameter, so the connect-time `options="-c statement_timeout=120000"` in `app/database.py` made `init_pool()` raise, cascading to `RuntimeError: Database pool not initialized` on every downstream `get_conn()`.
- Drops the connect-time `options=` and instead issues `SET LOCAL statement_timeout = 120000` inside the implicit transaction at the top of `get_conn()`. `SET LOCAL` is transaction-scoped, so it survives pgbouncer transaction-mode multiplexing (a session-level `SET` would not).
- One file changed (`app/database.py`); all 13 Python services share this code path (api-server, Scoring-Worker, basis-state, basis-provenance, basis-backfill-*), so this single fix unblocks all of them. The migration runner uses the same `get_conn()` path so it's unblocked too — no separate change. Pooled endpoint retained; no `DATABASE_URL` change.

## Test plan
- [ ] Railway redeploy of `api-server` shows `Database pool initialized` and the `unsupported startup parameter in options: statement_timeout` error is gone.
- [ ] `Scoring-Worker`, `basis-state`, `basis-provenance`, and the 8 `basis-backfill-*` services likewise come up cleanly on next deploy.
- [ ] `/api/health` returns `healthy` with a non-zero `stablecoin_count`.
- [ ] A long-running query (>120s) still trips `statement_timeout` as expected — confirming `SET LOCAL` took effect.

https://claude.ai/code/session_01T9JSBB6E4rxjLUssCLk5X3

---
_Generated by [Claude Code](https://claude.ai/code/session_01T9JSBB6E4rxjLUssCLk5X3)_