### PR TITLE
fix(wallets): always attest batch reindex, even with processed=0

### DIFF
--- a/app/indexer/pipeline.py
+++ b/app/indexer/pipeline.py
@@ -803,11 +803,23 @@ async def run_pipeline_batch(batch_size: int = 500) -> dict:
         f"elapsed={elapsed:.0f}s, remaining={total_remaining - indexed}"
     )
 
-    # Attest wallet batch
+    # Attest wallet batch — always, even when indexed=0. The `if indexed > 0`
+    # gate kept "wallets" silent in state_attestations whenever the batch
+    # reindex ran but found no stale wallets to refresh (steady state across
+    # a freshly-indexed graph). Same pattern as #137 / #141: attest the
+    # ran-but-empty case so the audit trail records the cycle.
     try:
         from app.state_attestation import attest_state
-        if indexed > 0:
-            await asyncio.to_thread(attest_state, "wallets", [{"cycle": "batch_reindex", "processed": indexed, "scored": scored, "balances_updated": balances_updated}])
+        await asyncio.to_thread(
+            attest_state,
+            "wallets",
+            [{
+                "cycle": "batch_reindex",
+                "processed": indexed,
+                "scored": scored,
+                "balances_updated": balances_updated,
+            }],
+        )
     except asyncio.CancelledError:
         raise
     except Exception as ae:

--- a/main.py
+++ b/main.py
@@ -188,11 +188,21 @@ def run_worker_loop():
                 f"{reindex_result.get('errors', 0)} errors, "
                 f"{reindex_result.get('remaining', '?')} remaining"
             )
-            # Attest wallet batch
+            # Attest wallet batch — always, even when processed=0.
+            # run_pipeline_batch internally attests via pipeline.py:806, but
+            # we keep this caller-side attestation for the main-thread path
+            # (different methodology context). Gate removed for the same
+            # reason as the inner site.
             try:
                 from app.state_attestation import attest_state
-                if reindex_result.get('processed', 0) > 0:
-                    attest_state("wallets", [{"cycle": "batch_reindex", "processed": reindex_result.get('processed', 0), "scored": reindex_result.get('scored', 0)}])
+                attest_state(
+                    "wallets",
+                    [{
+                        "cycle": "batch_reindex",
+                        "processed": reindex_result.get('processed', 0),
+                        "scored": reindex_result.get('scored', 0),
+                    }],
+                )
             except Exception as ae:
                 logger.debug(f"Wallet attestation skipped: {ae}")
         except Exception as e:


### PR DESCRIPTION
Staleness-tail bug 3d. `wallets` domain went 9 days silent in `state_attestations`.

## Root cause

Two gates kept the domain silent in steady state:

| line | gate |
|---|---|
| `app/indexer/pipeline.py:809` (canonical) | `if indexed > 0` |
| `main.py:194` (caller-side duplicate) | `if reindex_result.get('processed', 0) > 0` |

Once the wallet graph stabilised — when `run_pipeline_batch` iterates the 500 stalest wallets and the staleness criterion isn't satisfied (because all 500 were just refreshed) — `indexed = 0` and neither gate fires. The cycle ran, the indexer just didn't have anything to update.

Same family as #137, #139, #141.

## Fix

Drop both gates. Attest unconditionally with the actual counts: `{processed, scored, balances_updated, cycle: "batch_reindex"}`.

A row with `processed=0` is the canonical statement: "batch reindex ran, found nothing stale." It also distinguishes "batch reindex never ran" from "batch reindex ran but did no work" — two failure modes that previously looked identical to coherence.

`main.py:194` is a caller-side duplicate that was producing a second row when both had data. Kept (rather than deleted) so the daily worker-loop path records its own provenance even if the inner call fails. Downstream consumers can dedupe by methodology + cycle_timestamp.

## Verification after merge

1. Scoring-Worker redeploys.
2. After the next batch reindex cycle: `SELECT cycle_timestamp, record_count FROM state_attestations WHERE domain='wallets' ORDER BY cycle_timestamp DESC LIMIT 5;` shows a fresh row.
3. Payload includes `processed: N` — useful diagnostic for whether the indexer is finding work.

## Sequence

5 remaining: web_research (8d), mempool_observations (3d), cqi_compositions (3d), peg_snapshots_5m (2.5d), exchange_snapshots (2.5d).

https://claude.ai/code/session_01T9JSBB6E4rxjLUssCLk5X3

---
_Generated by [Claude Code](https://claude.ai/code/session_01T9JSBB6E4rxjLUssCLk5X3)_