### PR TITLE
fix(web-research): always attest, even when no scores produced

### DIFF
--- a/app/collectors/web_research.py
+++ b/app/collectors/web_research.py
@@ -538,17 +538,29 @@ async def run_web_research_collection() -> list[dict]:
         except Exception as e:
             logger.warning(f"Meeting cadence research failed for {slug}: {e}")
 
-    # Attest
+    # Attest — always, even when scored is empty. Previously gated on
+    # `if scored:`, which made the domain go silent whenever the research
+    # cycle ran but produced no scoreable rows (parser miss, source down,
+    # all targets skipped). Same family as #137 / #142: attest the
+    # ran-but-empty state with a structured payload so the cycle is in the
+    # audit trail.
     try:
         from app.state_attestation import attest_state
         scored = [r for r in results if "score" in r]
         if scored:
-            _loop = asyncio.get_event_loop()
-            await _loop.run_in_executor(None, attest_state, "web_research", [
+            payload = [
                 {"type": r["entity_type"], "slug": r["entity_slug"],
                  "component": r["component"], "score": r["score"]}
                 for r in scored
-            ])
+            ]
+        else:
+            payload = [{
+                "status": "ran_no_scores",
+                "results_count": len(results),
+                "scored_count": 0,
+            }]
+        _loop = asyncio.get_event_loop()
+        await _loop.run_in_executor(None, attest_state, "web_research", payload)
     except asyncio.CancelledError:
         raise
     except Exception as e:


### PR DESCRIPTION
Staleness-tail bug 3e. `web_research` went 8 days silent in `state_attestations`.

## Root cause

Same family as #137 / #142: an `attest_state` call site gated on a truthy-list check. `app/collectors/web_research.py:545`:

```python
if scored:
    await _loop.run_in_executor(None, attest_state, "web_research", [...])
```

When the research cycle ran but produced zero scoreable rows (parser miss, empty target list, source domain down, all targets skipped), the gate stayed closed and the domain went silent.

## Fix

Always attest. When `scored` is non-empty, emit the per-result payload as before. When empty:

```python
[{"status": "ran_no_scores", "results_count": N, "scored_count": 0}]
```

`results_count` distinguishes "produced nothing" from "produced raw results but none scoreable" — useful diagnostic for whoever investigates next.

## Verification

After merge + worker redeploy + next web_research cycle:
`SELECT cycle_timestamp, batch_hash FROM state_attestations WHERE domain='web_research' ORDER BY cycle_timestamp DESC LIMIT 5;` shows fresh rows.

## Sequence

4 remaining: mempool_observations (3d), cqi_compositions (3d), peg_snapshots_5m (2.5d), exchange_snapshots (2.5d). Continuing.

https://claude.ai/code/session_01T9JSBB6E4rxjLUssCLk5X3

---
_Generated by [Claude Code](https://claude.ai/code/session_01T9JSBB6E4rxjLUssCLk5X3)_