### PR TITLE
fix(deploy-safety): retry init_pool, fail loud, add /healthz + /readyz

### DIFF
--- a/app/database.py
+++ b/app/database.py
@@ -6,6 +6,7 @@ Simple PostgreSQL connection management with connection pooling.
 import asyncio
 import os
 import logging
+import time
 import traceback
 from contextlib import contextmanager
 from typing import Optional, Any
@@ -53,36 +54,65 @@ _pool: Optional[ThreadedConnectionPool] = None
 _STATEMENT_TIMEOUT_MS = 120000  # 120 s query timeout
 
 
-def init_pool(database_url: Optional[str] = None, min_conn: int = 5, max_conn: int = 50):
-    """Initialize the connection pool. Call once at startup."""
+def init_pool(database_url: Optional[str] = None, min_conn: int = 5, max_conn: int = 50) -> bool:
+    """Initialize the connection pool. Call once at startup.
+
+    Returns True on success, False on failure. Retries up to 3 times with
+    exponential backoff (1s, 2s, 4s — ~7s total) to handle cold-start races
+    against the Neon pooler warming up.
+
+    On failure, leaves `_pool = None` and returns False so the caller can
+    decide whether to crash-loop (Railway will mark CRASHED and roll back) or
+    continue in a degraded mode.
+    """
     global _pool
     url = database_url or os.environ.get("DATABASE_URL", "")
     if not url:
         logger.error("DATABASE_URL not set — database unavailable")
-        return
-    logger.info(f"Database URL prefix: {url[:50]}...")
-    try:
-        # TCP keepalives: prevent the OS from silently dropping idle connections
-        # after PostgreSQL's idle-session timeout. Without this, connections that
-        # sit in the pool for >~30 min get closed server-side and the next caller
-        # gets a "connection already closed" error.
-        #
-        # NOTE: do NOT pass `options="-c statement_timeout=..."` here — Neon's
-        # -pooler endpoint (pgbouncer, transaction mode) rejects any libpq
-        # startup `options` parameter. Statement timeout is applied per
-        # transaction inside get_conn() via SET LOCAL.
-        _pool = ThreadedConnectionPool(
-            min_conn, max_conn, url,
-            keepalives=1,
-            keepalives_idle=30,     # start probing after 30 s idle
-            keepalives_interval=10, # retry probe every 10 s
-            keepalives_count=5,     # drop after 5 failed probes
-            connect_timeout=10,     # 10s connection timeout
-        )
-        logger.info(f"Database pool initialized (min={min_conn}, max={max_conn}, keepalives=on)")
-    except Exception as e:
-        logger.error(f"Failed to initialize database pool: {e}")
         _pool = None
+        return False
+    logger.info(f"Database URL prefix: {url[:50]}...")
+
+    last_err: Optional[Exception] = None
+    for attempt in range(1, 4):  # 1, 2, 3
+        try:
+            # TCP keepalives: prevent the OS from silently dropping idle connections
+            # after PostgreSQL's idle-session timeout. Without this, connections that
+            # sit in the pool for >~30 min get closed server-side and the next caller
+            # gets a "connection already closed" error.
+            #
+            # NOTE: do NOT pass `options="-c statement_timeout=..."` here — Neon's
+            # -pooler endpoint (pgbouncer, transaction mode) rejects any libpq
+            # startup `options` parameter. Statement timeout is applied per
+            # transaction inside get_conn() via SET LOCAL.
+            _pool = ThreadedConnectionPool(
+                min_conn, max_conn, url,
+                keepalives=1,
+                keepalives_idle=30,     # start probing after 30 s idle
+                keepalives_interval=10, # retry probe every 10 s
+                keepalives_count=5,     # drop after 5 failed probes
+                connect_timeout=10,     # 10s connection timeout
+            )
+            logger.info(
+                f"Database pool initialized (min={min_conn}, max={max_conn}, "
+                f"keepalives=on, attempt={attempt})"
+            )
+            return True
+        except Exception as e:
+            last_err = e
+            backoff = 2 ** (attempt - 1)  # 1s, 2s, 4s
+            logger.error(
+                f"Failed to initialize database pool (attempt {attempt}/3): {e}"
+            )
+            if attempt < 3:
+                logger.info(f"Retrying pool init in {backoff}s...")
+                time.sleep(backoff)
+
+    logger.critical(
+        f"Database pool initialization failed after 3 attempts. Last error: {last_err}"
+    )
+    _pool = None
+    return False
 
 
 def close_pool():

