### PR TITLE
fix(enrichment): register cqi_composition as a slow-cycle task

### DIFF
--- a/app/enrichment_worker.py
+++ b/app/enrichment_worker.py
@@ -781,6 +781,24 @@ async def run_enrichment_pipeline() -> dict:
         timeout_seconds=300, group="analysis", priority=3,
     ))
 
+    # ---- CQI composition (matrix) ----
+    #
+    # compute_cqi_matrix() builds the asset × protocol CQI grid and
+    # attests `cqi_compositions` for both the populated and empty cases
+    # (composition.py:460 / :462). But the only call site was the HTTP
+    # endpoint at server.py:6720, so the domain went 3 days silent
+    # whenever no agent hit /api/compose/cqi. Same shape as rqs_composition
+    # — run it on the slow cycle so the domain stays fresh independent of
+    # API traffic.
+    async def _run_cqi_composition():
+        from app.composition import compute_cqi_matrix
+        return await asyncio.to_thread(compute_cqi_matrix)
+
+    pipeline.add(EnrichmentTask(
+        name="cqi_composition", func=_run_cqi_composition,
+        timeout_seconds=300, group="analysis", priority=3,
+    ))
+
     # =========================================================================
     # Universal Data Layer collectors
     # =========================================================================


### PR DESCRIPTION
Staleness-tail bug 3g. `cqi_compositions` went 3 days silent in `state_attestations`.

## Root cause

Same shape as #139 (rqs_composition). `compute_cqi_matrix()` in `app/composition.py` attests `cqi_compositions` correctly for **both** populated and empty cases:

```python
if matrix:
    attest_state("cqi_compositions", [<matrix payload>])  # composition.py:460
else:
    attest_state("cqi_compositions", [{"status": "ran_no_results", ...}])  # :462
```

But the only call site is the HTTP endpoint at `server.py:6720`. After 3 days of no `/api/compose/cqi` traffic, the domain went silent — exact same failure mode as rqs_composition before #139.

## Fix

Register `compute_cqi_matrix()` as a slow-cycle enrichment task. Cheap work — aggregates existing SII × PSI scores via geometric mean, no external API calls — so no gate needed. `group="analysis"`, `priority=3`, `timeout=300s` matches `divergence_detection` and `rqs_composition`.

## Verification

After merge + worker redeploy + one slow cycle (~3h): `SELECT cycle_timestamp FROM state_attestations WHERE domain='cqi_compositions' ORDER BY cycle_timestamp DESC LIMIT 5;` shows a fresh row.

## Sequence

2 remaining: peg_snapshots_5m (2.5d), exchange_snapshots (2.5d). Both data_layer domains; likely the same gate-on-truthy pattern.

https://claude.ai/code/session_01T9JSBB6E4rxjLUssCLk5X3

---
_Generated by [Claude Code](https://claude.ai/code/session_01T9JSBB6E4rxjLUssCLk5X3)_