### PR TITLE
hotfix: bump healthcheckTimeout 10s → 300s (api-server needs ~34s to boot)

### DIFF
--- a/railway.json
+++ b/railway.json
@@ -4,6 +4,6 @@
     "restartPolicyType": "ON_FAILURE",
     "restartPolicyMaxRetries": 5,
     "healthcheckPath": "/healthz",
-    "healthcheckTimeout": 10
+    "healthcheckTimeout": 300
   }
 }


### PR DESCRIPTION
Hotfix for #132. api-server takes ~34s to boot (migration check + import side-effects + route registration), and my 10s `healthcheckTimeout` from #132 killed both #132 and #133 deploys before the app finished startup.

Logs:
```
02:09:03  Healthcheck started (path=/healthz, retry=10s)
02:09:13  1/1 replicas never became healthy! Healthcheck failed!
02:09:14  Deploy FAILED
02:09:33  [INFO] main: Database ready: 36 stablecoins registered
02:09:37  INFO: Application startup complete.
```

300s gives generous headroom for cold starts and the migration check.

## Known side-effects (not addressed in this hotfix)

- Scoring-Worker and other non-web services still get a healthcheck applied to them because `railway.json` settings cascade. Their /healthz path doesn't exist (they don't run uvicorn), so they show FAILED in the Railway dashboard even though their actual workload is running. Fix is per-service config in Railway, not in this repo. **Wave-3 cleanup, not blocking.**
- `app/server.py` startup hook logs `cannot access local variable 'asyncio'` for some optional sub-modules. Pre-existing pattern (local `import asyncio` inside a sub-block shadows the module-level import). Caught by surrounding `try`/`except`, non-fatal. Wave-3 cleanup.

## Merge urgency

High — without this, api-server is on the pre-#132 deploy (still healthy thanks to #130, but lacking the deploy-safety hardening from #132 and the Wave-2 pgbouncer fixes from #133).

https://claude.ai/code/session_01T9JSBB6E4rxjLUssCLk5X3

---
_Generated by [Claude Code](https://claude.ai/code/session_01T9JSBB6E4rxjLUssCLk5X3)_