### PR TITLE
fix(mempool): emit capture_status heartbeat from worker cycle, not WS loop

### DIFF
--- a/app/data_layer/mempool_watcher.py
+++ b/app/data_layer/mempool_watcher.py
@@ -895,6 +895,31 @@ async def emit_24h_summary() -> None:
         "alchemy_cu_rolling24h": cu_rolling,
     })
 
+    # mempool_capture_status heartbeat — fires from the worker cycle
+    # regardless of WS state. PR #140 added a heartbeat inside
+    # _subscribe_and_consume's frame loop, but that loop never runs
+    # when the WS connection itself is rejected. Today the watcher is
+    # disabled after 20 consecutive 429s from Alchemy (the same
+    # capacity issue tracked in the May 11 punchlist), so the inner
+    # heartbeat never fires and mempool_capture_status went 14 days
+    # silent. Emitting from emit_24h_summary, which is called from
+    # worker.py every fast cycle, decouples the freshness signal from
+    # the WS lifecycle.
+    #
+    # We classify "running" vs "stalled" on captured-rows in the last
+    # 24h. Non-zero means observations landed (either via WS or via
+    # whatever fallback path), so the watcher's net effect is alive.
+    try:
+        cap_24h = int(summary["captured"])
+        cap_status = "running" if cap_24h > 0 else "stalled"
+        await _attest_capture_status(
+            cap_status,
+            f"worker_heartbeat captured_24h={cap_24h} "
+            f"alchemy_cu_24h={cu_rolling}",
+        )
+    except Exception as e:
+        logger.warning(f"[mempool_capture_status] heartbeat skipped: {e}")
+
 
 # ---------------------------------------------------------------------------
 # Orchestration entry point


### PR DESCRIPTION
P3 of the 2026-05-11 Wave-3 staleness triage. `mempool_capture_status` went 14 days silent. PR #140 added a 1h heartbeat inside `_subscribe_and_consume`'s frame loop — but that loop never runs when the WebSocket connection itself is rejected.

## Root cause (smoking gun in cycle_errors)

```
cycle_phase   = mempool_watcher
error_type    = mempool_watcher_disabled
error_message = "20 consecutive failures. Last: InvalidStatus:
                 server rejected WebSocket connection: HTTP 429"
occurred_at   = 2026-05-11T11:27:57Z
```

Alchemy is rate-limiting the WS subscribe (same capacity issue tracked in the May 11 punchlist follow-up #1). The watcher gave up after 20 attempts. `_subscribe_and_consume` never enters its frame loop, so PR #140's heartbeat never has a chance to fire.

State_attestations confirms: the last 10 `mempool_capture_status` rows are all `entity_id='resumed'`, latest `2026-04-26` — exactly the WS-lifecycle-driven pattern.

## Fix

Add a worker-side heartbeat in `emit_24h_summary()` (called from `worker.py:938` every fast cycle). Decouples the freshness signal from the WS lifecycle entirely. Classifies as:

| condition | status |
|---|---|
| `captured_24h > 0` | `"running"` |
| `captured_24h == 0` | `"stalled"` |

Same pattern PR #144 used to fix `mempool_observations` (which has been firing every 7 minutes since), now applied to `mempool_capture_status`.

PR #140's inner heartbeat stays — when the WS recovers it's still useful as a per-connection liveness signal. The worker-side heartbeat is the WS-independent backstop.

## Operational note (separate concern)

The underlying Alchemy quota exhaustion is still tracked in the May 11 punchlist follow-up #1 — this PR fixes only the freshness signal, not the root WS failure. Operator still needs to decide whether to upgrade Alchemy or investigate the dwellir fallback.

## Verification

After merge + worker redeploy + one fast cycle:

```sql
SELECT entity_id, cycle_timestamp
FROM state_attestations
WHERE domain = 'mempool_capture_status'
ORDER BY cycle_timestamp DESC LIMIT 3;
```

Should show recent rows with `entity_id` in `{'running','stalled'}`.

## Sequence

P4 (wallets), P5 (web_research), P6 (psi_discoveries) follow in separate PRs.

https://claude.ai/code/session_01T9JSBB6E4rxjLUssCLk5X3

---
_Generated by [Claude Code](https://claude.ai/code/session_01T9JSBB6E4rxjLUssCLk5X3)_