### PR TITLE
fix(pooler): VACUUM via unpooled endpoint + batch backfill/indexer inserts

### DIFF
--- a/app/indexer/pipeline.py
+++ b/app/indexer/pipeline.py
@@ -21,7 +21,7 @@ from datetime import datetime, timezone
 
 import httpx
 
-from app.database import fetch_all, fetch_one, execute, fetch_one_async, fetch_all_async, execute_async
+from app.database import fetch_all, fetch_one, execute, fetch_one_async, fetch_all_async, execute_async, get_cursor
 from app.indexer.config import BLOCK_EXPLORER_PROVIDER, EXPLORER_RATE_LIMIT_DELAY
 from app.indexer.scanner import batch_scan_all_holdings, fetch_top_holders, fetch_token_list
 from app.indexer.scorer import compute_wallet_risk
@@ -78,39 +78,62 @@ async def _store_wallet(address: str, source: str, label: str = None, chain: str
     )
 
 
-async def _store_holdings(wallet_address: str, holdings: list[dict]) -> None:
-    """Insert wallet holdings snapshot (one per wallet/token/day)."""
+def _store_holdings_sync(wallet_address: str, holdings: list[dict]) -> None:
+    """Full-refresh today's holdings for a wallet — one DELETE + one bulk INSERT.
+
+    The previous implementation issued one DELETE + one INSERT per holding,
+    i.e. 2N transactions per wallet. Under the Neon -pooler endpoint each of
+    those takes a pool slot, and at ~50 holdings/wallet × hundreds of wallets
+    per indexer batch this can saturate the 50-conn pool. This converts to a
+    single transaction (1 DELETE + 1 bulk INSERT via execute_values) per wallet.
+
+    All four call sites pass the complete current holdings snapshot for the
+    wallet, so the DELETE-all-today-then-bulk-insert semantics match what
+    callers expect.
+    """
     wallet_address = wallet_address.lower()
-    for h in holdings:
-        # Delete existing row for today, then insert fresh
-        await execute_async(
+    import psycopg2.extras as _pgex
+    with get_cursor() as cur:
+        cur.execute(
             """
             DELETE FROM wallet_graph.wallet_holdings
             WHERE wallet_address = %s
-              AND token_address = %s
               AND public.immutable_date(indexed_at) = CURRENT_DATE
             """,
-            (wallet_address, h["token_address"]),
+            (wallet_address,),
         )
-        await execute_async(
+        if not holdings:
+            return
+        _pgex.execute_values(
+            cur,
             """
             INSERT INTO wallet_graph.wallet_holdings
                 (wallet_address, token_address, symbol, balance, value_usd,
                  is_scored, sii_score, sii_grade, pct_of_wallet, indexed_at)
-            VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, NOW())
+            VALUES %s
             """,
-            (
-                wallet_address,
-                h["token_address"],
-                h["symbol"],
-                h["balance"],
-                h["value_usd"],
-                h["is_scored"],
-                h.get("sii_score"),
-                None,
-                h.get("pct_of_wallet"),
-            ),
+            [
+                (
+                    wallet_address,
+                    h["token_address"],
+                    h["symbol"],
+                    h["balance"],
+                    h["value_usd"],
+                    h["is_scored"],
+                    h.get("sii_score"),
+                    None,
+                    h.get("pct_of_wallet"),
+                )
+                for h in holdings
+            ],
+            template="(%s, %s, %s, %s, %s, %s, %s, %s, %s, NOW())",
+            page_size=200,
         )
+
+
+async def _store_holdings(wallet_address: str, holdings: list[dict]) -> None:
+    """Async wrapper around the sync bulk-store helper."""
+    await asyncio.to_thread(_store_holdings_sync, wallet_address, holdings)
 
 
 async def _store_risk_score(wallet_address: str, risk: dict) -> None:

--- a/app/services/psi_backfill.py
+++ b/app/services/psi_backfill.py
@@ -16,7 +16,7 @@ from datetime import datetime, timezone, timedelta
 
 import httpx
 
-from app.database import execute, fetch_one
+from app.database import execute, fetch_one, get_cursor
 from app.index_definitions.psi_v01 import TARGET_PROTOCOLS
 from app.collectors.psi_collector import PROTOCOL_GOVERNANCE_TOKENS
 from app.api_usage_tracker import track_api_call
@@ -108,36 +108,53 @@ def backfill_protocol_tvl(slug: str) -> int:
         if "-" not in k and isinstance(v, (int, float)) and v > 0
     ]) if current_chain_tvls else 1
 
-    records = 0
+    rows: list[tuple] = []
     for entry in tvl_history:
         ts = entry.get("date")
         tvl_val = entry.get("totalLiquidityUSD", 0)
         if not ts or not tvl_val:
             continue
-
         record_date = datetime.fromtimestamp(ts, tz=timezone.utc).date()
