### PR TITLE
fix(schema-drift): column + parser fixes for the May 10 Neon migration fallout

### DIFF
--- a/app/coherence.py
+++ b/app/coherence.py
@@ -221,12 +221,23 @@ def _check_sii_psi_alignment() -> list[dict]:
         sii_rows = fetch_all("SELECT stablecoin_id FROM scores")
         sii_ids = {r["stablecoin_id"] for r in sii_rows} if sii_rows else set()
 
-        # Check collateral exposure table for stablecoins referenced by PSI
+        # Check collateral exposure for stablecoins PSI references that
+        # don't have an SII score. protocol_collateral_exposure tracks
+        # tokens by `token_symbol` (e.g. "USDC"), not by an internal
+        # stablecoin id, so we resolve the canonical stablecoin id via a
+        # case-insensitive join against the stablecoins registry. The
+        # previous query asked for a `stablecoin_id` column on
+        # protocol_collateral_exposure, which has never existed on that
+        # table — the May-10 schema-drift triage surfaced this as 65
+        # fails/24h across all 13 scored protocols.
         exposure_rows = fetch_all(
             """
-            SELECT DISTINCT stablecoin_id
-            FROM protocol_collateral_exposure
-            WHERE snapshot_date > CURRENT_DATE - 7
+            SELECT DISTINCT s.id AS stablecoin_id
+            FROM protocol_collateral_exposure pce
+            JOIN stablecoins s
+              ON LOWER(s.symbol) = LOWER(pce.token_symbol)
+            WHERE pce.snapshot_date > CURRENT_DATE - 7
+              AND pce.is_stablecoin = TRUE
             """
         )
         for row in (exposure_rows or []):

--- a/app/collectors/parameter_history.py
+++ b/app/collectors/parameter_history.py
@@ -68,7 +68,13 @@ def _eth_call_sync(contract: str, data: str, chain: str = "ethereum") -> str:
             except Exception:
                 pass
 
-    # Etherscan fallback (ethereum only)
+    # Etherscan fallback (ethereum only). Etherscan v2 requires `chainid`;
+    # without it the API returns `{"status":"0","message":"NOTOK","result":
+    # "Missing/Invalid Chain Id, see https://api.etherscan.io/v2/chainlist ..."}`,
+    # whose `result` field is a URL/error string, not hex. The previous
+    # code took that string and returned it; downstream _decode_uint256
+    # then crashed in int(value, 16). The May-10 cycle_errors triage saw
+    # 44 invalid-literal failures/24h from this single path.
     if chain == "ethereum":
         api_key = os.environ.get("ETHERSCAN_API_KEY", "")
         if api_key:
@@ -76,6 +82,7 @@ def _eth_call_sync(contract: str, data: str, chain: str = "ethereum") -> str:
                 resp = httpx.get(
                     "https://api.etherscan.io/v2/api",
                     params={
+                        "chainid": 1,
                         "module": "proxy",
                         "action": "eth_call",
                         "to": contract,
@@ -85,9 +92,40 @@ def _eth_call_sync(contract: str, data: str, chain: str = "ethereum") -> str:
                     },
                     timeout=15,
                 )
-                result = resp.json().get("result", "0x")
-                if result and result != "0x":
-                    return result
+                # Guard 1: HTTP error returned an HTML body. httpx.json()
+                # would raise on non-JSON, but Etherscan sometimes wraps an
+                # error message in valid JSON with status="0".
+                try:
+                    body = resp.json()
+                except ValueError:
+                    logger.warning(
+                        f"Etherscan returned non-JSON body for {contract}: "
+                        f"content-type={resp.headers.get('content-type', '?')} "
+                        f"prefix={resp.text[:80]!r}"
+                    )
+                    body = None
+
+                if isinstance(body, dict):
+                    raw = body.get("result", "0x")
+                    # Guard 2: result must be a non-empty hex string.
+                    # Etherscan's error-state result is plain text (e.g.
+                    # "Missing/Invalid Chain Id ...") which str.startswith
+                    # filters cleanly.
+                    if (
+                        isinstance(raw, str)
+                        and raw.startswith("0x")
+                        and len(raw) >= 2
+                        and all(c in "0123456789abcdefABCDEF" for c in raw[2:])
+                    ):
+                        if raw != "0x":
+                            return raw
+                    else:
+                        logger.warning(
+                            f"Etherscan eth_call returned non-hex result for "
+                            f"{contract}: status={body.get('status')!r} "
+                            f"message={body.get('message')!r} "
+                            f"result={str(raw)[:80]!r}"
+                        )
             except Exception as e:
                 logger.warning(f"Etherscan eth_call fallback failed: {e}")
                 try:

--- a/app/ops/routes.py
+++ b/app/ops/routes.py
@@ -1879,8 +1879,14 @@ async def protocol_deep_dive(slug: str, request: Request):
 
         collateral = []
         try:
