### PR TITLE
fix(ohlcv): always attest dex_pool_ohlcv, even with zero records

### DIFF
--- a/app/data_layer/ohlcv_collector.py
+++ b/app/data_layer/ohlcv_collector.py
@@ -211,6 +211,18 @@ async def run_ohlcv_collection() -> dict:
 
     if all_pools == 0:
         logger.error("[dex_pool_ohlcv] ZERO pools found — liquidity_depth has no DEX rows. OHLCV depends on liquidity collector producing pool data first.")
+        # Attest the ran-but-empty state so the domain stays fresh and the
+        # reason for the absence is in the audit trail. Without this, an
+        # upstream liquidity_depth outage silently freezes dex_pool_ohlcv.
+        try:
+            from app.data_layer.provenance_scaling import attest_data_batch
+            await asyncio.to_thread(
+                attest_data_batch,
+                "dex_pool_ohlcv",
+                [{"records": 0, "pools": 0, "status": "no_upstream_pools"}],
+            )
+        except Exception as e:
+            logger.warning(f"[ohlcv_collector] no-pools attestation failed: {e}")
         return {"pools_found": 0, "records_stored": 0}
 
     total_records = 0
@@ -283,11 +295,21 @@ async def run_ohlcv_collection() -> dict:
                 except Exception:
                     pass
 
-    # Provenance
+    # Provenance — always attest, even when total_records=0. The previous
+    # `if total_records > 0` gate made the domain go silent whenever the
+    # collector ran against pools but received no bars (paywall, rate limit,
+    # geofenced response, empty pools). Attesting `records=0` is a valid
+    # statement: the cycle ran, this is what we got. link_batch_to_proof is
+    # still skipped on the zero-bars case because it correlates rows in
+    # liquidity_depth + dex_pool_ohlcv, which would be nonsensical with no
+    # rows on this side.
     try:
         from app.data_layer.provenance_scaling import attest_data_batch, link_batch_to_proof
+        payload = {"records": total_records, "pools": pools_processed}
+        if total_records == 0:
+            payload["status"] = "queried_no_bars"
+        await asyncio.to_thread(attest_data_batch, "dex_pool_ohlcv", [payload])
         if total_records > 0:
-            await asyncio.to_thread(attest_data_batch, "dex_pool_ohlcv", [{"records": total_records, "pools": pools_processed}])
             await link_batch_to_proof("dex_pool_ohlcv", "liquidity_depth")
     except asyncio.CancelledError:
         raise


### PR DESCRIPTION
Staleness-tail bug 3c. `dex_pool_ohlcv` went 10 days silent in `state_attestations`.

## Root cause

`run_ohlcv_collection()` in `app/data_layer/ohlcv_collector.py` had **two silent-exit paths** that bypassed attestation:

| line | path | reason |
|---|---|---|
| `:214` | early return when `all_pools == 0` | upstream `liquidity_depth` produced no DEX rows |
| `:289` | provenance block gated on `if total_records > 0` | collector ran but received zero bars (paywall, rate limit, transient API) |

The enrichment task itself fires every 3h (gate `SELECT MAX(timestamp) FROM dex_pool_ohlcv` with `min_hours=3` opens when data is stale). So the trigger was firing; the collector just produced no `state_attestations` row because of these inner gates.

Identical family to #137 (psi_discoveries), #139 (rqs_composition), #140 (mempool_capture_status): valid `attest_state` call sites that fire only under happy-path conditions.

## Fix

1. **Zero-upstream-pools path** — add an attestation with `status="no_upstream_pools"` so the audit trail records the dependency failure.

2. **Main provenance block** — drop the `if total_records > 0` gate. Always emit `{records: N, pools: P}`; tag `status="queried_no_bars"` when N=0. `link_batch_to_proof` stays conditional on `records>0` because correlation across liquidity_depth + dex_pool_ohlcv needs rows on both sides.

Schema unchanged; only trigger conditions fixed.

## Verification after merge

1. Scoring-Worker redeploys; within ~3h the next OHLCV cycle runs.
2. `SELECT entity_id, record_count, cycle_timestamp FROM state_attestations WHERE domain='dex_pool_ohlcv' ORDER BY cycle_timestamp DESC LIMIT 5;` shows a fresh row regardless of whether new bars landed.
3. If the table itself remains dry, payload will carry `status="no_upstream_pools"` or `"queried_no_bars"` — that's the actual diagnostic signal for whoever investigates next.

## Sequence

6 staleness bugs to go: wallets (9d), web_research (8d), mempool_observations (3d), cqi_compositions (3d), peg_snapshots_5m (2.5d), exchange_snapshots (2.5d). Triaging one at a time.

https://claude.ai/code/session_01T9JSBB6E4rxjLUssCLk5X3

---
_Generated by [Claude Code](https://claude.ai/code/session_01T9JSBB6E4rxjLUssCLk5X3)_