### PR TITLE
fix(oracle): cycle-summary heartbeat for oracle_stress_events

### DIFF
--- a/app/collectors/oracle_behavior.py
+++ b/app/collectors/oracle_behavior.py
@@ -665,4 +665,25 @@ async def collect_oracle_readings() -> dict:
         f"stress={results['stress_events_detected']} "
         f"errors={results['errors']}"
     )
+
+    # Per-cycle heartbeat attestation. _handle_stress_event() at line 471
+    # writes oracle_stress_events rows when an actual stress event is
+    # detected, but in steady state (no anomalies) the domain stays silent.
+    # Same family as #144 (mempool_observations) — emit a cycle-summary row
+    # so the domain freshness tracks "the detector ran" rather than "an
+    # event happened." Coherence threshold for oracle_stress_events is 168h
+    # (event-driven, weekly check), but operators still want a per-cycle
+    # signal that the detector is alive.
+    try:
+        from app.state_attestation import attest_state
+        await asyncio.to_thread(attest_state, "oracle_stress_events", [{
+            "status": "cycle_complete",
+            "oracles_read": results["oracles_read"],
+            "readings_stored": results["readings_stored"],
+            "stress_events_detected": results["stress_events_detected"],
+            "errors_count": len(results["errors"]),
+        }])
+    except Exception as e:
+        logger.warning(f"[oracle] cycle heartbeat attestation skipped: {e}")
+
     return results


### PR DESCRIPTION
Wave-2a of the May 11 staleness triage. `oracle_stress_events` was 1d 11h stale.

## Root cause

Attestation fires only inside `_handle_stress_event` at `app/collectors/oracle_behavior.py:471`, which is reached only when an actual oracle deviation is detected. In steady state — oracles tracking CEX prices within tolerance — no stress events occur, so the domain stays silent even though the detector runs every cycle.

Same family as #144 (mempool_observations summary backstop) and #140 (mempool_capture_status heartbeat): event-driven attest needs a periodic backstop so freshness tracks **detector liveness**, not **event occurrence**.

## Fix

After the summary log line in `collect_oracle_readings()` (called on every fast cycle, ~hourly), emit a single `state_attestations` row:

```python
attest_state("oracle_stress_events", [{
    "status": "cycle_complete",
    "oracles_read": N, "readings_stored": M,
    "stress_events_detected": K, "errors_count": E,
}])
```

Per-event rows from `_handle_stress_event` keep firing — they remain source of truth when actual stress events occur. The heartbeat is purely a freshness backstop.

Coherence threshold for `oracle_stress_events` stays 168h (event-driven, weekly), but operators get a per-cycle signal that the detector is alive.

## Verification

After merge + worker redeploy + next fast cycle (~1h):
`SELECT entity_id, cycle_timestamp FROM state_attestations WHERE domain='oracle_stress_events' ORDER BY cycle_timestamp DESC LIMIT 5;` — fresh row with status=`cycle_complete`.

## Sequence

3 remaining in Wave 2: rpi_components, dohi_components, governance_events. Triaging next.

https://claude.ai/code/session_01T9JSBB6E4rxjLUssCLk5X3

---
_Generated by [Claude Code](https://claude.ai/code/session_01T9JSBB6E4rxjLUssCLk5X3)_