### PR TITLE
fix(wallets): worker-side attest decoupled from run_pipeline_batch

### DIFF
--- a/app/worker.py
+++ b/app/worker.py
@@ -1985,6 +1985,8 @@ async def run_slow_cycle():
     # -------------------------------------------------------------------------
     # Wallet batch re-index — every cycle (500 stalest wallets)
     # -------------------------------------------------------------------------
+    reindex_result: dict | None = None
+    reindex_failure: str | None = None
     try:
         from app.indexer.pipeline import run_pipeline_batch
         logger.info("Running wallet batch re-index (500 stalest wallets)...")
@@ -1996,7 +1998,43 @@ async def run_slow_cycle():
             f"{reindex_result.get('remaining', '?')} remaining"
         )
     except Exception as e:
+        reindex_failure = f"{type(e).__name__}: {e}"
         logger.warning(f"Wallet batch re-index failed: {e}")
+
+    # Attest "wallets" domain from the worker side regardless of how
+    # run_pipeline_batch ended. PR #142 added attestation inside the
+    # function at pipeline.py:806, but the function has at least four
+    # early-return paths (missing ETHERSCAN_API_KEY, stale-wallets query
+    # failure, all-wallets-fresh, and silent timeouts when batch_scan
+    # hangs past the asyncio.wait_for budget) — none of which reach the
+    # attest block. cycle_errors shows 10 enrichment_wallet_reindex
+    # timeouts in the last 24h, which is why the domain has been silent
+    # since May 1. Decouple the freshness signal from the indexer's
+    # success by attesting from worker.py with whatever state we have.
+    try:
+        from app.state_attestation import attest_state
+        if reindex_result is not None:
+            payload = {
+                "cycle": "batch_reindex_worker",
+                "status": "ok",
+                "processed": reindex_result.get("processed", 0),
+                "scored": reindex_result.get("scored", 0),
+                "balances_updated": reindex_result.get("balances_updated", 0),
+                "errors": reindex_result.get("errors", 0),
+                "remaining": reindex_result.get("remaining"),
+            }
+            if reindex_result.get("error"):
+                payload["status"] = "early_return"
+                payload["error_message"] = str(reindex_result["error"])[:200]
+        else:
+            payload = {
+                "cycle": "batch_reindex_worker",
+                "status": "failed",
+                "error_message": (reindex_failure or "unknown")[:200],
+            }
+        await asyncio.to_thread(attest_state, "wallets", [payload])
+    except Exception as _e_attest:
+        logger.warning(f"wallets worker attest failed: {_e_attest}")
 
     # -------------------------------------------------------------------------
     # Wallet expansion + profile rebuild — daily gate via DB timestamp


### PR DESCRIPTION
P4 of the 2026-05-11 Wave-3 staleness triage. `wallets` domain was 9 days stale despite PR #142 patching two attest sites.

## Root cause

The wallet batch re-index is **structurally broken**, not just silent. Direct query of `wallet_graph.wallets`:

| metric | value |
|---|---|
| total EVM wallets | 848,128 |
| stale (>24h) | 848,128 |
| indexed in last 1h | 0 |
| most recent index | 2026-05-01T19:40:40Z |

Not a single wallet has been indexed since May 1. `cycle_errors` shows why: `enrichment_wallet_reindex` hit 10 timeout-at-900s errors in the last 24h, and `enrichment_wallet_expansion` hit 10 timeout-at-2400s. `run_pipeline_batch` is hanging past its budget and never reaching the attest block at `pipeline.py:806`.

`run_pipeline_batch` also has four early-return paths that bypass the inner attest:

| line | condition |
|---|---|
| `pipeline.py:669` | `ETHERSCAN_API_KEY` missing |
| `pipeline.py:697` | stale-wallets query raises |
| `pipeline.py:705` | `wallet_list` empty (all fresh) |
| silent timeout | `batch_scan_all_holdings` hangs past `wait_for` budget |

PR #142's inner attest is correct for the happy path but the function is rarely reaching it.

## Fix

Add a worker-side attest in `worker.py`'s wallet re-index block (line 1985-1999) that fires **after** the try/except completes, regardless of whether `run_pipeline_batch` succeeded, errored, or hung. Status field distinguishes:

| status | meaning |
|---|---|
| `"ok"` | function returned with counts |
| `"early_return"` | function returned `{"error": ...}` |
| `"failed"` | function raised; `reindex_failure` captures class + message |

PR #142's inner attest stays — when the function completes the happy path, both fire (redundant but harmless). The worker-side attest is the freshness backstop.

## Operational follow-up (NOT addressed)

The underlying indexer timeouts (`batch_scan_all_holdings` hanging, 2400s expansion timeouts, 36 blockscout `fetch_single` failures) are a separate issue. This PR fixes only the freshness signal. The `wallets` data table won't advance until the indexer is fixed. Adding to punchlist.

## Verification

After merge + worker redeploy + one fast cycle:

```sql
SELECT entity_id, cycle_timestamp, record_count
FROM state_attestations
WHERE domain = 'wallets'
ORDER BY cycle_timestamp DESC LIMIT 3;
```

Should show fresh rows. State will most likely be `"failed"` or `"early_return"` until the indexer is fixed — that itself is the diagnostic signal operators need.

https://claude.ai/code/session_01T9JSBB6E4rxjLUssCLk5X3

---
_Generated by [Claude Code](https://claude.ai/code/session_01T9JSBB6E4rxjLUssCLk5X3)_