--- a/app/server.py
+++ b/app/server.py
@@ -479,7 +479,17 @@ def _seed_cda_issuer_registry():
 
 @app.on_event("startup")
 async def startup():
-    init_pool()
+    # Fail loud if the pool can't come up. In Gunicorn/Uvicorn multi-worker
+    # setups main.py's pool init runs once in the parent; each worker also
+    # imports app.server and re-runs this startup hook. If the pool fails in a
+    # worker we want to crash that worker so Railway notices and rolls back —
+    # not silently serve 503s.
+    if not init_pool():
+        logger.critical("init_pool() failed in server startup hook — exiting worker")
+        # os._exit, not sys.exit, because we're inside an asyncio task and a
+        # plain SystemExit may be swallowed by the event loop / Uvicorn
+        # supervisor.
+        os._exit(1)
     # Seed CDA issuer registry from config
     try:
         await asyncio.to_thread(_seed_cda_issuer_registry)
@@ -1359,6 +1369,62 @@ async def playground_report(token: str):
 
     return HTMLResponse(content=html or "Report generation failed",
                         headers={"Cache-Control": "private, no-store"})
+
+
+# =============================================================================
+# 0. GET /healthz, /readyz — lightweight liveness / readiness probes
+# =============================================================================
+# These are short, uncached, and have no dependency on the integrity layer or
+# the response cache. Railway's healthcheck uses /healthz; orchestrators use
+# /readyz to gate traffic. Keep them cheap so they don't share a fate with
+# heavy API queries.
+
+def _probe_db_quick() -> tuple[bool, str]:
+    """Open a pool checkout and run SELECT 1. Returns (ok, reason)."""
+    from app.database import _pool as _db_pool, get_conn
+    if _db_pool is None:
+        return False, "pool not initialized"
+    try:
+        with get_conn() as conn:
+            cur = conn.cursor()
+            cur.execute("SELECT 1")
+            cur.fetchone()
+            cur.close()
+        return True, "ok"
+    except Exception as e:
+        return False, f"db ping failed: {type(e).__name__}: {e}"
+
+
+@app.get("/healthz")
+async def healthz():
+    """Liveness probe — pool initialized + SELECT 1. 200 healthy, 503 not."""
+    ok, reason = await asyncio.to_thread(_probe_db_quick)
+    payload = {"ok": ok, "reason": reason}
+    return JSONResponse(payload, status_code=200 if ok else 503)
+
+
+@app.get("/readyz")
+async def readyz():
+    """Readiness probe — healthz checks + migrations table populated."""
+    ok, reason = await asyncio.to_thread(_probe_db_quick)
+    if not ok:
+        return JSONResponse({"ok": False, "reason": reason}, status_code=503)
+
+    def _check_migrations() -> tuple[bool, str]:
+        try:
+            from app.database import fetch_one
+            row = fetch_one(
+                "SELECT 1 AS x FROM migrations WHERE name = '001_initial_schema'"
+            )
+            if row:
+                return True, "ok"
+            return False, "001_initial_schema not recorded in migrations table"
+        except Exception as e:
+            return False, f"migrations check failed: {type(e).__name__}: {e}"
+
+    mig_ok, mig_reason = await asyncio.to_thread(_check_migrations)
+    payload = {"ok": mig_ok, "reason": mig_reason}
+    return JSONResponse(payload, status_code=200 if mig_ok else 503)
 
 
 # =============================================================================

--- a/main.py
+++ b/main.py
@@ -757,7 +757,14 @@ def run_migrations():
 def main():
     # 1. Initialize database
     logger.info("Initializing database pool...")