+            # `protocol_collateral_exposure` exposes the token name as
+            # `token_symbol`, not `stablecoin_symbol`. The previous column
+            # name has never existed on this table; the May-10 schema-drift
+            # triage attributed 65 fails/24h across all 13 scored protocols
+            # to this single mismatch. We alias to `stablecoin_symbol` in the
+            # SELECT so callers downstream don't have to change.
             collateral = await fetch_all_async("""
-                SELECT stablecoin_symbol, tvl_usd, pool_count
+                SELECT token_symbol AS stablecoin_symbol, tvl_usd, pool_count
                 FROM protocol_collateral_exposure
                 WHERE protocol_slug = %s
                 ORDER BY tvl_usd DESC

--- a/app/rpi/forum_scraper.py
+++ b/app/rpi/forum_scraper.py
@@ -18,6 +18,7 @@ import time
 from datetime import datetime, timezone, timedelta
 
 import httpx
+from psycopg2.extras import Json
 
 from app.database import execute, fetch_one, fetch_all
 
@@ -268,7 +269,13 @@ def scrape_forum(protocol_slug: str, config: dict = None,
                 """, (
                     protocol_slug, base_url, post_id, str(topic_id), title,
                     body_excerpt, op.get("username", ""), str(cat_id),
-                    bool(vendors), vendors if vendors else None,
+                    # mentioned_vendors is a JSONB column; psycopg2 adapts a
+                    # Python list to text[] by default, which the column type
+                    # rejects ("column is of type jsonb but expression is of
+                    # type text[]"). Serialize explicitly so it goes in as
+                    # jsonb. Surfaced in the May-10 schema-drift triage at
+                    # 38 fails/24h.
+                    bool(vendors), Json(vendors) if vendors else None,
                     has_incident, has_budget,
                     budget_amount, posted_at,
                 ))


### PR DESCRIPTION
May-11 schema-drift triage from the 2026-05-10 Neon migration. Closes 6 missing tables (via direct DDL on prod, already done) + 4 code-level fixes shipping here.

## Background — root cause

**838+ cycle failures/24h** all traced to schema drift after May-10's Replit-Neon → owned-Neon pg_dump/pg_restore. The `migrations` tracking table was preserved (so the runner sees them as "applied"), but the May-10 backup dropped the actual table DDL for at least 6 tables. Verified via direct SQL on prod Neon (`small-scene-57890564`):

| migration | status table | table existed? |
|---|---|---|
| `055_phase3_disclosure_tables` | applied 2026-04-12 | ❌ tti_disclosure_extractions missing |
| `066_enforcement_history` | applied 2026-04-14 | ❌ enforcement_records missing |
| `071_protocol_parameter_history` | applied 2026-04-14 | ❌ 3 tables missing |
| `103_regulatory_registry_checks` | applied 2026-05-01 | ❌ regulatory_registry_checks missing |

Confirms hypothesis (a) from the triage: Replit-Neon's pg_dump skipped tables created outside Replit's UI.

## Action taken on prod (in parallel with this PR)

Re-applied DDL for all 6 tables via `run_sql` (idempotent `CREATE TABLE IF NOT EXISTS`). Verified all 7 tables (incl. the existing `governance_forum_posts`) now in `information_schema.tables`. Migrations table left as-is so the runner doesn't try to re-execute migrations with `CREATE INDEX CONCURRENTLY` inside a transaction.

## Code fixes in this PR

### #6 — `protocol_collateral_exposure.stablecoin_id` (65 fails/24h)

Two sites asked for columns that have never existed on this table (it uses `protocol_slug` + `token_symbol` + `is_stablecoin`, expects canonical id resolved via the stablecoins registry):

- **`app/coherence.py:227`** — `SELECT DISTINCT stablecoin_id ...` rewritten to JOIN `stablecoins` on `LOWER(symbol)` + filter `is_stablecoin=TRUE`.
- **`app/ops/routes.py:1883`** — `SELECT stablecoin_symbol, ...` aliased to `token_symbol AS stablecoin_symbol` so downstream consumers don't change.

### #7 — `governance_forum_posts.mentioned_vendors` jsonb vs text[] (38 fails/24h)

User's bug report referenced "rpi_forum_posts"; actual table is `governance_forum_posts`. Column is `jsonb`, code passes `list[str]` which psycopg2 adapts as `text[]`. PostgreSQL rejects the implicit cast. Fix: wrap with `psycopg2.extras.Json` so list becomes serialized jsonb.

### #9 — Etherscan HTML-as-hex parser (44 fails/24h)

`app/collectors/parameter_history.py::_eth_call_sync` called Etherscan v2 without `chainid`. Etherscan returns valid JSON with `result="Missing/Invalid Chain Id, see https://api.etherscan.io/v2/chainlist for the list of supported chains"`. Old code returned that string as if it were hex; `_decode_uint256` then crashed in `int(value, 16)`.

Fix:
- Add `chainid=1` to the request (the actual missing feature).
- Guard: validate `result` is a hex string (starts with `0x`, body is hex chars) before returning. If `status="0"` or result is non-hex, log structured warning with `status/message/prefix` and skip — caller treats it as `"0x"` / no data.

## Operational follow-up (NOT addressed here — for the punchlist)

**Alchemy returning HTTP 429 "Monthly capacity limit exceeded" — 88 fails/24h.** The Alchemy plan is exhausted. Operator decision needed:
- Upgrade Alchemy plan
- Investigate why dwellir fallback reverts on the same calls ("execution reverted" — different issue, suggests the call shape is wrong on dwellir)

Surfacing in the May-11 punchlist; not patching in code.

## Verification after merge

For each fixed cycle_phase, query:

```sql
SELECT cycle_phase, error_type, COUNT(*) AS n
FROM cycle_errors
WHERE cycle_phase = '<phase>'
  AND occurred_at > NOW() - INTERVAL '1 hour'
GROUP BY cycle_phase, error_type
ORDER BY n DESC;
```

Expected: zero rows (or only operational 429/timeout left). If the same error class persists at high volume, fix didn't take.

## Sequence

Wave-2c/d (dohi + governance_events freshness) and remaining cleanups (PR #138 metadata, psi_discoveries main.py:244, Wave-1 re-verification, May 11 punchlist) all queued for after this lands.

https://claude.ai/code/session_01T9JSBB6E4rxjLUssCLk5X3

---
_Generated by [Claude Code](https://claude.ai/code/session_01T9JSBB6E4rxjLUssCLk5X3)_