### PR TITLE
fix(web-research): worker-side attest decoupled from 24h gate

### DIFF
--- a/app/worker.py
+++ b/app/worker.py
@@ -1897,6 +1897,8 @@ async def run_slow_cycle():
     # -------------------------------------------------------------------------
     # Web research collection — daily gate (expensive Parallel API calls)
     # -------------------------------------------------------------------------
+    _wr_status = "skipped_unknown"
+    _wr_scored = 0
     try:
         last_research = await fetch_one_async(
             "SELECT MAX(computed_at) AS latest FROM generic_index_scores WHERE index_id LIKE 'web_research_%'"
@@ -1912,12 +1914,34 @@ async def run_slow_cycle():
             from app.collectors.web_research import run_web_research_collection
             logger.info("Running web research collection...")
             research_results = await run_web_research_collection()
-            scored = sum(1 for r in research_results if "score" in r)
-            logger.info(f"Web research complete: {scored} components collected")
+            _wr_scored = sum(1 for r in research_results if "score" in r)
+            _wr_status = "ran"
+            logger.info(f"Web research complete: {_wr_scored} components collected")
         else:
+            _wr_status = "skipped_fresh"
             logger.info(f"Web research skipped — last ran {research_age_hours:.1f}h ago")
     except Exception as e:
+        _wr_status = "error"
         logger.warning(f"Web research collection failed: {e}")
+
+    # Attest web_research from the worker side regardless of whether the
+    # 24h gate opened. The gate reads MAX(computed_at) across ALL
+    # web_research_* index_ids; if any single id (e.g. web_research_bridge)
+    # is fresher than 24h, the entire collector is skipped — even though
+    # web_research_protocol and web_research_exchange may be days stale.
+    # PR #143's attest inside run_web_research_collection() never fires
+    # when the gate skips. Heartbeat from the worker side decouples
+    # freshness from the gate.
+    try:
+        from app.state_attestation import attest_state
+        await asyncio.to_thread(attest_state, "web_research", [{
+            "status": _wr_status,
+            "gate_age_hours": round(research_age_hours, 2)
+                if isinstance(research_age_hours, (int, float)) else None,
+            "scored": _wr_scored,
+        }])
+    except Exception as _e_attest:
+        logger.warning(f"web_research worker attest failed: {_e_attest}")
 
     # -------------------------------------------------------------------------
     # Daily-gated: governance event collection (Snapshot/Tally)


### PR DESCRIPTION
P5 of the 2026-05-11 Wave-3 staleness triage. `web_research` domain was 8 days stale despite PR #143 patching the attest inside `run_web_research_collection()`.

## Root cause

Same shape as PR #153's OHLCV fix. `worker.py:1911` has a 24h gate:

```sql
SELECT MAX(computed_at) FROM generic_index_scores
WHERE index_id LIKE 'web_research_%'
```

When ANY `web_research_*` index_id is fresher than 24h, the gate is **closed** and `run_web_research_collection()` is skipped — taking the attest with it. Live query of `generic_index_scores` reveals the diagnostic:

| index_id | last computed | staleness |
|---|---|---|
| `web_research_bridge` | 2026-05-11 01:32 | 13h |
| `web_research_exchange` | 2026-05-04 12:27 | 7d |
| `web_research_protocol` | 2026-05-03 06:54 | 8d |

So `bridge` flipping the MAX-aggregated gate to "fresh" suppresses collection for `exchange` and `protocol` even though those are very stale. The inner attest never fires.

## Fix

Worker-side attest after the gate check, regardless of outcome:

| status | meaning |
|---|---|
| `"ran"` | gate opened, collector ran |
| `"skipped_fresh"` | gate closed because some `web_research_*` index is < 24h |
| `"error"` | exception in the block |

Payload includes `gate_age_hours` and `scored` count. PR #143's inner attest stays — it's the source of truth when collection fires; worker-side is the freshness backstop.

## Operational follow-up (NOT addressed)

The per-index_id staleness (protocol/exchange at 7-8d) is a separate concern — the collector's targeting needs to round-robin across `index_id`s rather than MAX-aggregating all of them. Surfacing in punchlist.

## Verification

After merge + worker redeploy + one fast cycle:

```sql
SELECT entity_id, cycle_timestamp
FROM state_attestations
WHERE domain = 'web_research'
ORDER BY cycle_timestamp DESC LIMIT 3;
```

Should show fresh rows with status in `{ran,skipped_fresh,error}`.

## Sequence

P6 (psi_discoveries) follows.

https://claude.ai/code/session_01T9JSBB6E4rxjLUssCLk5X3

---
_Generated by [Claude Code](https://claude.ai/code/session_01T9JSBB6E4rxjLUssCLk5X3)_