-    init_pool()
+    if not init_pool():
+        # Crash before binding the port so Railway marks the deploy CRASHED
+        # and rolls back. Without this, Uvicorn would happily bind anyway and
+        # every downstream request would 500 on "Database pool not initialized"
+        # while Railway thought the deploy was healthy — which is exactly the
+        # failure mode that produced the 2026-05-10 Neon-pooler incident.
+        logger.critical("init_pool() failed after retries — exiting before port bind")
+        sys.exit(1)
 
     db_status = db_health_check()
     if db_status.get("status") == "healthy":

--- a/railway.json
+++ b/railway.json
@@ -2,6 +2,8 @@
   "$schema": "https://railway.com/railway.schema.json",
   "deploy": {
     "restartPolicyType": "ON_FAILURE",
-    "restartPolicyMaxRetries": 5
+    "restartPolicyMaxRetries": 5,
+    "healthcheckPath": "/healthz",
+    "healthcheckTimeout": 10
   }
 }


### PR DESCRIPTION
Track A part 2 of the 2026-05-10 Neon-pooler incident audit (part 1 was #130). This PR hardens startup behavior so the same failure mode — `init_pool` raises, every downstream `get_conn` raises, but Railway marks the deploy SUCCESS because Uvicorn still binds the port — cannot reproduce.

Track A part 3 (migration runner safety) was scoped as a separate workstream but inspection showed it's **already in place**: `migrations/001_initial_schema.sql:265` creates the `migrations` tracking table with `CREATE TABLE IF NOT EXISTS`, every subsequent migration inserts with `ON CONFLICT DO NOTHING`, and the runner in `main.py:546` checks the table before applying each. Idempotent + self-bootstrapping; no code change needed. Noted in commit message.

## Summary

- `app/database.py::init_pool()` retries up to 3 attempts with exponential backoff (1s + 2s + 4s ≈ 7s total) and returns `bool`. Cold-start races against the Neon pooler warming up are now self-healing.
- `main.py` checks the return value and `sys.exit(1)` BEFORE binding the port if init failed after retries — Railway will mark the deploy CRASHED and roll back rather than serving 503s on every request.
- `app/server.py` FastAPI startup hook re-checks `init_pool()` per worker and calls `os._exit(1)` if a worker can't connect (the event loop would swallow `sys.exit`).
- Adds `GET /healthz` (pool initialized + `SELECT 1`, 200/503) and `GET /readyz` (healthz + `001_initial_schema` recorded in `migrations` table, 200/503). Uncached, bypasses the integrity layer.
- `railway.json` sets `healthcheckPath: "/healthz"`, `healthcheckTimeout: 10`. Railway will hold traffic until the probe goes green.

## Why this matters

The 2026-05-10 incident root cause was a single libpq option in the URL, but the **detection failure** was that Railway saw deploy=SUCCESS while every request 500'd. This PR closes that gap. Healthcheck probe + fail-loud means future pool-init failures will:

1. Be retried 3× automatically (covers cold-start races).
2. If they still fail, the process exits before binding the port.
3. Railway marks CRASHED → auto-rollback per existing `restartPolicyType: ON_FAILURE`.

## Test plan

- [ ] Railway redeploy on api-server, Scoring-Worker, basis-backfill-* shows `Database pool initialized (..., attempt=1)` (healthy path).
- [ ] `GET /healthz` returns 200 `{"ok": true, "reason": "ok"}`.
- [ ] `GET /readyz` returns 200 `{"ok": true, "reason": "ok"}`.
- [ ] Railway healthcheck dashboard now shows the green probe.
- [ ] Manually simulate failure (set `DATABASE_URL=postgres://nobody@nowhere/x` on a non-prod env): confirm the deploy goes CRASHED, not SUCCESS, within ~10s.

## Out of scope

- pgbouncer-pattern code fixes (Wave-2 batch — VACUUM autocommit, PSI batch inserts, indexer per-holding loop).
- Neon settings (autosuspend, retention) — Wave-2.
- Track F canon doc update — separate PR to `basis-protocol/canon`.

https://claude.ai/code/session_01T9JSBB6E4rxjLUssCLk5X3

---
_Generated by [Claude Code](https://claude.ai/code/session_01T9JSBB6E4rxjLUssCLk5X3)_