### PR TITLE
fix(rpi): always attest rpi_components, even when scoring returns empty

### DIFF
--- a/app/enrichment_worker.py
+++ b/app/enrichment_worker.py
@@ -417,7 +417,13 @@ async def run_enrichment_pipeline() -> dict:
         from app.rpi.scorer import run_rpi_scoring
         result = await asyncio.to_thread(run_rpi_scoring)
 
-        # Attest RPI component scores
+        # Attest RPI component scores — always, even when scoring returns
+        # no protocols. Previously gated on `if result:`, which silenced the
+        # domain whenever run_rpi_scoring() returned None/empty (cascading
+        # failure from the incident detector, no protocols configured,
+        # transient DB issue). Same family as #138 / #141 / #143: always
+        # attest with a structured status payload so coherence can
+        # distinguish "task ran with data" from "task never ran".
         try:
             from app.state_attestation import attest_state
             if result:
@@ -425,7 +431,11 @@ async def run_enrichment_pipeline() -> dict:
                     {"slug": r.get("protocol_slug", ""), "score": r.get("overall_score")}
                     for r in result if isinstance(r, dict)
                 ]
-                await asyncio.to_thread(attest_state, "rpi_components", records)
+                if not records:
+                    records = [{"status": "ran_no_dict_results", "result_count": len(result)}]
+            else:
+                records = [{"status": "ran_no_results", "result_count": 0}]
+            await asyncio.to_thread(attest_state, "rpi_components", records)
         except Exception as ae:
             logger.error(f"RPI components attestation failed: {ae}")
             try:


### PR DESCRIPTION
Wave-2b of the May 11 staleness triage. `rpi_components` was 22h stale.

## Root cause

The enrichment task at `app/enrichment_worker.py:417` has a 24h gate (`rpi_scores.computed_at`), so it correctly runs once per day. But the attestation block at line 423 was gated:

```python
if result:
    records = [...]
    attest_state("rpi_components", records)
```

When `run_rpi_scoring()` returned None or empty (cascading failure from the incident detector at line 412, no protocols configured, transient DB read), no attestation fired. 22h stale was the boundary — task runs every 24h, and on an empty-result cycle the domain stayed silent until the next non-empty run.

Same family as #138 / #141 / #143.

## Fix

Always attest with a structured status payload:

| condition | payload |
|---|---|
| result has scoreable dict rows | `[{slug, score}, ...]` (existing) |
| result has rows but none are dicts | `[{"status": "ran_no_dict_results", "result_count": N}]` |
| result is empty/None | `[{"status": "ran_no_results", "result_count": 0}]` |

Coherence can now distinguish: task never ran / task ran but produced nothing / task ran with data.

## Sequence

2 remaining: dohi_components (18h), governance_events (18h). Checking whether they share a collector next.

https://claude.ai/code/session_01T9JSBB6E4rxjLUssCLk5X3

---
_Generated by [Claude Code](https://claude.ai/code/session_01T9JSBB6E4rxjLUssCLk5X3)_