+        rows.append((slug, record_date.isoformat(), tvl_val, chain_count))
 
-        try:
-            execute("""
+    if not rows:
+        logger.info(f"Backfilled 0 TVL records for {slug} (no eligible entries)")
+        return 0
+
+    # Single batched upsert replaces what was an O(n) per-row execute() loop.
+    # Each row used to consume a pool slot and a separate transaction; under
+    # the Neon -pooler endpoint that's particularly wasteful, and at hundreds
+    # of rows per protocol it dwarfs the actual insert work.
+    import psycopg2.extras as _pgex
+    try:
+        with get_cursor() as cur:
+            _pgex.execute_values(
+                cur,
+                """
                 INSERT INTO historical_protocol_data
                     (protocol_slug, record_date, tvl, chain_count, data_source)
-                VALUES (%s, %s, %s, %s, 'defillama')
+                VALUES %s
                 ON CONFLICT (protocol_slug, record_date) DO UPDATE SET
                     tvl = EXCLUDED.tvl,
                     chain_count = EXCLUDED.chain_count
-            """, (slug, record_date.isoformat(), tvl_val, chain_count))
-            records += 1
-        except Exception as e:
-            logger.warning(f"TVL insert error for {slug} @ {record_date}: {e}")
-            try:
-                from app.worker import _record_cycle_error
-                _record_cycle_error(
-                    error_type="services_backfill_protocol_tvl_insert_failure",
-                    error_message=str(e)[:500],
-                    cycle_phase="psi_backfill",
-                )
-            except Exception:
-                pass
+                """,
+                [(s, d, t, c, "defillama") for (s, d, t, c) in rows],
+                template="(%s, %s, %s, %s, %s)",
+                page_size=500,
+            )
+        records = len(rows)
+    except Exception as e:
+        logger.warning(f"TVL bulk insert error for {slug}: {e}")
+        try:
+            from app.worker import _record_cycle_error
+            _record_cycle_error(
+                error_type="services_backfill_protocol_tvl_insert_failure",
+                error_message=str(e)[:500],
+                cycle_phase="psi_backfill",
+            )
+        except Exception:
+            pass
+        records = 0
 
     logger.info(f"Backfilled {records} TVL records for {slug}")
     return records
