### PR TITLE
fix(enrichment): register rqs_composition as a slow-cycle task

### DIFF
--- a/app/enrichment_worker.py
+++ b/app/enrichment_worker.py
@@ -761,6 +761,26 @@ async def run_enrichment_pipeline() -> dict:
         ),
     ))
 
+    # ---- RQS composition (batch) ----
+    #
+    # compute_rqs_all() iterates TARGET_PROTOCOLS and calls
+    # compute_rqs_for_protocol() per slug. Each per-slug call attests the
+    # `rqs_composition` (singular) domain; the batch attests
+    # `rqs_compositions` (plural). Both domains used to be silent for 19
+    # days because the only call sites were the HTTP endpoints
+    # (server.py:6868, payments.py:402) — if no agent hit /api/compose/rqs,
+    # the domain stayed stale. This task makes the composition run on the
+    # slow cycle (no gate; the work is cheap — aggregates existing scores,
+    # no external API calls).
+    async def _run_rqs_composition():
+        from app.composition import compute_rqs_all
+        return await asyncio.to_thread(compute_rqs_all)
+
+    pipeline.add(EnrichmentTask(
+        name="rqs_composition", func=_run_rqs_composition,
+        timeout_seconds=300, group="analysis", priority=3,
+    ))
+
     # =========================================================================
     # Universal Data Layer collectors
     # =========================================================================


### PR DESCRIPTION
Staleness-tail bug 3a of the May 11 triage. `rqs_composition` has been silent in `state_attestations` since April 22 (19 days).

## Root cause

`compute_rqs_for_protocol()` and `compute_rqs_all()` in `app/composition.py` both call `attest_state()` correctly:

- `compute_rqs_for_protocol` attests `rqs_composition` (singular) per slug → `composition.py:359`
- `compute_rqs_all` attests `rqs_compositions` (plural) for the batch → `composition.py:388,393`

But the only call sites are HTTP endpoints:

| call site | route |
|---|---|
| `app/server.py:6868` | `GET /api/compose/rqs` |
| `app/server.py:6875` | `GET /api/compose/rqs/{slug}` |
| `app/payments.py:402` | x402 paid per-request path |

**No worker task, no enrichment registration, no cron.** If no agent hits those endpoints — which has been the case for 19 days — neither domain advances. The attestation calls themselves are wired correctly; the trigger isn't.

Different shape from #137 (psi_discoveries was registered but gated). Same family: an `attest_state` call site that only fires when upstream conditions are met, and those conditions weren't.

## Fix

Register `compute_rqs_all()` as a slow-cycle enrichment task. The work is cheap — aggregates existing PSI scores + treasury holdings, no external API calls — so it can run on every slow cycle (~3h) without a freshness gate.

Each iteration:
- `compute_rqs_for_protocol()` runs once per protocol → attests `rqs_composition` (singular) N times
- `compute_rqs_all()` attests `rqs_compositions` (plural) once

Both domains stay fresh. `group="analysis"`, `priority=3`, `timeout=300s` mirrors the `divergence_detection` task — the other lightweight analysis task.

## Verification after merge

1. Scoring-Worker redeploys.
2. Within one slow cycle (~3h), the `rqs_composition` enrichment task fires.
3. `SELECT * FROM state_attestations WHERE domain='rqs_composition' ORDER BY attested_at DESC LIMIT 5;` shows rows from today.
4. Same for `rqs_compositions` (plural).

## Sequence

Bug 3b (`mempool_capture_status`, 14 days) follows next. Triaged one at a time per the May 11 discipline.

https://claude.ai/code/session_01T9JSBB6E4rxjLUssCLk5X3

---
_Generated by [Claude Code](https://claude.ai/code/session_01T9JSBB6E4rxjLUssCLk5X3)_