### PR TITLE
fix(coingecko): exchange_trust_ratio — distinguish "field absent" from zero

### DIFF
--- a/app/collectors/coingecko.py
+++ b/app/collectors/coingecko.py
@@ -33,6 +33,27 @@ def _headers() -> dict:
     return h
 
 
+def _has_trust_signal(ticker: dict) -> bool:
+    """Return True iff CoinGecko provided ANY usable trust signal on this ticker.
+
+    Distinguishes "field absent" (signal=None, both keys missing or null) from
+    "low trust" (signal=red, or numeric rank>10). The former should NOT count
+    toward the denominator of exchange_trust_ratio — we have no information,
+    not bad information.
+
+    Signals we consider present:
+      - trust_score is a known string value ("green", "yellow", "red")
+      - trust_score_rank is a finite numeric value
+    """
+    ts = ticker.get("trust_score")
+    if ts in ("green", "yellow", "red"):
+        return True
+    rank = ticker.get("trust_score_rank")
+    if isinstance(rank, (int, float)):
+        return True
+    return False
+
+
 def _is_high_trust(ticker: dict) -> bool:
     """Check if a ticker is from a high-trust exchange.
 
@@ -499,16 +520,41 @@ async def collect_market_activity_components(
     })
     
     # Trust Score Ratio
+    #
+    # CoinGecko's response shape for tickers has drifted: for some assets
+    # (notably USDC on 2026-05-11) both `trust_score` and `trust_score_rank`
+    # are null on every ticker. The previous implementation divided
+    # high_trust by len(tickers) regardless, producing raw=0/normalized=0 —
+    # which falsely scored the asset as "no exchange has high trust" when the
+    # truth is "CoinGecko didn't tell us." Distinguish those two cases:
+    # divide only by tickers that have a usable trust signal, and if NONE do,
+    # mark the reading stale instead of emitting a misleading zero.
     if tickers:
-        high_trust = sum(1 for t in tickers if _is_high_trust(t))
-        trust_ratio = high_trust / len(tickers)
-        components.append({
-            "component_id": "exchange_trust_ratio",
-            "category": "market_activity",
-            "raw_value": round(trust_ratio, 4),
-            "normalized_score": round(trust_ratio * 100, 2),
-            "data_source": "coingecko",
-        })
+        rated = [t for t in tickers if _has_trust_signal(t)]
+        if rated:
+            high_trust = sum(1 for t in rated if _is_high_trust(t))
+            trust_ratio = high_trust / len(rated)
+            components.append({
+                "component_id": "exchange_trust_ratio",
+                "category": "market_activity",
+                "raw_value": round(trust_ratio, 4),
+                "normalized_score": round(trust_ratio * 100, 2),
+                "data_source": "coingecko",
+            })
+        else:
+            components.append({
+                "component_id": "exchange_trust_ratio",
+                "category": "market_activity",
+                "raw_value": None,
+                "normalized_score": None,
+                "data_source": "coingecko",
+                "is_stale": True,
+                "error_message": (
+                    f"CoinGecko returned {len(tickers)} tickers but none "
+                    f"carried a trust_score or trust_score_rank — field "
+                    f"absent, not zero."
+                ),
+            })
     
     # Stablecoin Market Share
     market_cap = md.get("market_cap", {}).get("usd", 0)

--- a/tests/test_coingecko_collector.py
+++ b/tests/test_coingecko_collector.py
@@ -1,6 +1,6 @@
 """Tests for CoinGecko collector trust-score parsing."""
 
-from app.collectors.coingecko import _is_high_trust
+from app.collectors.coingecko import _is_high_trust, _has_trust_signal
 
 
 def _make_tickers(specs):
@@ -16,12 +16,25 @@ def _make_tickers(specs):
     return tickers
 
 
+def _compute_trust_ratio_signal_aware(tickers):
+    """Replicate the signal-aware trust-ratio calculation.
+
+    Mirrors the production logic in collect_market_activity_components:
+    divide high_trust by tickers-with-signal, not all tickers. Returns
+    (ratio, signaled_count) so callers can detect the "no signal at all"
+    case where the production code now emits is_stale=True.
+    """
+    rated = [t for t in tickers if _has_trust_signal(t)]
+    if not rated:
+        return None, 0
+    high_trust = sum(1 for t in rated if _is_high_trust(t))
+    return high_trust / len(rated), len(rated)
+
+
 def _compute_trust_ratio(tickers):
-    """Replicate the trust-ratio calculation from collect_market_activity_components."""
-    if not tickers:
-        return 0.0
-    high_trust = sum(1 for t in tickers if _is_high_trust(t))
-    return high_trust / len(tickers)
+    """Back-compat helper: same as signal-aware, but flattens to ratio only."""
+    ratio, _ = _compute_trust_ratio_signal_aware(tickers)
+    return ratio if ratio is not None else 0.0
 
 
 # ---- test_exchange_trust_ratio_handles_string_trust_score ----
@@ -76,3 +89,76 @@ def test_is_high_trust_rank_boundary():
     """Rank exactly 10 is high trust; 11 is not."""
     assert _is_high_trust({"trust_score_rank": 10})
     assert not _is_high_trust({"trust_score_rank": 11})
+
+
+# ---- _has_trust_signal: distinguishes "field absent" from "field is bad" ----
+def test_has_trust_signal_red_is_signal():
+    """A 'red' trust_score IS a signal (low trust, but provided)."""
+    assert _has_trust_signal({"trust_score": "red"})
+
+
+def test_has_trust_signal_yellow_is_signal():
+    """A 'yellow' trust_score IS a signal."""
+    assert _has_trust_signal({"trust_score": "yellow"})
+
+
+def test_has_trust_signal_high_rank_is_signal():
+    """A numeric rank, even 500, IS a signal (CoinGecko did rank the exchange)."""
+    assert _has_trust_signal({"trust_score_rank": 500})
+
+
+def test_has_trust_signal_both_null_is_no_signal():
+    """Both fields explicitly null is NOT a signal — CoinGecko told us nothing."""
+    assert not _has_trust_signal({"trust_score": None, "trust_score_rank": None})
+
+
+def test_has_trust_signal_empty_ticker_is_no_signal():
+    """Empty ticker (fields missing entirely) is NOT a signal."""
+    assert not _has_trust_signal({})
+
+
+# ---- signal-aware trust-ratio: regression for USDC raw=0/normalized=0 ----
+def test_trust_ratio_signal_aware_all_null_returns_none():
+    """When every ticker is missing trust signal, ratio is None (not 0).
+
+    This is the USDC bug from 2026-05-11: production wrote raw=0,
+    normalized=0 to component_readings even though CoinGecko simply
+    hadn't populated the trust_score* fields. Production now records
+    this case as is_stale=True with raw=None.
+    """
+    tickers = _make_tickers([
+        (None, None),
+        (None, None),
+        (None, None),
+    ])
+    ratio, signaled = _compute_trust_ratio_signal_aware(tickers)
+    assert ratio is None
+    assert signaled == 0
+
+
+def test_trust_ratio_signal_aware_partial_signal_divides_by_signaled():
+    """If only some tickers have a signal, divide by signaled-count, not total.
+
+    3 tickers; 2 carry signal (one green, one red); 1 is silent. Old
+    code would have returned 1/3 ≈ 0.33 (wrongly penalising the absent
+    ticker). Signal-aware returns 1/2 = 0.5 — high_trust / rated.
+    """
+    tickers = _make_tickers([
+        ("green", None),   # signal: high trust
+        ("red", None),     # signal: low trust
+        (None, None),      # NO signal — must not count
+    ])
+    ratio, signaled = _compute_trust_ratio_signal_aware(tickers)
+    assert signaled == 2
+    assert ratio == 0.5
+
+
+def test_trust_ratio_signal_aware_all_red_still_returns_zero():
+    """All tickers signal low trust → ratio=0 (correct). Not the bug case."""
+    tickers = _make_tickers([
+        ("red", None),
+        ("red", None),
+    ])
+    ratio, signaled = _compute_trust_ratio_signal_aware(tickers)
+    assert signaled == 2
+    assert ratio == 0.0


### PR DESCRIPTION
Cluster-staleness bug 2 of 3 from the May 11 triage.

## Symptom

`component_readings` for USDC's `exchange_trust_ratio` reads `raw_value=0, normalized_score=0` from coingecko (verified 2026-05-11 08:17 UTC). Not stale — actively writing zero every cycle. SII's market_activity category gets penalised accordingly.

## Root cause

`collect_market_activity_components()` at `app/collectors/coingecko.py:502` computed `high_trust / len(tickers)` regardless of whether each ticker carried a trust signal. CoinGecko's response shape has drifted: for some assets (notably USDC right now), **both** `trust_score` and `trust_score_rank` are null on every ticker — the `trust_score_rank` fallback from #95 was the last line of defence and CoinGecko stepped past it.

When that happens:
- `_is_high_trust` returns False for every ticker
- `high_trust = 0`
- `ratio = 0 / N = 0.0`
- Persisted as `raw=0, normalized=0`

That's wrong: we have **no information**, not **bad information**. An exchange CoinGecko didn't rank shouldn't drag a stablecoin's score down.

## Fix

1. **New `_has_trust_signal(ticker)` helper.** Returns True iff CoinGecko provided ANY usable trust signal: `trust_score` in `(green/yellow/red)` OR `trust_score_rank` is numeric. Red ranks and high ranks still count as "signal received, low trust" — they belong in the denominator. Null/missing fields don't.

2. **`exchange_trust_ratio` divides by signaled count.** `rated = [t for t in tickers if _has_trust_signal(t)]`; ratio = `high_trust / len(rated)`.

3. **If NO tickers carry a signal, emit a stale reading** instead of a misleading zero:
   ```python
   raw_value=None, normalized_score=None, is_stale=True,
   error_message="CoinGecko returned N tickers but none carried…"
   ```
   The structured "we don't know" the score engine can act on.

## Tests

- `_has_trust_signal` unit tests for each branch (red, yellow, high rank, both null, empty ticker).
- Three regression tests on the signal-aware ratio:
  - **all null → ratio=None, signaled=0** (the USDC case)
  - partial signal → divide by signaled, not total
  - all red → ratio=0.0 (legitimate low-trust universe)
- All four existing `_is_high_trust` tests retained unchanged.

## Out of scope

- The other places `_is_high_trust` is used (`cross_exchange_variance` at line 238) already filter tickers correctly — they require `trust_score in ("green", "yellow")` OR `_is_high_trust(t)`, which naturally excludes null-signal tickers from the variance computation. No bug there.

## Verification

After merge + worker redeploy: query `component_readings WHERE component_id='exchange_trust_ratio' AND stablecoin_id='usdc' ORDER BY collected_at DESC LIMIT 5`. Each row should either show `raw_value > 0` (CoinGecko has signal again) or `is_stale=true` with the explanatory `error_message`. The `raw=0, normalized=0` pattern should no longer appear when the cause is field absence.

https://claude.ai/code/session_01T9JSBB6E4rxjLUssCLk5X3

---
_Generated by [Claude Code](https://claude.ai/code/session_01T9JSBB6E4rxjLUssCLk5X3)_