### PR TITLE
fix(worker): inline attest for peg/exchange/ohlcv on the live worker path

### DIFF
--- a/app/worker.py
+++ b/app/worker.py
@@ -1233,6 +1233,20 @@ async def run_fast_cycle():
                 await asyncio.sleep(0.15)
         _ex_total = await fetch_one_async("SELECT COUNT(*) as c FROM exchange_snapshots")
         logger.error(f"=== EXCHANGES: {_ex_ok} ok, {_ex_err} err, total={_ex_total} ===")
+
+        # Attest from the live worker.py path (see peg_snapshots_5m comment
+        # below for why PR #146's data_layer/exchange_collector.py patch
+        # didn't take). data_layer:exchange_snapshots was 2.7d stale until
+        # this added the call to the inline writer's actual end.
+        try:
+            from app.data_layer.provenance_scaling import attest_data_batch
+            await asyncio.to_thread(attest_data_batch, "exchange_snapshots", [{
+                "status": "ok" if _ex_ok else "ran_no_inserts",
+                "exchanges_ok": _ex_ok,
+                "exchanges_err": _ex_err,
+            }])
+        except Exception as _e_attest:
+            logger.warning(f"exchange_snapshots worker attest failed: {_e_attest}")
     except Exception as _e2: logger.error(f"=== EXCHANGES FAILED: {_e2} ===")
 
     # ==== 3. YIELD SNAPSHOTS (DeFiLlama) ====
@@ -1316,6 +1330,23 @@ async def run_fast_cycle():
                 except Exception as _e: logger.error(f"peg fail {_sc['id']}: {_e}")
                 await asyncio.sleep(0.15)
         logger.error(f"=== PEG: {_pg_ok}, MCHART: {_mc_ok}, elapsed={time.time()-_mc_start:.1f}s ===")
+
+        # Attest from the live worker.py path. PR #146 patched
+        # app/data_layer/peg_monitor.py but that module is only called
+        # from the enrichment task, whose db_gate on peg_snapshots_5m
+        # stays closed because *this* loop keeps the table fresh. So
+        # the patched code is dead on the live path. Attest here instead
+        # — `data_layer:peg_snapshots_5m` was 2.7 days stale until this
+        # fix landed despite peg_snapshots_5m being written every cycle.
+        try:
+            from app.data_layer.provenance_scaling import attest_data_batch
+            await asyncio.to_thread(attest_data_batch, "peg_snapshots_5m", [{
+                "status": "ok" if _pg_ok else "ran_no_inserts",
+                "peg_rows": _pg_ok,
+                "mchart_rows": _mc_ok,
+            }])
+        except Exception as _e_attest:
+            logger.warning(f"peg_snapshots_5m worker attest failed: {_e_attest}")
     except Exception as _e5: logger.error(f"=== PEG FAILED: {_e5} ===")
 
     # ==== 6. LIQUIDITY DEPTH (CEX tickers) ====
@@ -2081,6 +2112,8 @@ async def run_slow_cycle():
     # -------------------------------------------------------------------------
     # DEX pool OHLCV — 6-hour gate, GeckoTerminal API
     # -------------------------------------------------------------------------
+    _ohlcv_status = "skipped_unknown"
+    _ohlcv_result = None
     try:
         ohlcv_last = await fetch_one_async("SELECT MAX(timestamp) as t FROM dex_pool_ohlcv")
         ohlcv_age = 7
@@ -2093,15 +2126,38 @@ async def run_slow_cycle():
         if ohlcv_age >= 6:
             from app.data_layer.ohlcv_collector import run_ohlcv_collection
             logger.info("Running DEX pool OHLCV collection...")
-            ohlcv_result = await run_ohlcv_collection()
+            _ohlcv_result = await run_ohlcv_collection()
+            _ohlcv_status = "ran"
             logger.info(
-                f"OHLCV collection: {ohlcv_result.get('records_stored', 0)} records, "
-                f"{ohlcv_result.get('pools_found', 0)} pools"
+                f"OHLCV collection: {_ohlcv_result.get('records_stored', 0)} records, "
+                f"{_ohlcv_result.get('pools_found', 0)} pools"
             )
         else:
+            _ohlcv_status = "skipped_fresh"
             logger.info(f"OHLCV collection skipped — last ran {ohlcv_age:.1f}h ago")
     except Exception as e:
+        _ohlcv_status = "error"
         logger.warning(f"OHLCV collection failed: {e}")
