### PR TITLE
docs: stage 2026-05-10 Neon incident canon updates for manual copy

### DIFF
--- a/docs/basis_protocol_v9_9_constitution_amendment.md
+++ b/docs/basis_protocol_v9_9_constitution_amendment.md
@@ -1,0 +1,138 @@
+# Constitution Amendment v9.9 — Pooled Connection Contract
+
+**Date:** 2026-05-11
+**Status:** Proposed (Wave-2 of the 2026-05-10 Neon migration audit)
+**Supersedes:** (none — establishes a new architectural constraint surfaced by the 2026-05-10 incident)
+
+## Forcing function
+
+On 2026-05-10, Basis migrated production Postgres from the Replit-managed
+Neon integration to a directly-owned Neon project. Every Python service
+crash-looped at startup with:
+
+> ERROR: unsupported startup parameter in options: statement_timeout.
+> Please use unpooled connection or remove this parameter from the startup package.
+
+Root cause: `app/database.py::init_pool()` passed
+`options="-c statement_timeout=120000"` as a libpq startup parameter to the
+new pooler endpoint. Neon's pooler is pgbouncer in transaction mode, which
+rejects any libpq startup `options`. Replit-managed Neon had hidden this
+incompatibility because its DATABASE_URL pointed at the direct (unpooled)
+endpoint by default.
+
+The fix (PR #130) is mechanical. The architectural lesson is not: the
+choice of pooler endpoint imposes constraints on every line of database
+code in the repo. We are committing to those constraints in this
+amendment so future contributors can ship safely without rediscovering
+them on a production deploy.
+
+## Decision
+
+**Every Postgres connection in the Basis hub MUST be assumed to be
+multiplexed through pgbouncer in transaction mode**, unless it is
+explicitly routed to the direct (unpooled) endpoint via the
+`_direct_db_url()` helper in `app/worker.py`.
+
+This means a checkout returned by `app.database.get_conn()`:
+
+1. **Cannot rely on session-level state surviving across transactions.**
+   Each `BEGIN ... COMMIT` may be served by a different physical server
+   connection. Settings that survive include only those set inside the
+   current transaction (`SET LOCAL`) or as part of the connect-time URL.
+   Settings that do NOT survive include `SET` without `LOCAL`,
+   `SET SESSION`, `autocommit = True` toggled mid-flight,
+   session-scoped advisory locks (`pg_advisory_lock` without `_xact`),
+   `WITH HOLD` cursors, persistent prepared statements
+   (psycopg3's `prepare_threshold` auto-prepare), named cursors held
+   across commits, and `LISTEN` / `NOTIFY`.
+
+2. **Cannot run statements that are themselves disallowed in
+   transactions.** `VACUUM`, `CLUSTER`, `CREATE DATABASE`,
+   `ALTER SYSTEM`, etc. cannot run via the pooler. They must use the
+   direct endpoint.
+
+3. **Should hold a transaction for as short a time as possible.** Each
+   transaction occupies a slot in the pool (`max_conn=50` per service ×
+   13 services = 650 client slots). Per-row `execute()` loops scale as
+   O(n) transactions and should be replaced with
+   `psycopg2.extras.execute_values()` (or equivalent COPY for large
+   batches).
+
+## Pooled connection contract
+
+Code calling `get_conn()` / `get_cursor()` MAY rely on:
+
+- The connection is open, healthy, and has TCP keepalives enabled.
+- `statement_timeout` is set to 120000 ms for the duration of the
+  current transaction via `SET LOCAL` at checkout.
+- The transaction will be committed if the block exits cleanly, rolled
+  back if it raises.
+
+Code calling `get_conn()` MUST NOT rely on:
+
+- Session-level GUCs persisting across `commit()` / `rollback()`.
+- Server-side state (temp tables, prepared statements, advisory locks)
+  outliving the current transaction.
+- A specific physical connection — connections are pooled and
+  multiplexed.
+
+## When to use the direct (unpooled) endpoint
+
+The direct endpoint is the same host without the `-pooler` suffix. It is
+appropriate for:
+
+- `VACUUM` / `ANALYZE` / `CLUSTER` / other transaction-incompatible
+  maintenance.
+- Migrations that must hold session-level locks or run
+  `CREATE INDEX CONCURRENTLY`.
+- One-shot administrative scripts (`setup.py`, ad-hoc backfills)
+  where the convenience of session-level state outweighs the cost of
+  the dedicated connection.
+- Long-running diagnostics where session-level state (named cursors,
+  WITH HOLD) is genuinely needed.
+
+The direct endpoint MUST NOT be used for the app's connection pool
+(`init_pool`), worker scoring cycles, or per-request work. Those stay
+on `-pooler`.
+
+The canonical helper is `app/worker.py::_direct_db_url()` — it derives
+the direct URL by stripping `-pooler` from `DATABASE_URL` and returns
+empty string if derivation fails, so callers can fall back gracefully.
+
+## Enforcement
+
+1. Code review: any new file that opens a `psycopg2.connect(...)` (vs
+   going through `get_conn()`) should justify why in a code comment and
+   reference this amendment.
+
+2. A future pre-commit lint can grep for the patterns Track B audited
+   (`SET ` without `LOCAL`, `pg_advisory_lock` without `_xact`,
+   `LISTEN`, `NOTIFY`, `WITH HOLD`, `prepare_threshold`, named cursors)
+   and warn. Not in scope for this amendment.
+
+3. The pgbouncer audit doc at
+   `docs/audits/2026-05-10-pgbouncer-audit.md` is the standing reference
+   for what does and doesn't work.
+
+## Scope
+
+In scope: all Python services that talk to Postgres
+(`app/server.py`, `app/worker.py`, `app/indexer/*`, `app/services/*`,
+backfill scripts, ops tools, governance crawler).
+
+Out of scope: the Solidity contracts, the keeper TypeScript service
+(no DB), the React frontend (no DB), dbt
+(reads via `DATABASE_URL` parsing — same pooler constraint applies,
+covered by Track C's `app/discovery.py::_ensure_pg_env` fix).
+
+## References
+
+- Track A pt1: `basis-hub` PR #130 (immediate fix, merged 2026-05-11).
+- Track A pt2: `basis-hub` PR #132 (deploy safety: retry,
+  fail-loud, `/healthz`, `/readyz`).
+- Track B audit: `docs/audits/2026-05-10-pgbouncer-audit.md`.
+- Track C: `basis-hub` PR #131 (Replit-ism purge, merged
+  2026-05-11).
+- Track E audit: `docs/audits/2026-05-10-neon-state.md`.
+- Wave-2 fixes: `basis-hub` PR #133 (VACUUM unpooled, batch
+  inserts).

