### PR TITLE
fix(governance): attest with status when protocols_processed is empty

### DIFF
--- a/app/collectors/governance_events.py
+++ b/app/collectors/governance_events.py
@@ -431,13 +431,25 @@ def run_governance_event_collection() -> dict:
         except Exception as e:
             logger.error(f"[gov_events] tally failed for {slug}: {e}")
 
-    # Attest governance events
+    # Attest governance events. When protocols_processed is empty the
+    # list-comprehension produces []; app/state_attestation.py::attest_state
+    # silently early-returns on empty list (line 63-64), so the domain
+    # would stay silent with no entry recorded. Pass a structured status
+    # payload in that case so coherence sees the cycle ran. Same pattern
+    # as the dohi_components else-branch and #146's ran_no_snapshots.
     try:
         from app.state_attestation import attest_state
-        attest_state("governance_events", [
-            {"protocol": slug, "new_events": total_new}
-            for slug in protocols_processed
-        ])
+        if protocols_processed:
+            attest_state("governance_events", [
+                {"protocol": slug, "new_events": total_new}
+                for slug in protocols_processed
+            ])
+        else:
+            attest_state("governance_events", [{
+                "status": "ran_no_protocols",
+                "total_new": total_new,
+                "total_skipped": total_skipped,
+            }])
     except Exception as e:
         logger.warning(f"Governance events attestation failed: {e}")
 


### PR DESCRIPTION
Wave-2c of the May 11 staleness triage. `governance_events` was 18h stale.

## Root cause

`app/collectors/governance_events.py:437` builds the attestation payload as a list comprehension over `protocols_processed`:

```python
attest_state("governance_events", [
    {"protocol": slug, "new_events": total_new}
    for slug in protocols_processed
])
```

When that list is empty (no protocols had Snapshot or Tally activity in the cycle), the comprehension produces `[]`. `app/state_attestation.py::attest_state` short-circuits on empty list at line 63-64:

```python
def attest_state(domain, records, entity_id=None):
    if not records:
        return ""
    ...
```

So the call returns silently with no row inserted. Same silent-drop pattern as #144 (mempool_observations) but on the **generator** side rather than the **writer** side.

## Fix

Branch on `protocols_processed` before the call. When non-empty, build the per-protocol records as before. When empty:

```python
[{"status": "ran_no_protocols", "total_new": 0, "total_skipped": 0}]
```

Gives coherence a concrete row ("cycle ran, no governance activity") and preserves the per-cycle freshness signal.

## Wave-2d note — `dohi_components` is on cadence, not broken

Inspection of state_attestations history for dohi_components shows it's firing at its expected ~24h cadence (rows on May 10 16:09, May 9 15:02, May 8 06:12, May 7 04:10, etc.). Its outer task `gate_check` is `governance_events` table freshness with `min_hours=24` — DOHI score doesn't change without governance activity, so daily re-scoring is by design. The inner attestation already handles both branches (results / `ran_no_results` status). Documenting in the May-11 punchlist rather than altering cadence.

## Verification

After merge + worker redeploy + next governance_events cycle:

```sql
SELECT entity_id, record_count, cycle_timestamp
FROM state_attestations
WHERE domain = 'governance_events'
ORDER BY cycle_timestamp DESC LIMIT 5;
```

Fresh row should appear within ~24h. If the cycle ran with no activity, payload will carry `status="ran_no_protocols"`.

## Sequence

Remaining: cycle_errors re-verification after #149 deploys, Wave-1 freshness re-verification after slow cycle elapses, May-11 punchlist.

https://claude.ai/code/session_01T9JSBB6E4rxjLUssCLk5X3

---
_Generated by [Claude Code](https://claude.ai/code/session_01T9JSBB6E4rxjLUssCLk5X3)_