### PR TITLE
hotfix: move healthcheck from repo-wide railway.json to per-service (api-server only)

### DIFF
--- a/railway.json
+++ b/railway.json
@@ -2,8 +2,6 @@
   "$schema": "https://railway.com/railway.schema.json",
   "deploy": {
     "restartPolicyType": "ON_FAILURE",
-    "restartPolicyMaxRetries": 5,
-    "healthcheckPath": "/healthz",
-    "healthcheckTimeout": 300
+    "restartPolicyMaxRetries": 5
   }
 }


### PR DESCRIPTION
Fixes a deploy regression introduced by #132 and inadequately patched by #135.

## What broke

`railway.json` at the repo root applies to **every** Railway service deploying from this repo. Of the 11 services that do so, only api-server is a FastAPI process serving `/healthz`:

| Service | Process | HTTP server? |
|---|---|---|
| api-server | FastAPI / Uvicorn | ✅ /healthz |
| Scoring-Worker | Python forever-loop | ❌ |
| Keeper | `npx tsx keeper/index.ts` | ❌ |
| basis-backfill-{cxri, vsri, lsti, psi} | one-shot Python | ❌ |
| basis-backfill-{tti, dohi, bri, rpi} | one-shot Python (paused) | ❌ |

After #132, every non-api service got `ConnectionRefused` on `/healthz`, exhausted the retry window, and was marked FAILED. Railway's `ON_FAILURE` policy then rolled them back to their previous SUCCESS deploys (commit `2897ede`, Track C). So the Wave-2 pgbouncer fixes from #133 are merged on main but **not actually running on the worker** — that's the largest live risk.

## What this PR does

1. Removes `healthcheckPath` and `healthcheckTimeout` from the repo's `railway.json`.
2. Per-service config already applied via Railway API (`updateServiceTool`): api-server has `healthcheckPath=/healthz, healthcheckTimeout=300`; every other service has no healthcheck.

Verified via `environmentSearchTool`:
- ✅ api-server: `healthcheckPath=/healthz, healthcheckTimeout=300`
- ✅ Scoring-Worker, Keeper, basis-backfill-* (7 services): no healthcheck config
- basis-state, basis-provenance: separate repos, unaffected

## Verification after merge

1. Scoring-Worker redeploy → SUCCESS; logs should show `Database pool initialized` + worker activity.
2. Keeper redeploy → SUCCESS.
3. basis-backfill-* redeploys → SUCCESS (or successful one-shot exit).
4. api-server `/healthz` still returns 200.
5. `state_attestations` table should resume fresh writes — worker has been on pre-Wave-2 code for ~1h.

## Out of scope

- Adding actual liveness servers to worker/keeper (option B from triage). Not needed for unblocking deploys; revisit if we want runtime liveness signal beyond "process started."
- The Wave-3 nit about `cannot access local variable 'asyncio'` in `app/server.py` startup hook (pre-existing, non-fatal, caught by try/except).

https://claude.ai/code/session_01T9JSBB6E4rxjLUssCLk5X3

---
_Generated by [Claude Code](https://claude.ai/code/session_01T9JSBB6E4rxjLUssCLk5X3)_