@@ -216,21 +233,38 @@ def backfill_protocol_token(slug: str, gecko_id: str, from_date: str = "2024-01-
             d = datetime.fromtimestamp(ts_ms / 1000, tz=timezone.utc).date()
             vol_map[d] = val
 
-        for ts_ms, price in prices:
-            d = datetime.fromtimestamp(ts_ms / 1000, tz=timezone.utc).date()
+        token_rows = [
+            (
+                slug,
+                datetime.fromtimestamp(ts_ms / 1000, tz=timezone.utc).date().isoformat(),
+                price,
+                mcap_map.get(datetime.fromtimestamp(ts_ms / 1000, tz=timezone.utc).date()),
+                vol_map.get(datetime.fromtimestamp(ts_ms / 1000, tz=timezone.utc).date()),
+            )
+            for ts_ms, price in prices
+        ]
+        if token_rows:
+            import psycopg2.extras as _pgex
             try:
-                execute("""
-                    INSERT INTO historical_protocol_data
-                        (protocol_slug, record_date, token_price, token_mcap, token_volume, data_source)
-                    VALUES (%s, %s, %s, %s, %s, 'coingecko')
-                    ON CONFLICT (protocol_slug, record_date) DO UPDATE SET
-                        token_price = COALESCE(EXCLUDED.token_price, historical_protocol_data.token_price),
-                        token_mcap = COALESCE(EXCLUDED.token_mcap, historical_protocol_data.token_mcap),
-                        token_volume = COALESCE(EXCLUDED.token_volume, historical_protocol_data.token_volume)
-                """, (slug, d.isoformat(), price, mcap_map.get(d), vol_map.get(d)))
-                records += 1
+                with get_cursor() as cur:
+                    _pgex.execute_values(
+                        cur,
+                        """
+                        INSERT INTO historical_protocol_data
+                            (protocol_slug, record_date, token_price, token_mcap, token_volume, data_source)
+                        VALUES %s
+                        ON CONFLICT (protocol_slug, record_date) DO UPDATE SET
+                            token_price = COALESCE(EXCLUDED.token_price, historical_protocol_data.token_price),
+                            token_mcap = COALESCE(EXCLUDED.token_mcap, historical_protocol_data.token_mcap),
+                            token_volume = COALESCE(EXCLUDED.token_volume, historical_protocol_data.token_volume)
+                        """,
+                        [(s, d, p, m, v, "coingecko") for (s, d, p, m, v) in token_rows],
+                        template="(%s, %s, %s, %s, %s, %s)",
+                        page_size=500,
+                    )
+                records += len(token_rows)
             except Exception as e:
-                logger.warning(f"psi_backfill: backfill_protocol_token insert failed for {slug} @ {d}: {e}")
+                logger.warning(f"psi_backfill: token bulk insert failed for {slug}: {e}")
                 try:
                     from app.worker import _record_cycle_error
                     _record_cycle_error(

--- a/app/worker.py
+++ b/app/worker.py
@@ -2809,11 +2809,39 @@ async def run_scoring_cycle():
     return result
 
 
+def _direct_db_url() -> str:
+    """Derive the unpooled Neon endpoint URL from DATABASE_URL.
+
+    VACUUM cannot run via the -pooler endpoint (pgbouncer transaction mode
+    rejects session-level autocommit and disallows VACUUM in a transaction).
+    The owned Neon project exposes both a pooled host (-pooler suffix) and a
+    direct host without the suffix; this helper strips the suffix so VACUUM
+    can target the direct endpoint while every other connection in the app
+    keeps using the pooler.
+
+    Returns empty string if DATABASE_URL is unset or doesn't have the
+    expected `-pooler.` infix.
+    """
+    url = os.environ.get("DATABASE_URL", "")
+    if not url or "-pooler." not in url:
+        return ""
+    return url.replace("-pooler.", ".", 1)
+
+
 def _run_vacuum_analyze_sync():
-    """Sync helper: VACUUM ANALYZE churny tables (called via to_thread)."""
+    """Sync helper: VACUUM ANALYZE churny tables (called via to_thread).
+
+    Uses the direct (unpooled) Neon endpoint — VACUUM is incompatible with
+    pgbouncer transaction-mode pooling. If the direct URL can't be derived
+    we skip the explicit VACUUM and rely on autovacuum instead.
+    """
     import psycopg2 as _vac_pg
-    _vac_url = os.environ.get("DATABASE_URL", "")
+    _vac_url = _direct_db_url()
     if not _vac_url:
+        logger.info(
+            "[startup] VACUUM ANALYZE skipped: direct (unpooled) DATABASE_URL "
+            "not derivable. Relying on autovacuum."
+        )
         return
     _vac_conn = _vac_pg.connect(_vac_url)
     _vac_conn.autocommit = True

--- a/docs/audits/2026-05-10-neon-state.md
+++ b/docs/audits/2026-05-10-neon-state.md
@@ -1,0 +1,167 @@
+# Neon Post-Migration State Audit — 2026-05-10
+
+**Track:** E (read-only Postgres verification)
+**Author:** Claude Code (automated)
+**Generated:** 2026-05-11 (updated with completed query results)
+**New Neon project:** `BasisProtocol` — id `small-scene-57890564`
+**Org:** `Basis` (`org-aged-brook-05137723`) — owned directly, separate from Replit
+**Region:** `aws-us-east-2` (proxy host `c-3.us-east-2.aws.neon.tech`)
+**Pooler endpoint (in scope):** `ep-quiet-star-aj2xkpn6-pooler.c-3.us-east-2.aws.neon.tech`
+
+---
+
+## EXECUTIVE SUMMARY
+
+✅ **AUDIT COMPLETE. WRITE TRAFFIC IS SAFE.**
+
+- **No behind sequences.** Every populated table's serial PK sequence is at or
+  ahead of `max(id)`. 18 sequences with `null` last_value all correspond to
+  empty tables (confirmed `max(id) = 0`).
+- **All app-required extensions present:** `pg_trgm 1.6`, `plpgsql 1.0`,
+  `uuid-ossp 1.1`. `pgcrypto` is not installed and not needed — the codebase
+  uses Python's `hashlib.sha256` for all hashing (no `gen_random_uuid` /
+  `crypt` / `digest` / `hmac` references in SQL or Python).
+- **Compute healthy:** `ep-quiet-star-aj2xkpn6` is `read_write`, active,
+  autoscaling 0.25–2 CU, region `aws-us-east-2`. Pooler mode `transaction`.
+- **Schemas present:** `public`, `wallet_graph`, `ops`, plus internal `_system`.
+- **High-volume table sanity:** `component_readings` 1,214,935 rows,
+  `score_history` 24,974, `wallet_holdings` 807,125, `wallet_edges` 1,380,112,
+  `data_provenance` 1,203,709, `market_chart_history` 1,878,880,
+  `peg_snapshots_5m` 1,253,494. Consistent with pre-migration volumes.
+
+## NON-BLOCKING OBSERVATIONS
+
+1. **History retention is 6h** (`history_retention_seconds: 21600`). Recommend
+   bumping to 7d (604800s) for production — supports point-in-time recovery
+   and branch rewinds during incident response. Neon-console-only change.
+
+2. **Compute autosuspend is 5 minutes** (`suspend_timeout_seconds: 300`) even
+   though the project default shows `0` (disabled). For a hot, multi-service
+   production workload the compute will warm-cycle every time traffic drops
+   for >5 min — that's the cold-start that the new `init_pool()` retry logic
+   in PR #132 specifically tolerates. Recommend setting compute autosuspend
+   to `0` (disabled) so the cold-start path is exceptional rather than
+   routine. Neon-console-only change.
+
+3. **Connection-pool math:** worst case = 13 services × `max_conn=50` = 650
+   client connections fanning into Neon's pooler. Neon's pgbouncer default
+   handles tens of thousands of client connections (the upstream limit is on
+   server-side connections, currently sized to compute CU). Not close to a
+   wall; flag for future as services scale.
+
+4. **Extension delta vs. expectations:** the Track E spec mentioned
+   `pgcrypto` as a baseline. We confirmed it's absent and the app doesn't
+   reference it — no action needed, just worth recording so a future audit
+   doesn't re-flag the same thing.
+
+5. **Owner identity confirmed:** project is under Basis-owned Neon org
+   `org-aged-brook-05137723`, created `2026-05-10T22:10:51Z` (matches the
+   incident timeline). Not nested under any Replit-managed account.
+
+---
+
+## CHECK-BY-CHECK RESULTS
+
+### 1. Project & branch identity ✅
+- Project `small-scene-57890564` named `BasisProtocol` in org `Basis`
+  (`org-aged-brook-05137723`)
+- pg_version 17, region `aws-us-east-2`
+- Compute `ep-quiet-star-aj2xkpn6` (Primary, read_write, currently `active`)
+- Branch `br-round-feather-ajk3ofap`
+- Pooler enabled on the compute, mode `transaction` (this is what rejects
+  libpq startup `options` — the root cause of the 2026-05-10 incident).
+
+### 2. Extensions ✅
+```
+extname     | extversion
+------------+-----------
+pg_trgm     | 1.6
+plpgsql     | 1.0
+uuid-ossp   | 1.1
+```
+`pgcrypto` absent — verified unused (no `gen_random_uuid` / `crypt` / `digest`
+/ `hmac` in `app/`, `migrations/`).
+
+### 3. Schemas ✅
+`public`, `wallet_graph`, `ops`, `_system` (plus pg internals).
+
+### 4. Tables ✅
+Schema-qualified inventory matches `migrations/*.sql` expectations. No
+required table missing.
+
+### 5. Approximate row counts ✅
+Spot-checked top tables (see Executive Summary). All populated tables that
+should have data have data. Empty tables (api_keys, payment_log, etc.) match
+their "feature not yet used heavily" status per CLAUDE.md.
+
+### 6. Sequence sanity ✅ — **most important check**
+
+Query result: **no BEHIND sequences.**
+
+Method: enumerated every serial/identity-backed sequence via `pg_class` +
+`pg_depend` join, then for each one queried `MAX(<column>)` from the
+underlying table and compared to `pg_sequence_last_value(seq_oid)`.
+
+Result: every populated sequence is **at or ahead of** its max(id). 18
+sequences with `null` last_value correspond to empty tables (`max(id) = 0`),
+which is normal — `pg_sequence_last_value` returns null until the first
+`nextval()` call. Empty-table sequences will allocate from 1 on first insert,
+which is correct.
+
+Spot-check on highest-volume tables (live values at audit time):
+
+| table                | max(id)   | seq_last  | status |
+|----------------------|-----------|-----------|--------|
+| api_usage_tracker    | 1,941,341 | 1,941,341 | OK     |
+| component_readings   | 1,214,935 | 1,214,935 | OK     |
+| data_provenance      | 1,203,709 | 1,203,709 | OK     |
+| generic_index_scores | 435,552   | 435,552   | OK     |
+| market_chart_history | 1,878,880 | 1,878,880 | OK     |
+| peg_snapshots_5m     | 1,253,494 | 1,253,494 | OK     |
+| rpc_provider_usage   | 584,050   | 585,625   | OK (seq ahead)  |
+| wallet_holdings      | 807,125   | 807,125   | OK     |
+| wallet_edges         | 1,380,112 | 1,380,263 | OK (seq ahead)  |
+| wallet_risk_scores   | 547,699   | 547,699   | OK     |
+
+This was the highest-priority pre-cutover risk — sequences not advancing
+with `pg_dump+restore` is the classic Postgres-migration footgun. **It did
+not happen here.**
+
+### 7. Indexes ⏭ (deferred)
+Did not enumerate exhaustively. App is performing within expectations
+(scoring cycle latency, indexer throughput) so any missing indexes are not
+production-blocking. Belongs in a perf audit, not an incident audit.
+
+### 8. Migration tracking ✅
+`migrations` table exists (created idempotently by 001's
+`CREATE TABLE IF NOT EXISTS migrations`). The runner in `main.py:546` checks
+this table before each migration and skips already-applied ones. The runner
+unblocked itself the moment PR #130 (Track A pt1) landed; no half-applied
+state.
+
+### 9. Roles & grants ⏭ (deferred)
+App role can connect, run all queries, perform writes — verified via
+Scoring-Worker logs at 01:46 UTC showing successful inserts into
+`wallet_graph.wallet_holdings` and other tables. No GRANT issues.
+
+### 10. Pooler & connection limits ✅
+Pooler enabled on compute, transaction mode, online. 13 services ×
+`max_conn=50` = 650 client connections. Not close to Neon's pooler ceiling.
+
+---
+
+## RECOMMENDED FOLLOW-UPS
+
+These are not blocking — they're production-hygiene improvements surfaced by
+this audit. Tracked in the Wave-2 PR description.
+
+1. **Increase `history_retention_seconds` from 21600 (6h) to 604800 (7d).**
+   Supports point-in-time recovery and branch rewinds during incident
+   response. Neon console change.
+
+2. **Set compute `suspend_timeout_seconds` to `0` (disabled).** Production
+   workloads shouldn't routinely cold-start. The new `init_pool()` retry
+   logic in PR #132 makes the cold-start path safe, but eliminating the
+   cold start at the source is better. Neon console change.
+
+3. **No code changes needed.** The DB state is clean.

--- a/docs/audits/2026-05-10-pgbouncer-audit.md
+++ b/docs/audits/2026-05-10-pgbouncer-audit.md
@@ -1,0 +1,247 @@
+# PostgreSQL Transaction-Mode Pooling Audit
+## 2026-05-10: Basis Protocol Neon Migration
+
+**Audit Context**: On 2026-05-10, Basis Protocol migrated production Postgres from Replit-managed Neon to a directly-owned Neon project using the `-pooler` endpoint (pgbouncer in transaction mode). This pooling mode multiplexes connections at the transaction boundary, making many session-level state changes unsafe. This audit identifies code patterns that do not survive transaction-mode pooling and may break unpredictably under load.
+
+**Key Constraint**: pgbouncer transaction mode resets ALL session state between transactions. Session-scoped settings (SET without LOCAL, session-state variables, prepared statements, advisory locks, LISTEN/NOTIFY, named cursors, etc.) are not preserved across physical connection reuses.
+
+---
+
+## Pattern 1: SET without LOCAL
+
+**Finding**: ✅ CLEAR
+- `app/database.py:167` correctly uses `SET LOCAL statement_timeout`
+- `app/ops/tools/health_checker.py:39` correctly uses `SET LOCAL statement_timeout`
+
+Both instances properly use `SET LOCAL`, which is scoped to the current transaction and survives pgbouncer multiplexing.
+
+**No findings in this category.**
+
+---
+
+## Pattern 2: Advisory Locks
+
+**Finding**: ✅ CLEAR
+
+Searched for `pg_advisory_lock`, `pg_try_advisory_lock`, etc. across all Python and SQL files.
+
+**Result**: No advisory locks found in codebase. Safe.
+
+---
+
+## Pattern 3: LISTEN / NOTIFY
+
+**Finding**: ✅ CLEAR
+
+Searched for LISTEN and NOTIFY PostgreSQL commands.
+
+**Result**: No LISTEN or NOTIFY usage found. Safe for transaction-mode pooling.
+
+---
+
+## Pattern 4: WITH HOLD Cursors
+
+**Finding**: ✅ CLEAR
+
+Searched for `WITH HOLD` and `withhold=True` patterns.
+
+**Result**: No WITH HOLD cursors found. All cursor usage is within a single transaction and released automatically on commit.
+
+---
+
+## Pattern 5: Named / Server-Side Cursors
+
+**Finding**: ✅ CLEAR
+
+Searched for `cursor(name=...)` patterns in `app/` directory.
+
+**Result**: No named cursors found. All cursor usage via standard `conn.cursor()` which creates unnamed (server-side) cursors but releases them within the transaction scope.
+
+---
+
+## Pattern 6: Temporary Tables Outside Transactions
+
+**Finding**: 🟡 SHOULD-FIX (1 finding)
+
+### Finding 6.1: Historical Price Backfill Temp Table
+- **File**: `app/services/historical_backfill.py:73–80`
+- **Code**:
+  ```python
+  cur.execute("""
+      CREATE TEMP TABLE _hp_stage (
+          coingecko_id VARCHAR(50),
+          ts TIMESTAMPTZ,
+          price DOUBLE PRECISION,
+          market_cap DOUBLE PRECISION,
+          volume_24h DOUBLE PRECISION
+      ) ON COMMIT DROP
+  """)
+  ```
+- **Risk**: The temp table is created and used within `with get_conn() as conn:`, which wraps the entire operation in a transaction with `conn.commit()` at line 100. **Actually safe** — the `ON COMMIT DROP` semantic applies within a single logical transaction. However, pgbouncer transaction mode means if the underlying physical connection is reused for the next caller before the first transaction commits, there could be edge-case race conditions if multiple concurrent requests hit this code path.
+- **Assessment**: Low risk because:
+  1. The temp table is created and dropped in a single transaction (lines 70–100).
+  2. `ON COMMIT DROP` is the correct semantic for transaction-mode safety.
+  3. No blocking risk to statement execution.
+- **Recommendation**: Current approach is safe. No changes required. Could document the transaction boundary for future maintainers.
+
+---
+
+## Pattern 7: Prepared Statements
+
+**Finding**: ✅ CLEAR
+
+- **Psycopg2 version**: `psycopg2-binary==2.9.10` (from `requirements.txt:14`)
+- **Auto-prepare behavior**: psycopg2 (version 2.x) does NOT auto-prepare statements. Only psycopg3 has the automatic `prepare_threshold` behavior that can conflict with pgbouncer transaction mode.
+- **Manual PREPARE**: No `PREPARE` or `EXECUTE` statements found in SQL files.
+- **Result**: Safe. No prepared-statement incompatibility.
+
+---
+
+## Pattern 8: Autocommit Assumptions
+
+**Finding**: 🔴 MUST-FIX (2 findings)
+
+### Finding 8.1: Setup Script Direct Connection
+- **File**: `setup.py:52–53`
+- **Code**:
+  ```python
+  conn = psycopg2.connect(db_url)
+  conn.autocommit = True
+  ```
+- **Risk**: This is a one-time setup script using a direct connection (not the pool), so it runs against the main (non-pooler) endpoint. Safe by design. However, if this script is ever used in production against the pooler endpoint (e.g., for hot-reload schema changes), it will fail because pgbouncer rejects `autocommit=True` at the session level.
+- **Assessment**: Low immediate risk (one-time setup), but fragile.
+- **Recommendation**: Document that this script must use the direct (non-pooler) endpoint. Add a comment or environment variable check.
+
+### Finding 8.2: Vacuum Worker VACUUM ANALYZE
+- **File**: `app/worker.py:2819`
+- **Code**:
+  ```python
+  _vac_conn = _vac_pg.connect(_vac_url)
+  _vac_conn.autocommit = True
+  ```
+- **Risk**: **CRITICAL**. This creates a direct connection and sets `autocommit = True` to run `VACUUM ANALYZE` on large tables (lines 2822–2844). If this connection ever routes through pgbouncer (e.g., if DATABASE_URL is changed to the pooler endpoint), the autocommit setting will fail. `VACUUM` cannot run in an explicit transaction in PostgreSQL, so this will error.
+- **Behavior today**: Likely working because the DATABASE_URL on 2026-05-10 points to the pooler endpoint, so this code path is probably using the pooler. The autocommit setting will be rejected by pgbouncer. **This is currently broken or bypassed.**
+- **Recommendation**: Either:
+  1. Connect to the direct (unpooled) Neon endpoint for VACUUM, or
+  2. Remove VACUUM from worker startup and rely on PostgreSQL autovacuum, or
+  3. Disable this code path entirely with a feature flag until a proper solution is in place.
+  4. **Do not rely on `conn.autocommit = True` for pgbouncer connections.**
+
+---
+
+## Pattern 9: Long-Running Queries / Transactions (>30s expected)
+
+**Finding**: 🟡 SHOULD-FIX (3 findings)
+
+### Finding 9.1: Historical Price Backfill Sync Loop
+- **File**: `app/services/historical_backfill.py:107–160+`
+- **Code**: `backfill_coin_sync()` fetches 90-day chunks from CoinGecko and calls `_store_chunk()` repeatedly.
+- **Risk**: The function processes multiple 90-day chunks in a loop (line 130), making HTTP requests between database operations. Each `_store_chunk()` call (line 37) wraps a full transaction including temp table creation, bulk insert, and merge (lines 70–100). Total latency could exceed 30s if:
+  - CoinGecko API is slow (30s timeout at line 146)
+  - Multiple coins being backfilled
+  - Network delays accumulate
+- **Assessment**: Moderate risk. Each transaction is bounded, but the overall backfill job could stall on slow API responses, holding a connection from the pool.
+- **Recommendation**: Add per-transaction timeout and implement exponential backoff for CoinGecko rate limiting. Consider breaking into smaller batches if a single coin backfill takes >30s.
+
+### Finding 9.2: PSI Protocol Backfill Per-Entry Inserts
+- **File**: `app/services/psi_backfill.py:112–143` (TVL) and `219–243` (token prices)
+- **Code**: 
+  ```python
+  for entry in tvl_history:  # line 112
+      execute("""INSERT INTO historical_protocol_data ...""")
+      records += 1
+  ```
+  ```python
+  for ts_ms, price in prices:  # line 219
+      execute("""INSERT INTO historical_protocol_data ...""")
+      records += 1
+  ```
+- **Risk**: These loops execute one INSERT per historical data point (potentially hundreds per protocol). Each `execute()` call goes through `get_cursor()` → `get_conn()` → transaction. For a protocol with 1000 days of history, this is 1000 separate transactions, each taking a pool slot briefly. Under high concurrency, this could cause pool saturation and statement timeouts (120s limit per transaction).
+- **Assessment**: **SHOULD-FIX**. Not an immediate crash, but inefficient and risky under load.
+- **Recommendation**: Batch the inserts using `psycopg2.extras.execute_values()` (similar to `historical_backfill.py:82–88`) to reduce from O(n) transactions to O(1).
+
+### Finding 9.3: Wallet Indexer Async Delete + Insert Loop
+- **File**: `app/indexer/pipeline.py:81–113` (holdings) and `116–150` (risk scores)
+- **Code**:
+  ```python
+  for h in holdings:
+      await execute_async("""DELETE FROM wallet_graph.wallet_holdings ...""")
+      await execute_async("""INSERT INTO wallet_graph.wallet_holdings ...""")
+  ```
+- **Risk**: For each wallet, there's a DELETE and INSERT transaction per holding (one per token). A wallet with 50 holdings = 100 transactions. If the indexer processes 1000 wallets in parallel, that's 100k concurrent transactions. This is not safe under pgbouncer's 30–50 connection limit and 120s statement timeout.
+- **Assessment**: **SHOULD-FIX** (probabilistic, but high-frequency code path).
+- **Recommendation**: Batch the delete/insert as a single upsert transaction per wallet:
+  ```sql
+  WITH updates AS (
+    INSERT INTO wallet_graph.wallet_holdings (wallet_address, token_address, ...) 
+    VALUES (...) ON CONFLICT (wallet_address, token_address, indexed_at::date)
+    DO UPDATE SET ... RETURNING *
+  ),
+  deletes AS (
+    DELETE FROM wallet_graph.wallet_holdings 
+    WHERE wallet_address = %s 
+      AND indexed_at::date = CURRENT_DATE
+      AND (wallet_address, token_address) NOT IN (SELECT ... FROM updates)
+  )
+  SELECT * FROM updates;
+  ```
+
+---
+
+## Pattern 10: Connection-Level Role / Search Path Setup
+
+**Finding**: ✅ CLEAR
+
+Searched for `SET ROLE` and `SET search_path` in Python files.
+
+**Result**: No connection-level role or search_path setup found in application code. Schema-qualified table references (e.g., `wallet_graph.wallets`) are hardcoded, making search_path unnecessary.
+
+---
+
+## Open Questions
+
+1. **Database URL Configuration**: Is `DATABASE_URL` pointing to the `-pooler` (transaction-mode) endpoint or the direct endpoint? Track A's statement_timeout fix assumes pooler. If setup.py or worker.py's VACUUM code runs against pooler with `autocommit=True`, it will fail.
+
+2. **VACUUM Necessity**: Is `VACUUM ANALYZE` on startup (worker.py:2813–2849) required for performance, or can autovacuum handle it? Transaction mode pooling cannot support explicit `VACUUM` without a dedicated unpooled connection.
+
+3. **Backfill Concurrency**: Are `backfill_protocol_tvl()` and `backfill_protocol_token()` called concurrently for multiple protocols? The per-insert loop pattern will cause O(n) transaction count.
+
+4. **Wallet Indexer Parallelism**: How many wallets are processed in parallel by `app/indexer/pipeline.py`? If >5, per-holding delete/insert will saturate the connection pool.
+
+---
+
+## Summary Table
+
+| Pattern | Category | File:Line | Issue | Severity |
+|---------|----------|-----------|-------|----------|
+| 8.1 | Autocommit | setup.py:52 | Direct conn with autocommit=True; fragile for pooler reuse | DEFER |
+| 8.2 | Autocommit | app/worker.py:2819 | VACUUM with autocommit=True; broken on pooler endpoint | **MUST-FIX** |
+| 6.1 | Temp Table | app/services/historical_backfill.py:73 | ON COMMIT DROP safe within transaction | DEFER |
+| 9.1 | Long TX | app/services/historical_backfill.py:107 | Per-chunk HTTP requests; potential stall >30s | SHOULD-FIX |
+| 9.2 | Long TX | app/services/psi_backfill.py:112–243 | Per-entry INSERT loop; O(n) transactions, batching needed | SHOULD-FIX |
+| 9.3 | Long TX | app/indexer/pipeline.py:81–150 | Per-holding delete+insert; 100k+ tx under load | SHOULD-FIX |
+
+---
+
+## Recommended Fix Priority
+
+1. **MUST-FIX (Blocking)**: 
+   - `app/worker.py:2819` — Move VACUUM to dedicated unpooled endpoint or remove.
+
+2. **SHOULD-FIX (Load-bearing)**:
+   - `app/services/psi_backfill.py:112–243` — Batch inserts (low effort, high impact).
+   - `app/indexer/pipeline.py:81–150` — Upsert per-wallet, not per-holding (medium effort).
+
+3. **DEFER (Fragile but non-blocking)**:
+   - `setup.py:52` — Document pooler endpoint restriction or add env var guard.
+   - `app/services/historical_backfill.py:107` — Already safe; add comment for future maintainers.
+
+---
+
+## Audit Completion
+
+**Scanned**: 507 Python/SQL files in /home/user/basis-hub  
+**Grep Patterns**: 1–10 per specification  
+**Total Findings**: 6 (1 MUST-FIX, 3 SHOULD-FIX, 2 DEFER)  
+**Safe Patterns**: 4 (Advisory locks, LISTEN/NOTIFY, WITH HOLD, Named cursors, Prepared statements, Role/search_path)
+


### PR DESCRIPTION
Wave-2 of the 2026-05-10 Neon migration audit. Track B (pgbouncer pattern audit) and Track E (Neon DB state) reports ship with this PR, alongside the three pgbouncer-transaction-mode fixes the Track B audit prioritized.

## Why

pgbouncer transaction mode (Neon's `-pooler` endpoint) multiplexes connections at the transaction boundary. Session-level state and per-row transaction patterns survive day-to-day load but degrade or fail under spikes. The 2026-05-10 incident exposed the libpq-startup-`options=` case (fixed in #130, hardened in #132); this PR addresses the next layer of patterns.

## Changes

1. **`app/worker.py`** — VACUUM ANALYZE now targets the direct (unpooled) Neon endpoint. New `_direct_db_url()` derives the unpooled host by stripping `-pooler` from `DATABASE_URL`. If the suffix isn't present we skip VACUUM and rely on autovacuum. The previous code opened a psycopg2 connection with `conn.autocommit = True` against the pooler, which pgbouncer rejects (and VACUUM can't run in a transaction anyway). **Pool itself stays on `-pooler`** — this is a single connection for a single startup task.

2. **`app/services/psi_backfill.py`** — `backfill_protocol_tvl()` and `backfill_protocol_token()` now batch into one `execute_values` call per chunk instead of one `execute()` per row. A typical 1000-day backfill went from 1000 transactions to 1.

3. **`app/indexer/pipeline.py`** — `_store_holdings()` now does one DELETE (today's rows for the wallet) + one bulk INSERT via `execute_values`, replacing the per-holding DELETE+INSERT loop. For a wallet with N holdings that's 2 transactions instead of 2N. Verified against all 4 call sites that `holdings` is the full current snapshot, so DELETE-all-today semantics match what callers want.

4. **`docs/audits/2026-05-10-pgbouncer-audit.md`** — Track B report.
5. **`docs/audits/2026-05-10-neon-state.md`** — Track E report (updated to reflect completed audit; sequence sanity ✅).

## Manual follow-ups (out of scope for this PR)

The Neon MCP doesn't expose project-setting mutations, so these are console-only:

- Bump `history_retention_seconds` from 21600 (6h) to 604800 (7d). Supports point-in-time recovery and branch rewinds during incident response.
- Set compute `suspend_timeout_seconds` to 0 (disabled). Eliminates routine cold starts; the new `init_pool()` retry in #132 tolerates them, but eliminating at source is better.

Both tracked in `docs/audits/2026-05-10-neon-state.md` § "Recommended follow-ups".

## Out of scope

Per the Track B audit's own classification:
- `setup.py:52` autocommit fragility — DEFER, one-time setup script.
- `historical_backfill.py` temp-table pattern — DEFER, already transaction-mode-safe.
- `historical_backfill.py` per-chunk HTTP stall — separate concern unrelated to pooling.

## Test plan

- [ ] Confirm Scoring-Worker startup logs show either `Database pool initialized` followed by `VACUUM ANALYZE complete` (direct URL derivable) OR `VACUUM ANALYZE skipped: direct (unpooled) DATABASE_URL not derivable` (URL malformed; falls back to autovacuum).
- [ ] Trigger a basis-backfill-psi run, confirm one TVL insert per chunk instead of hundreds, and DB row count matches expectations.
- [ ] Run wallet indexer batch over ~100 wallets; confirm `wallet_holdings` updates are atomic per-wallet (no half-state where some tokens are today's and some are yesterday's).
- [ ] After merge, bump Neon retention to 7d and disable compute autosuspend via the Neon console.

## Sequencing

This PR is independent of #132 (Track A pt2/pt3) — they don't share files except `app/worker.py` doesn't conflict (pt2 didn't touch the VACUUM helper). Either can land first.

https://claude.ai/code/session_01T9JSBB6E4rxjLUssCLk5X3

---
_Generated by [Claude Code](https://claude.ai/code/session_01T9JSBB6E4rxjLUssCLk5X3)_