--- a/docs/canon-update-2026-05-10.md
+++ b/docs/canon-update-2026-05-10.md
@@ -1,0 +1,119 @@
+# Canon Update Proposal — 2026-05-10 Neon Migration
+
+**Purpose:** drafts of the changes that need to land in `basis-protocol/canon`
+to reflect post-cutover reality. My GitHub MCP is restricted to
+`basis-protocol/basis-hub`, so I cannot push these to canon directly —
+copy them over manually. Tag the canon commit `transition-2026-05-10`.
+
+---
+
+## 1. PROJECT_INSTRUCTIONS — proposed diffs
+
+These are the deltas the user's Track F prompt called out. Numbers are
+verified against the live Railway project (`valiant-celebration`) and the
+new Neon project (`small-scene-57890564`) as of 2026-05-11 02:00 UTC.
+
+### Services
+
+- Service count: **13** (was: documented as "5 services"). Live list:
+  api-server, Scoring-Worker, Keeper, basis-state, basis-provenance,
+  basis-backfill-{tti, cxri, vsri, dohi, bri, lsti, rpi, psi}.
+- 4 of the backfills (tti, dohi, bri, rpi) currently in REMOVED status,
+  `restart_policy: NEVER` — intentionally paused one-shot jobs that
+  completed Apr 22. They count toward "services exist" but not toward
+  "services live".
+- Service naming: the spoke that handles provenance is named
+  **`basis-provenance`** (deploys from `basis-protocol/basis-provenance`,
+  Dockerfile `/Dockerfile.prover`). If the canon doc currently calls it
+  "prover", rename to `basis-provenance`.
+
+### Repos
+
+- `basis-state` and `basis-provenance` are **separate repos** with their
+  own main branches. They are pure spokes — they talk to the hub via the
+  API and do not have `DATABASE_URL` env vars. They were unaffected by
+  the libpq-options bug directly; they were broken transitively because
+  the api-server was down.
+
+### Database
+
+Add a new line / section:
+
+> **Database:** Neon Postgres, owned directly by Basis
+> (org `org-aged-brook-05137723`, project `BasisProtocol` /
+> `small-scene-57890564`), pg17, region `aws-us-east-2`. Migrated
+> 2026-05-10 from the Replit-managed Neon integration.
+
+### Replit decommission
+
+Keep "in progress" until 2026-05-17, then flip to "complete".
+basis-hub PR #131 (merged 2026-05-11) deleted the last 5 Replit-only
+files from the repo (`.replit`, `replit.md`, `pyproject.toml`,
+`uv.lock`, `.streamlit/config.toml`) and updated 12 docs.
+
+### Dev environment
+
+The Track C audit's stated goal was "GitHub Codespaces once Track C and
+Codespaces setup are both complete". Track C is done; Codespaces setup
+has **not** been verified by me. Keep "transition pending" until
+someone confirms a fresh Codespace boots cleanly with the new
+`.env.example`. Per canon-discipline rules, don't write "Codespaces
+ready" until it literally is.
+
+---
+
+## 2. Constitution amendment v9.9
+
+Drafted in `basis-protocol/basis-hub` at:
+`docs/basis_protocol_v9_9_constitution_amendment.md`
+
+Summary: documents the pooled-connection contract — what code can
+assume about a `get_conn()` checkout, which Postgres features are
+off-limits in transaction-mode pooling, and when to use the direct
+(unpooled) endpoint. References the 2026-05-10 incident as the
+forcing function.
+
+**To copy:** read
+`basis-protocol/basis-hub/docs/basis_protocol_v9_9_constitution_amendment.md`
+and commit as
+`basis-protocol/canon/<wherever-amendments-live>/basis_protocol_v9_9_constitution_amendment.md`.
+The file is self-contained.
+
+---
+
+## 3. Punchlist entry
+
+Drafted in `basis-protocol/basis-hub` at:
+`docs/punchlist_2026-05-10_neon_incident.md`
+
+Includes date, root cause, all 6 tracks (A–F) and their status, the
+two open hardening PRs (#132, #133), and the manual follow-ups (Neon
+console retention + autosuspend, canon copy, Claude.ai project-knowledge
+re-upload). Self-contained.
+
+---
+
+## 4. Open caveat for the canon writer
+
+Per canon-discipline rules (not aspirational):
+
+- Don't write "Codespaces complete" until verified.
+- Don't write "Replit decommissioned" until 2026-05-17 has passed.
+- Don't write "Wave-2 complete" until PR #133 is merged.
+- Don't write "deploy-safety complete" until PR #132 is merged.
+
+These are tracked in the punchlist entry; flip them there when each
+lands so the canon doc and the punchlist don't drift.
+
+---
+
+## Why this is a proposal not a push
+
+The harness running this session restricts my GitHub MCP to
+`basis-protocol/basis-hub`. I cannot create branches, commits, or PRs
+on `basis-protocol/canon`. The three files above are the canon-bound
+deliverables, staged in the hub for human-mediated copy.
+
+If you want me to push directly to canon in a future session, grant
+the harness the canon repo as well and re-run Track F. Otherwise,
+copying these three files is the close-out for Track F.

