### PR TITLE
fix(psi): third psi_discoveries path — worker.py:2468 PSI expansion

### DIFF
--- a/app/worker.py
+++ b/app/worker.py
@@ -2468,6 +2468,9 @@ async def run_slow_cycle():
     # -------------------------------------------------------------------------
     # PSI expansion pipeline — daily gate (discover → enrich → promote)
     # -------------------------------------------------------------------------
+    _psi_status = "skipped_unknown"
+    _psi_synced = _psi_discovered = _psi_enriched = _psi_promoted = 0
+    _psi_hours_since: float | None = None
     try:
         from app.collectors.psi_collector import (
             collect_collateral_exposure,
@@ -2486,22 +2489,50 @@ async def run_slow_cycle():
             from datetime import date
             days_diff = (date.today() - last_date).days if isinstance(last_date, date) else 1
             hours_since = days_diff * 24
+        _psi_hours_since = hours_since
 
         if hours_since >= 24:
             logger.info("Running PSI expansion pipeline...")
             await asyncio.to_thread(collect_collateral_exposure)
-            synced = await asyncio.to_thread(sync_collateral_to_backlog)
-            discovered = await asyncio.to_thread(discover_protocols)
-            enriched = await asyncio.to_thread(enrich_protocol_backlog)
-            promoted = await asyncio.to_thread(promote_eligible_protocols)
+            _psi_synced = await asyncio.to_thread(sync_collateral_to_backlog)
+            _psi_discovered = await asyncio.to_thread(discover_protocols)
+            _psi_enriched = await asyncio.to_thread(enrich_protocol_backlog)
+            _psi_promoted = await asyncio.to_thread(promote_eligible_protocols)
+            _psi_status = "ran"
             logger.info(
-                f"PSI expansion: {synced} stablecoins synced, {discovered} discovered, "
-                f"{enriched} enriched, {promoted} promoted"
+                f"PSI expansion: {_psi_synced} stablecoins synced, {_psi_discovered} discovered, "
+                f"{_psi_enriched} enriched, {_psi_promoted} promoted"
             )
         else:
+            _psi_status = "skipped_fresh"
             logger.info(f"PSI expansion skipped — last ran {hours_since:.0f}h ago")
     except Exception as e:
+        _psi_status = "error"
         logger.warning(f"PSI expansion pipeline failed: {e}")
+
+    # Attest psi_discoveries from the live worker path. PR #137 patched
+    # the enrichment_worker task and PR #150 patched main.py:244, but
+    # this block at worker.py:2468 is the actual code that fires on
+    # every fast cycle. It runs `collect_collateral_exposure()` itself,
+    # which keeps protocol_collateral_exposure fresh, which closes the
+    # 24h db_gate on BOTH the enrichment task AND main.py's path —
+    # rendering both prior fixes dead code in practice.
+    #
+    # Heartbeat from here so freshness tracks the worker cycle, not the
+    # rare day when this block's own 24h gate happens to open.
+    try:
+        from app.state_attestation import attest_state
+        await asyncio.to_thread(attest_state, "psi_discoveries", [{
+            "status": _psi_status,
+            "hours_since_last_expansion": round(_psi_hours_since, 2)
+                if isinstance(_psi_hours_since, (int, float)) else None,
+            "synced": _psi_synced,
+            "discovered": _psi_discovered,
+            "enriched": _psi_enriched,
+            "promoted": _psi_promoted,
+        }])
+    except Exception as _e_attest:
+        logger.warning(f"psi_discoveries worker attest failed: {_e_attest}")
 
     # -------------------------------------------------------------------------
     # Pool wallet discovery — daily gate via DB timestamp


### PR DESCRIPTION
P6 of the 2026-05-11 Wave-3 staleness triage. `psi_discoveries` went 29 days silent despite PRs #137 (enrichment task) and #150 (main.py legacy duplicate). Both fixes are dead code on the live path.

## Root cause — the third path

`app/worker.py:2468-2504` is the actual PSI expansion code that runs on every fast cycle. It:

1. Reads `MAX(snapshot_date) FROM protocol_collateral_exposure` to check 24h freshness.
2. If stale, runs the chain: `collect_collateral_exposure → sync_collateral_to_backlog → discover_protocols → enrich → promote`.
3. **Never calls `attest_state`.**

Because step 1 writes to `protocol_collateral_exposure` itself, this block's own gate stays closed (data freshly written) for the next 24h. The enrichment task's `db_gate` (#137's path) also reads `protocol_collateral_exposure` freshness and stays closed for the same reason. `main.py`'s path (#150) also gates on the same table.

So all three paths see "data fresh, skip" almost every cycle, with **this single block firing the actual work and nobody attesting**.

| path | gates on | who keeps it closed |
|---|---|---|
| `enrichment_worker.py::_run_psi_expansion` (#137) | `protocol_collateral_exposure` freshness | worker.py:2468 itself |
| `main.py:222` (#150) | `time.time() - last_expansion_at >= 24h` + nothing else | worker.py:2468 if it runs first |
| `worker.py:2468` (this PR) | `MAX(snapshot_date) >= 24h` | itself — closes its own gate after each run |

## Fix

Add worker-side attest in the `worker.py:2468` block after the gate check + optional run. Status field captures:

| status | meaning |
|---|---|
| `"ran"` | gate opened, full chain executed; counts in synced/discovered/enriched/promoted |
| `"skipped_fresh"` | gate closed (data < 24h) |
| `"error"` | exception |

Plus `hours_since_last_expansion` for diagnostic. PRs #137 and #150 stay (no harm; useful if their paths ever do fire). The worker.py path is now the freshness source of truth.

## Verification

After merge + worker redeploy + one fast cycle:

```sql
SELECT entity_id, cycle_timestamp
FROM state_attestations
WHERE domain = 'psi_discoveries'
ORDER BY cycle_timestamp DESC LIMIT 3;
```

Should show fresh rows. Most cycles will write `status="skipped_fresh"` (the gate normally being closed is steady state). The point is that the cycle ran and was attested — the registry-stability case is no longer indistinguishable from a frozen worker.

## Wave-3 closes here

All 6 stuck-domain triages landed: P1+P2 (#153), P3 (#154), P4 (#155), P5 (#156), P6 (this).

Pending follow-ups for the punchlist:
1. **Schema widen** — `state_attestations.domain VARCHAR(30)` is too narrow; ≥3 collectors (entity_snapshots_hourly, market_chart_history, wallet_chain_presence) silently fail today.
2. **Indexer timeouts** — `run_pipeline_batch` hanging past `wait_for` budget; 848k wallets stuck since May 1.
3. **Alchemy quota** — WS rejected with 429; mempool watcher disabled.
4. **web_research per-index targeting** — `bridge` keeps the gate closed for `protocol` + `exchange`.

https://claude.ai/code/session_01T9JSBB6E4rxjLUssCLk5X3

---
_Generated by [Claude Code](https://claude.ai/code/session_01T9JSBB6E4rxjLUssCLk5X3)_