### PR TITLE
fix(followups): persist is_stale/error_message + close psi_discoveries gate

### DIFF
--- a/app/worker.py
+++ b/app/worker.py
@@ -338,15 +338,25 @@ def store_component_readings(components: list[dict]):
     
     with get_cursor() as cur:
         for comp in components:
+            # Persist `is_stale` and `error_message` if the collector
+            # provided them. Both columns exist on component_readings
+            # (migration 001). Before this fix the INSERT silently dropped
+            # them, so PR #138's exchange_trust_ratio "field absent" path
+            # was writing raw=NULL/normalized=NULL with is_stale=false and
+            # no error message — contradicting the structured-stale signal
+            # the fix intended.
             cur.execute("""
                 INSERT INTO component_readings
-                    (stablecoin_id, component_id, category, raw_value, normalized_score, data_source, collected_at)
-                VALUES (%s, %s, %s, %s, %s, %s, NOW())
+                    (stablecoin_id, component_id, category, raw_value, normalized_score,
+                     data_source, is_stale, error_message, collected_at)
+                VALUES (%s, %s, %s, %s, %s, %s, %s, %s, NOW())
                 ON CONFLICT (stablecoin_id, component_id, immutable_date(collected_at))
                 DO UPDATE SET
                     raw_value = EXCLUDED.raw_value,
                     normalized_score = EXCLUDED.normalized_score,
                     data_source = EXCLUDED.data_source,
+                    is_stale = EXCLUDED.is_stale,
+                    error_message = EXCLUDED.error_message,
                     collected_at = EXCLUDED.collected_at
             """, (
                 comp["stablecoin_id"],
@@ -355,6 +365,8 @@ def store_component_readings(components: list[dict]):
                 comp.get("raw_value"),
                 comp.get("normalized_score"),
                 comp.get("data_source", "unknown"),
+                bool(comp.get("is_stale", False)),
+                comp.get("error_message"),
             ))
 
 

--- a/main.py
+++ b/main.py
@@ -248,11 +248,21 @@ def run_worker_loop():
                     f"PSI expansion: {synced} stablecoins synced, {discovered} discovered, "
                     f"{enriched} enriched, {promoted} promoted"
                 )
-                # Attest PSI discoveries
+                # Attest PSI discoveries — always, even with discovered=0 and
+                # promoted=0. The enrichment-task path (#137) added the same
+                # fix at app/enrichment_worker.py, but its db_gate stays
+                # closed because main.py's `collect_collateral_exposure()`
+                # call above keeps `protocol_collateral_exposure` fresh —
+                # so the enrichment task never actually fires in production.
+                # That made #137's fix a no-op for the live code path and
+                # left psi_discoveries silent. Dropping the gate here too.
                 try:
                     from app.state_attestation import attest_state
-                    if discovered or promoted:
-                        attest_state("psi_discoveries", [{"synced": synced, "discovered": discovered, "enriched": enriched, "promoted": promoted}])
+                    attest_state(
+                        "psi_discoveries",
+                        [{"synced": synced, "discovered": discovered,
+                          "enriched": enriched, "promoted": promoted}],
+                    )
                 except Exception as ae:
                     logger.debug(f"PSI discovery attestation skipped: {ae}")
             except Exception as e:


### PR DESCRIPTION
Two May-11 followup cleanups, batched because they share the "fix swallowed at the persistence/active-path layer" theme.

## Cleanup A — component_readings `is_stale` / `error_message` persistence

#138 (exchange_trust_ratio "field absent" guard) sets `is_stale=True` + a structured `error_message` in the "no tickers carried trust signal" branch. But `app/worker.py:341`, the writer that takes those dicts and inserts into `component_readings`, never referenced those columns — so prod ended up with `raw_value=NULL/normalized_score=NULL` but `is_stale=false` and `error_message=NULL`. The structured signal #138 intended was being silently dropped at persistence.

Both columns exist on the table (migration 001:37-38). Fix is purely in the INSERT + ON CONFLICT UPDATE list — extend to write `is_stale` and `error_message`, defaulting to bool/None as the comp dict provides.

## Wave-2 followup — `psi_discoveries` main.py legacy path

#137 dropped the `if discovered or promoted` gate inside the enrichment task (`app/enrichment_worker.py::_run_psi_expansion`). But the **live path in production** is `main.py:222-258` — the daily PSI expansion inside `run_worker_loop`. That path also calls `collect_collateral_exposure()` itself, which keeps `protocol_collateral_exposure` fresh, which keeps the enrichment task's db_gate **closed**.

So the enrichment task never fires in steady state; the legacy main.py path is what's actually running; and that path still had the gate. **#137's fix was a no-op for the production code path.**

Dropping the gate in `main.py:244` too. Now whenever the daily-cycle PSI expansion runs (cadence 24h), it attests with whatever current state is — `discovered=0/promoted=0` is the canonical "registry steady" statement.

## Verification

After merge + worker redeploy:

```sql
SELECT entity_id, record_count, cycle_timestamp
FROM state_attestations
WHERE domain = 'psi_discoveries'
ORDER BY cycle_timestamp DESC LIMIT 5;
```
Should show a fresh row within ~24h.

```sql
SELECT component_id, raw_value, normalized_score, is_stale, error_message
FROM component_readings
WHERE component_id = 'exchange_trust_ratio'
  AND collected_at > NOW() - INTERVAL '2 hours'
ORDER BY collected_at DESC LIMIT 5;
```
For USDC: rows should show `is_stale=true, error_message='CoinGecko returned N tickers but none carried…'` when CoinGecko data is empty.

## Sequence

Remaining: Wave-2c (governance_events empty-list), Wave-2d (dohi heartbeat), cycle_errors re-verification, Wave-1 freshness re-verification, May-11 punchlist.

https://claude.ai/code/session_01T9JSBB6E4rxjLUssCLk5X3

---
_Generated by [Claude Code](https://claude.ai/code/session_01T9JSBB6E4rxjLUssCLk5X3)_