--- a/docs/punchlist_2026-05-10_neon_incident.md
+++ b/docs/punchlist_2026-05-10_neon_incident.md
@@ -1,0 +1,71 @@
+# Punchlist Entry — 2026-05-10 Neon migration incident
+
+**Incident date:** 2026-05-10 ~22:48 UTC (api-server deploy 54967f6a)
+**Root cause identified:** 2026-05-11 ~00:50 UTC
+**Production restored:** 2026-05-11 ~01:03 UTC (api-server on PR #130)
+**Severity:** P0 (all 13 Railway services unable to connect to DB; api-server returned 500 on every request).
+**Detection failure:** Railway marked the breaking deploy as SUCCESS because Uvicorn bound the port despite `init_pool()` raising. Caught by external observation, not internal monitoring.
+
+## Root cause
+
+`app/database.py::init_pool()` passed
+`options="-c statement_timeout=120000"` as a libpq startup parameter to
+`ThreadedConnectionPool`. The new owned-Neon `DATABASE_URL` points at the
+`-pooler` endpoint (pgbouncer, transaction mode), which rejects all libpq
+startup `options`:
+
+> ERROR: unsupported startup parameter in options: statement_timeout.
+> Please use unpooled connection or remove this parameter from the startup package.
+
+`init_pool()` raised; every downstream `get_conn()` raised the cascading
+`RuntimeError: Database pool not initialized. Call init_pool() first.`
+
+The Replit-managed Neon integration had hidden this incompatibility — its
+DATABASE_URL pointed at the direct (unpooled) endpoint by default. The
+owned-Neon `DATABASE_URL` points at `-pooler`, which is correct for
+connection-efficiency but exposed the latent libpq-options bug.
+
+## Tracks
+
+| Track | Owner | Scope | Status | Reference |
+|---|---|---|---|---|
+| A pt1 | CC | Drop libpq `options=`, apply timeout via `SET LOCAL` in `get_conn()` | ✅ merged | basis-hub#130 (`7b6828a`) |
+| A pt2 | CC | `init_pool` retry (3× exp backoff), fail-loud `sys.exit(1)` before port bind, `/healthz`, `/readyz`, Railway `healthcheckPath` | 🟡 open | basis-hub#132 |
+| A pt3 | CC | Migration runner safety — no change needed; 001 already idempotent, `migrations` table self-bootstraps, runner skips applied | ✅ verified | (no PR — folded into #132 commit message) |
+| B | CC | pgbouncer pattern audit across repo | ✅ report | `docs/audits/2026-05-10-pgbouncer-audit.md` |
+| C | CC | Replit-ism purge (5 files deleted, 12 docs updated, latent `_ensure_pg_env` bug fixed) | ✅ merged | basis-hub#131 (`2897ede`) |
+| D | CC | Railway env-var inventory across 13 services | ✅ done | All clean. No PG*, no REPL*, no broken refs. |
+| E | CC | Neon DB state verification (sequences, extensions, etc.) | ✅ report | `docs/audits/2026-05-10-neon-state.md`. No behind sequences. Write traffic safe. |
+| F | CC | Canon doc update | 🟡 drafted | This file + `basis_protocol_v9_9_constitution_amendment.md` (in basis-hub; copy to canon manually) |
+| Wave-2 | CC | VACUUM unpooled endpoint, batch backfill/indexer inserts | 🟡 open | basis-hub#133 |
+
+## Resolution status (as of 2026-05-11 02:00 UTC)
+
+- **Production restored:** ✅ all DB-using services on the fix commit and confirmed healthy via logs (`Database pool initialized`, normal worker activity).
+- **6 services auto-deployed the fix:** api-server, Scoring-Worker, Keeper, basis-backfill-cxri, basis-backfill-vsri, basis-backfill-lsti.
+- **3 services required force-redeploy from main HEAD:** basis-state and basis-provenance (separate repos; rebuilt from their own main), basis-backfill-psi (wired to `basis-protocol/basis-hub` repo so it auto-deploys going forward).
+- **4 backfill services intentionally paused:** basis-backfill-tti, dohi, bri, rpi (`restart_policy: NEVER`, completed April 22, not affected by incident).
+- **DB state verified clean:** no behind sequences, extensions correct, schemas correct, row counts consistent with pre-migration volumes. Write traffic safe.
+
+## Hardening pending (open PRs)
+
+1. **basis-hub#132** — deploy-safety PR. Once merged, a future `init_pool()` failure will be retried 3× automatically, then crash the process before port bind, then trigger Railway's `restartPolicyType: ON_FAILURE` rollback. The detection-failure mode from this incident cannot reproduce.
+
+2. **basis-hub#133** — Wave-2 PR. Removes the three remaining pgbouncer-unsafe patterns from worker startup + PSI backfill + wallet indexer. Production-functional today but probabilistically unsafe under load spikes.
+
+## Manual follow-ups (out of scope for PRs)
+
+- **Neon console:** bump `history_retention_seconds` from 21600 (6h) to 604800 (7d).
+- **Neon console:** set compute `suspend_timeout_seconds` to 0 (disabled) to eliminate routine cold starts.
+- **Canon repo:** copy `basis_protocol_v9_9_constitution_amendment.md` + this punchlist entry from basis-hub `docs/` to the canon repo. Tag commit `transition-2026-05-10`.
+- **Claude.ai project knowledge:** manual re-upload of updated CLAUDE.md (Shlok; not automatable from CC).
+
+## Lessons
+
+1. **Replit-managed Neon hid assumptions.** Auto-injected env vars, integration variable refs, libpq option handling, session-pooling guarantees — none of those survive the move to owned Neon. The Wave-2 audit (Tracks B, C, D, E) was the right response: sweep the whole surface rather than just fix the symptom.
+
+2. **Deploy success != deploy works.** Railway's port-bind probe was satisfied even with a dead pool. The healthcheck path (#132) closes this.
+
+3. **Pooler-mode constraints belong in the constitution.** Amendment v9.9 documents the contract.
+
+4. **Sequence sanity is the scariest migration risk.** Even though it didn't bite us here, the audit (Track E §6) confirms the migration was clean. Future Postgres migrations should run this check before write traffic resumes.


### PR DESCRIPTION
Track F of the 2026-05-10 Neon migration audit, drafted as files in the hub for manual copy to `basis-protocol/canon`. Claude Code's GitHub MCP for this session is restricted to `basis-hub`, so I cannot push these directly to the canon repo.

## Files

1. **`docs/basis_protocol_v9_9_constitution_amendment.md`** — proposed amendment v9.9 documenting the pooled-connection contract: what code can assume about a `get_conn()` checkout, which Postgres features are off-limits under pgbouncer transaction mode, and when to use the direct (unpooled) endpoint via `_direct_db_url()`. References the 2026-05-10 incident as the forcing function.

2. **`docs/punchlist_2026-05-10_neon_incident.md`** — incident punchlist entry. Root cause, all 6 tracks (A–F) with status, the two open hardening PRs (#132 deploy safety, #133 Wave-2 pgbouncer fixes), and manual follow-ups.

3. **`docs/canon-update-2026-05-10.md`** — pointer document with proposed `PROJECT_INSTRUCTIONS` deltas (service count 5→13, `basis-provenance` name confirmation, owned-Neon database line, Replit decommission timing, dev-environment honesty about Codespaces not yet verified). Lists open caveats per canon-discipline (no aspirational statements).

## What to do with this PR

Two options:

- **Merge as-is.** The three files live in `basis-hub/docs/` as the working record of Track F. Someone then copies them to `basis-protocol/canon` separately. Lowest friction.
- **Use as a draft and don't merge.** Copy the contents into canon, then close this PR without merging.

Either way, the canon-side commit should be tagged `transition-2026-05-10` per the original Track F spec.

## Caveats (worth honoring before publishing to canon)

- Don't write "Codespaces complete" until a fresh Codespace has been verified to boot with the new `.env.example`. Track C is done; Codespaces wiring is not in my scope.
- Don't write "Replit decommissioned" until 2026-05-17 has passed.
- Don't write "Wave-2 complete" until PR #133 is merged.
- Don't write "deploy-safety complete" until PR #132 is merged.

These are tracked in the punchlist entry — flip them there when each lands so the canon doc and the punchlist don't drift.

https://claude.ai/code/session_01T9JSBB6E4rxjLUssCLk5X3

---
_Generated by [Claude Code](https://claude.ai/code/session_01T9JSBB6E4rxjLUssCLk5X3)_