### PR TITLE
fix(mempool): emit hourly heartbeat attestation in capture loop

### DIFF
--- a/app/data_layer/mempool_watcher.py
+++ b/app/data_layer/mempool_watcher.py
@@ -457,6 +457,15 @@ async def _subscribe_and_consume(ws, watchlist: list[str]) -> int:
 
     event_count = 0
     _loop = asyncio.get_event_loop()
+    # Heartbeat: emit a 'running' state_attestation every ~1h so the
+    # mempool_capture_status domain stays fresh in steady state. The
+    # existing attestations only fire on pause/resume transitions; in
+    # the common case (Alchemy CU under budget, WS connection stable),
+    # neither transition happens for days and the domain looks dead
+    # even though capture is healthy. This was 14 days silent before
+    # the heartbeat.
+    last_heartbeat = time.time()
+    HEARTBEAT_INTERVAL_SEC = 3600
     async for raw in ws:
         try:
             msg = json.loads(raw)
@@ -476,6 +485,16 @@ async def _subscribe_and_consume(ws, watchlist: list[str]) -> int:
                         None, _attest_observation,
                         tx.get("hash", ""), int(time.time() * 1000),
                     )
+
+        # Heartbeat check after each frame — fires when wall-clock crosses
+        # the interval boundary, regardless of event volume.
+        now = time.time()
+        if now - last_heartbeat >= HEARTBEAT_INTERVAL_SEC:
+            await _attest_capture_status(
+                "running",
+                f"heartbeat events_observed={event_count} subscription={subscription_id}",
+            )
+            last_heartbeat = now
 
     return event_count
 


### PR DESCRIPTION
Staleness-tail bug 3b. `mempool_capture_status` went 14 days silent in `state_attestations`.

## Root cause

`_attest_capture_status()` only fires on state transitions:

| line | trigger | event |
|---|---|---|
| `:529` | Alchemy 24h CU > pause threshold | `status="paused"` |
| `:567` | WS connection closes | `status="resumed"` |

In steady state — CU under budget, single long-lived WS connection, no errors — **neither transition occurs**. The Scoring-Worker logs prove capture is healthy: `[mempool_observations] 24h SUMMARY: captured=31292 confirmed=31292 dropped=0`. The watcher isn't broken; it just has nothing to attest.

Same family as #137 (psi_discoveries) and #139 (rqs_composition): an `attest_state` call site exists, is wired correctly, but fires only under conditions that don't occur in steady state.

## Fix

Inside `_subscribe_and_consume` (the WS event loop), wall-clock check on each frame and emit a `"running"` status attestation once an hour:

```python
HEARTBEAT_INTERVAL_SEC = 3600
if now - last_heartbeat >= HEARTBEAT_INTERVAL_SEC:
    await _attest_capture_status(
        "running",
        f"heartbeat events_observed={event_count} ...",
    )
```

Hourly cadence keeps the domain inside any reasonable coherence threshold without flooding the table (≤24 rows/day vs the thousands from per-observation writes). USDC/USDT mainnet traffic guarantees frequent WS frames, so wall-clock check on each arrival is sufficient — no separate timer task.

Domain version stays `mempool-v0.1.0`: schema and emission contract unchanged; only the trigger condition expands.

## Verification after merge

1. Scoring-Worker redeploys.
2. Within an hour: `SELECT entity_id, cycle_timestamp FROM state_attestations WHERE domain='mempool_capture_status' AND entity_id='running' ORDER BY cycle_timestamp DESC LIMIT 5;` shows fresh `running` rows.
3. Existing `paused`/`resumed` entries continue to fire on actual transitions.

## Sequence

`mempool_observations` (3 days stale per the May 11 list) is a **separate** but related bug — its attest fires on every captured tx via `_attest_observation`, so a 3-day silence likely means the watcher had a connection blackout window or the function was failing silently. That's bug 3f (lower priority). Next in queue: bug 3c `dex_pool_ohlcv` (10 days).

https://claude.ai/code/session_01T9JSBB6E4rxjLUssCLk5X3

---
_Generated by [Claude Code](https://claude.ai/code/session_01T9JSBB6E4rxjLUssCLk5X3)_