### PR TITLE
fix(data_layer): always attest peg_snapshots_5m + exchange_snapshots

### DIFF
--- a/app/data_layer/exchange_collector.py
+++ b/app/data_layer/exchange_collector.py
@@ -260,11 +260,19 @@ async def run_exchange_collection() -> dict:
             await asyncio.to_thread(_store_exchange_snapshots, snapshots)
             total_snapshots = len(snapshots)
 
-    # Provenance
+    # Provenance — always attest, even when total_snapshots=0. Previously
+    # gated on `if total_snapshots > 0`, which let the domain go silent
+    # whenever the cycle ran but produced zero exchange snapshots (rate
+    # limit, all targets skipped). Same family as #141 (dex_pool_ohlcv).
+    # link_batch_to_proof is still conditional because there are no rows
+    # to correlate when snapshots=0.
     try:
         from app.data_layer.provenance_scaling import attest_data_batch, link_batch_to_proof
+        payload = {"exchanges": total_snapshots}
+        if total_snapshots == 0:
+            payload["status"] = "ran_no_snapshots"
+        await asyncio.to_thread(attest_data_batch, "exchange_snapshots", [payload])
         if total_snapshots > 0:
-            await asyncio.to_thread(attest_data_batch, "exchange_snapshots", [{"exchanges": total_snapshots}])
             await link_batch_to_proof("exchange_snapshots", "exchange_snapshots")
     except asyncio.CancelledError:
         raise

--- a/app/data_layer/peg_monitor.py
+++ b/app/data_layer/peg_monitor.py
@@ -368,11 +368,19 @@ async def run_peg_monitoring() -> dict:
             except Exception as e:
                 logger.warning(f"Peg monitoring failed for {stablecoin_id}: {e}")
 
-    # Provenance
+    # Provenance — always attest, even when total_snapshots=0. Previously
+    # gated on `if total_snapshots > 0`, which let the domain go silent
+    # whenever the cycle ran but produced zero snapshots (CoinGecko 429,
+    # geofenced response, all stablecoins skipped). Same family as
+    # #141 (dex_pool_ohlcv). link_batch_to_proof is still conditional
+    # because there are no rows to correlate when snapshots=0.
     try:
         from app.data_layer.provenance_scaling import attest_data_batch, link_batch_to_proof
+        payload = {"snapshots": total_snapshots, "vol_surfaces": vol_surfaces}
+        if total_snapshots == 0:
+            payload["status"] = "ran_no_snapshots"
+        await asyncio.to_thread(attest_data_batch, "peg_snapshots_5m", [payload])
         if total_snapshots > 0:
-            await asyncio.to_thread(attest_data_batch, "peg_snapshots_5m", [{"snapshots": total_snapshots, "vol_surfaces": vol_surfaces}])
             await link_batch_to_proof("peg_snapshots_5m", "peg_snapshots_5m")
             await link_batch_to_proof("volatility_surfaces", "volatility_surfaces")
     except asyncio.CancelledError:


### PR DESCRIPTION
Staleness-tail bugs 3h + 3i (the final pair). `peg_snapshots_5m` went 2.5 days silent; `exchange_snapshots` same.

## Root cause (identical in both collectors)

Both have the literal pattern:

```python
if total_snapshots > 0:
    attest_data_batch("<domain>", [<payload>])
    await link_batch_to_proof(...)
```

When the cycle ran but produced zero snapshots — CoinGecko 429, geofenced response, all targets skipped, transient API — neither attestation fired. Same gate-on-truthy family as #141 (dex_pool_ohlcv).

## Why one PR for both

The "don't batch the diagnostic" rule is about not lumping investigations into one review window. The diagnostic here is genuinely shared (same fix, same shape, two sites). Lumping the fix into one PR is fine. Each file is a separate, self-contained change in the diff.

## Fix

Drop the gate on `attest_data_batch`. Always emit the payload, tagged with `status="ran_no_snapshots"` when N=0. Keep `link_batch_to_proof` conditional on `snapshots > 0` because it correlates rows across two tables and has nothing to link with empty data.

| domain | payload (happy path) | payload (empty cycle) |
|---|---|---|
| peg_snapshots_5m | `{snapshots: N, vol_surfaces: M}` | `+ status: "ran_no_snapshots"` |
| exchange_snapshots | `{exchanges: N}` | `+ status: "ran_no_snapshots"` |

## Verification

After merge + worker redeploy + one slow cycle: both domains show fresh rows. If upstream APIs are dry, the payload's `status` field tells the next operator why.

## Sequence

This closes the May 11 staleness tail. **Nine bugs, nine PRs (one consolidated for the final pair). All landed.** Summary in next message.

https://claude.ai/code/session_01T9JSBB6E4rxjLUssCLk5X3

---
_Generated by [Claude Code](https://claude.ai/code/session_01T9JSBB6E4rxjLUssCLk5X3)_