+
+    # Attest from worker.py side regardless of whether the 6h gate opened.
+    # PR #141 added attestation inside run_ohlcv_collection(), but the gate
+    # at the top of this block keeps the function silent in steady state
+    # (data is fresh ~4 hours out of every 6) — so the patched attest
+    # fired only 2 times ever per state_attestations. Heartbeating from
+    # the worker side gives the domain hourly freshness with a status that
+    # reflects whether collection actually fired.
+    try:
+        from app.data_layer.provenance_scaling import attest_data_batch
+        _ohlcv_payload = {
+            "status": _ohlcv_status,
+            "table_age_hours": round(ohlcv_age, 2) if isinstance(ohlcv_age, (int, float)) else None,
+        }
+        if _ohlcv_result:
+            _ohlcv_payload["records_stored"] = _ohlcv_result.get("records_stored", 0)
+            _ohlcv_payload["pools_found"] = _ohlcv_result.get("pools_found", 0)
+        await asyncio.to_thread(attest_data_batch, "dex_pool_ohlcv", [_ohlcv_payload])
+    except Exception as _e_attest:
+        logger.warning(f"dex_pool_ohlcv worker attest failed: {_e_attest}")
 
     # -------------------------------------------------------------------------
     # Wallet behavior tagging — every cycle, computed from existing data


### PR DESCRIPTION
P1+P2 of the 2026-05-11 Wave-3 staleness triage. Same diagnostic as psi_discoveries #137 → #150: PRs #141 and #146 patched the `app/data_layer/` modules, but those modules are **dead code on the live worker path**. The actual writers are inline in `app/worker.py`.

## Evidence

State_attestations row counts BEFORE this fix (per `SELECT domain, COUNT(*) FROM state_attestations GROUP BY domain`):

| domain | total rows ever | latest |
|---|---|---|
| `data_layer:peg_snapshots_5m` | 3 | 2026-05-08 |
| `data_layer:exchange_snapshots` | 11 | 2026-05-08 |
| `data_layer:dex_pool_ohlcv` | 2 | 2026-05-01 |

Yet the underlying tables are written on every fast cycle (peg latest data 46m old, dex_pool_ohlcv latest 2h48m old). Worker comment at `app/worker.py:1147` confirms the design: *"Data layer — fetch + store directly in worker.py (proven pattern). No collector store functions. worker.py owns the INSERT."* That comment is correct; the `data_layer/` modules' attestation just isn't wired to it.

## Fix

Three additions to `app/worker.py`:

1. **After PEG block (~line 1318)** — `attest_data_batch("peg_snapshots_5m", [{status, peg_rows, mchart_rows}])`. Status is `"ok"` when `_pg_ok > 0`, `"ran_no_inserts"` otherwise.

2. **After EXCHANGE block (~line 1236)** — same pattern with `{status, exchanges_ok, exchanges_err}`.

3. **After OHLCV gate-check block (~line 2104)** — always attest, even when the 6h gate keeps `run_ohlcv_collection()` from firing. Payload carries `status` (`"ran"` / `"skipped_fresh"` / `"error"`), `table_age_hours`, and result counts when collection ran. PR #141's attest inside `ohlcv_collector` stays — useful when collection actually fires; worker-side heartbeat is the freshness backstop.

All three are wrapped in try/except logger.warning so a transient DB issue can't poison the cycle.

## Wave-3 follow-up surfaced

`state_attestations.domain` column is **VARCHAR(30)**. At least 3 collectors generate domain names that exceed it (`data_layer:entity_snapshots_hourly`=34, `data_layer:market_chart_history`=31, `data_layer:wallet_chain_presence`=32). 2 `data_layer_attest_data_batch_failure` errors in last 24h confirm with `"value too long for type character varying(30)"`. **Separate PR will widen the column** — not addressed here since the three domains I'm fixing in this PR all fit within 30 chars.

## Verification

After merge + worker redeploy + one fast cycle (~hourly):

```sql
SELECT domain, MAX(cycle_timestamp) AS latest, NOW() - MAX(cycle_timestamp) AS staleness
FROM state_attestations
WHERE domain IN (
  'data_layer:peg_snapshots_5m',
  'data_layer:exchange_snapshots',
  'data_layer:dex_pool_ohlcv'
) GROUP BY domain;
```

All three should show < 1h staleness.

## Sequence

P3-P6 (mempool_capture_status, wallets, web_research, psi_discoveries) follow in separate PRs — each potentially a different live-path mismatch.

https://claude.ai/code/session_01T9JSBB6E4rxjLUssCLk5X3

---
_Generated by [Claude Code](https://claude.ai/code/session_01T9JSBB6E4rxjLUssCLk5X3)_