### PR TITLE
fix(psi): always attest psi_discoveries — gate kept it silent 29 days

### DIFF
--- a/app/enrichment_worker.py
+++ b/app/enrichment_worker.py
@@ -278,26 +278,31 @@ async def _run_psi_expansion():
         "synced": synced, "discovered": discovered,
         "enriched": enriched, "promoted": promoted,
     }
-    # Attest PSI discovery state when new protocols discovered or promoted
-    if discovered or promoted:
+    # Attest PSI discovery state every cycle, even when discovered=0 and
+    # promoted=0. The protocol universe stabilizes — once the registry is
+    # full, new-discovery counts stay at 0 indefinitely. Gating on
+    # `discovered or promoted` made the domain go silent for 29 days
+    # (April 12 → May 11). An attestation of `{discovered: 0, promoted: 0}`
+    # is a valid statement: "I ran the discovery cycle, registry is steady."
+    # That keeps the domain fresh and proves the system is alive.
+    try:
+        from app.state_attestation import attest_state
+        await asyncio.to_thread(
+            attest_state,
+            "psi_discoveries",
+            [{"synced": synced, "discovered": discovered, "enriched": enriched, "promoted": promoted}],
+        )
+    except Exception as ae:
+        logger.error(f"[enrichment] psi_discoveries attestation failed: {ae}")
         try:
-            from app.state_attestation import attest_state
-            await asyncio.to_thread(
-                attest_state,
-                "psi_discoveries",
-                [{"synced": synced, "discovered": discovered, "enriched": enriched, "promoted": promoted}],
+            from app.worker import _record_cycle_error
+            _record_cycle_error(
+                error_type="psi_discoveries_attestation_failure",
+                error_message=str(ae),
+                cycle_phase="psi_expansion",
             )
-        except Exception as ae:
-            logger.error(f"[enrichment] psi_discoveries attestation failed: {ae}")
-            try:
-                from app.worker import _record_cycle_error
-                _record_cycle_error(
-                    error_type="psi_discoveries_attestation_failure",
-                    error_message=str(ae),
-                    cycle_phase="psi_expansion",
-                )
-            except Exception:
-                pass
+        except Exception:
+            pass
     return result
 
 

--- a/tests/test_psi_discoveries_attestation.py
+++ b/tests/test_psi_discoveries_attestation.py
@@ -30,8 +30,14 @@ def test_psi_expansion_attests_when_discovered_or_promoted():
         ]
 
 
-def test_psi_expansion_skips_attestation_when_nothing_discovered():
-    """When both discovered=0 and promoted=0, attest_state should NOT be called."""
+def test_psi_expansion_attests_every_cycle_even_when_nothing_discovered():
+    """When discovered=0 and promoted=0, attest_state must STILL be called.
+
+    Regression: gating on (discovered or promoted) made the domain go silent
+    for 29 days once the protocol registry stabilized. An attestation of
+    `{discovered: 0, promoted: 0}` is the canonical statement that the
+    discovery cycle ran and the registry is steady.
+    """
     mock_attest = MagicMock()
 
     with (
@@ -47,4 +53,9 @@ def test_psi_expansion_skips_attestation_when_nothing_discovered():
         result = asyncio.run(_run_psi_expansion())
 
         assert result == {"synced": 2, "discovered": 0, "enriched": 0, "promoted": 0}
-        mock_attest.assert_not_called()
+        mock_attest.assert_called_once()
+        call_args = mock_attest.call_args
+        assert call_args[0][0] == "psi_discoveries"
+        assert call_args[0][1] == [
+            {"synced": 2, "discovered": 0, "enriched": 0, "promoted": 0}
+        ]


### PR DESCRIPTION
Cluster-staleness bug 1 of 3 from the May 11 triage. psi_discoveries has been stuck at April 12 in `state_attestations` for 29 days.

## Root cause

PR #91 relocated psi_discoveries attestation into the enrichment pipeline (Wave A of the May 5 punchlist). The call survived but kept the same gate the old call had:

```python
if discovered or promoted:
    attest_state("psi_discoveries", ...)
```

Once the protocol registry stabilized — and it did, by April 12 — both counts are 0 every cycle. The enrichment task still runs every 24h (its `gate_check` fires correctly); it just decides every cycle that zero new protocols means nothing to attest. So the row never advances.

Compare with the other 3 cluster domains PR #91 relocated:

| domain | gate | satisfied every cycle? |
|---|---|---|
| rpi_components | `if result:` (recomputed scores) | ✅ |
| divergence_signals | `if signals:` (always generated) | ✅ |
| provenance | `if prov_rows:` (last 2h window) | ✅ |
| **psi_discoveries** | `if discovered or promoted:` (NEW things found?) | ❌ (after registry stabilizes) |

The other three have gates that effectively act as null-checks. `discovered or promoted` is a change-detector — fundamentally different. PR #100 closed 11 similar always-attest gaps but psi_discoveries wasn't in that list.

## Fix

Drop the gate. Attest unconditionally with the current state:

```python
{synced: N, discovered: 0, promoted: 0, enriched: 0}
```

is a valid statement — "I ran the discovery cycle, registry is steady." That's what attestations exist for: proving liveness, not signaling change. Hash diffs across rows tell us when something actually changed; row freshness tells us the system is alive.

The regression test in `tests/test_psi_discoveries_attestation.py` literally codified the bug (`mock_attest.assert_not_called()` when discovered=0). Inverted to assert the always-attest invariant.

## Out of scope

`main.py:241-247` has a duplicate of the same gate in the legacy worker-thread path. Left untouched here — once the enrichment task fires every 24h, psi_discoveries stays fresh regardless of the main.py path. The redundant daily-loop block is a separate cleanup.

Bugs 2 (exchange_trust_ratio CoinGecko parser) and 3 (9-domain staleness tail) follow the same triage discipline — one diagnostic at a time. Will land separately.

## Verification after merge

1. Scoring-Worker redeploys.
2. Within 24h, the slow-cycle `psi_expansion` task fires.
3. `SELECT * FROM state_attestations WHERE domain='psi_discoveries' ORDER BY attested_at DESC LIMIT 5;` shows a row from today.
4. Coherence sweep stops flagging psi_discoveries.

https://claude.ai/code/session_01T9JSBB6E4rxjLUssCLk5X3

---
_Generated by [Claude Code](https://claude.ai/code/session_01T9JSBB6E4rxjLUssCLk5X3)_