### PR TITLE
migration: widen state_attestations.domain (and siblings) to TEXT

### DIFF
--- a/docs/basis_punchlist_2026_05_11.md
+++ b/docs/basis_punchlist_2026_05_11.md
@@ -312,11 +312,25 @@ ORDER BY n DESC;
    work completes. Mempool capture is heartbeat-only in the interim;
    parameter_history collector continues failing ~88/day. Accepted
    degraded state.
-2. **state_attestations.domain VARCHAR(30) truncation** — 3 collectors
-   generate names exceeding 30 chars (entity_snapshots_hourly=34,
-   market_chart_history=31, wallet_chain_presence=32). 2 silent
-   `data_layer_attest_data_batch_failure` "value too long" errors in 24h.
-   Schema migration to TEXT (or VARCHAR(128)) queued.
+2. **state_attestations.domain VARCHAR(30) truncation — FIXED in
+   migration 107**. Diagnostic surfaced 10 attestation-related columns
+   with restrictive lengths (2 × `domain` VARCHAR(30), 8 ×
+   `methodology_version` VARCHAR(20) across state_attestations,
+   discovery_signals, assessment_events, component_batch_hashes,
+   cqi_attestations, report_attestations, rpi_score_history, rpi_scores).
+   All 10 widened to TEXT via `migrations/107_widen_attestation_columns_to_text.sql`,
+   applied to prod 2026-05-11T15:40:54Z.
+
+   Substrate verification (per lesson 7):
+   - `information_schema.columns`: all 10 columns now `data_type='text'`,
+     `character_maximum_length=NULL`
+   - `cycle_errors WHERE error_message LIKE '%value too long%' AND
+     occurred_at > NOW() - INTERVAL '1 hour'`: **0 rows** (was 2/24h
+     pre-migration)
+   - `migrations` table: row inserted `2026-05-11T15:40:54.978Z`
+
+   Long-named domain attestation verification (entity_snapshots_hourly,
+   market_chart_history, wallet_chain_presence) deferred to next cycle.
 3. **run_pipeline_batch structural hang** — FIXED in PR #160 (Wave 4).
    See above for diagnostic. Watch the Wave-4 verification queries over
    the next 24h: enrichment_wallet_reindex timeouts should stop, MAX

--- a/migrations/107_widen_attestation_columns_to_text.sql
+++ b/migrations/107_widen_attestation_columns_to_text.sql
@@ -1,0 +1,142 @@
+-- Migration 107: Widen attestation-related columns to TEXT
+--
+-- 2026-05-11 silent data loss class:
+--   state_attestations.domain VARCHAR(30) was truncating three
+--   collector-generated domain names that exceed 30 chars:
+--     data_layer:entity_snapshots_hourly (34)
+--     data_layer:market_chart_history (31)
+--     data_layer:wallet_chain_presence (32)
+--   2 silent `data_layer_attest_data_batch_failure` "value too long"
+--   errors in last 24h (more historically).
+--
+-- discovery_signals.domain shares the same 30-char limit. Widening
+-- preventively to avoid the same trap when discovery domains get
+-- longer names.
+--
+-- methodology_version VARCHAR(20) across 8 attestation tables is also
+-- restrictive — current values fit ("v1.0.0", "mempool-v0.1.0") but
+-- future versioning schemes (e.g. semantic-version + suffix) could
+-- exceed it. Widen now while the migration is cheap.
+--
+-- Per v9.10 amendment: ALTER COLUMN TYPE is safe on the pooler
+-- endpoint (no advisory locks, no session state required). Postgres
+-- TEXT and VARCHAR(n) share identical storage — the type change is
+-- O(1) in metadata, no table rewrite needed.
+--
+-- Idempotent: each ALTER is gated by an information_schema check so
+-- re-running is a no-op.
+
+DO $$
+BEGIN
+    -- state_attestations.domain
+    IF EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_schema = 'public'
+          AND table_name = 'state_attestations'
+          AND column_name = 'domain'
+          AND data_type = 'character varying'
+    ) THEN
+        ALTER TABLE state_attestations ALTER COLUMN domain TYPE TEXT;
+    END IF;
+
+    -- state_attestations.methodology_version
+    IF EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_schema = 'public'
+          AND table_name = 'state_attestations'
+          AND column_name = 'methodology_version'
+          AND data_type = 'character varying'
+    ) THEN
+        ALTER TABLE state_attestations ALTER COLUMN methodology_version TYPE TEXT;
+    END IF;
+
+    -- discovery_signals.domain
+    IF EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_schema = 'public'
+          AND table_name = 'discovery_signals'
+          AND column_name = 'domain'
+          AND data_type = 'character varying'
+    ) THEN
+        ALTER TABLE discovery_signals ALTER COLUMN domain TYPE TEXT;
+    END IF;
+
+    -- discovery_signals.methodology_version
+    IF EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_schema = 'public'
+          AND table_name = 'discovery_signals'
+          AND column_name = 'methodology_version'
+          AND data_type = 'character varying'
+    ) THEN
+        ALTER TABLE discovery_signals ALTER COLUMN methodology_version TYPE TEXT;
+    END IF;
+
+    -- assessment_events.methodology_version
+    IF EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_schema = 'public'
+          AND table_name = 'assessment_events'
+          AND column_name = 'methodology_version'
+          AND data_type = 'character varying'
+    ) THEN
+        ALTER TABLE assessment_events ALTER COLUMN methodology_version TYPE TEXT;
+    END IF;
+
+    -- component_batch_hashes.methodology_version
+    IF EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_schema = 'public'
+          AND table_name = 'component_batch_hashes'
+          AND column_name = 'methodology_version'
+          AND data_type = 'character varying'
+    ) THEN
+        ALTER TABLE component_batch_hashes ALTER COLUMN methodology_version TYPE TEXT;
+    END IF;
+
+    -- cqi_attestations.methodology_version
+    IF EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_schema = 'public'
+          AND table_name = 'cqi_attestations'
+          AND column_name = 'methodology_version'
+          AND data_type = 'character varying'
+    ) THEN
+        ALTER TABLE cqi_attestations ALTER COLUMN methodology_version TYPE TEXT;
+    END IF;
+
+    -- report_attestations.methodology_version
+    IF EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_schema = 'public'
+          AND table_name = 'report_attestations'
+          AND column_name = 'methodology_version'
+          AND data_type = 'character varying'
+    ) THEN
+        ALTER TABLE report_attestations ALTER COLUMN methodology_version TYPE TEXT;
+    END IF;
+
+    -- rpi_score_history.methodology_version
+    IF EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_schema = 'public'
+          AND table_name = 'rpi_score_history'
+          AND column_name = 'methodology_version'
+          AND data_type = 'character varying'
+    ) THEN
+        ALTER TABLE rpi_score_history ALTER COLUMN methodology_version TYPE TEXT;
+    END IF;
+
+    -- rpi_scores.methodology_version
+    IF EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_schema = 'public'
+          AND table_name = 'rpi_scores'
+          AND column_name = 'methodology_version'
+          AND data_type = 'character varying'
+    ) THEN
+        ALTER TABLE rpi_scores ALTER COLUMN methodology_version TYPE TEXT;
+    END IF;
+END $$;
+
+INSERT INTO migrations (name) VALUES ('107_widen_attestation_columns_to_text') ON CONFLICT DO NOTHING;


### PR DESCRIPTION
Operational follow-up #2 from the May 11 punchlist — silent data loss class.

## Diagnostic surfaced 10 columns

| table | column | old | new |
|---|---|---|---|
| state_attestations | domain | VARCHAR(30) | TEXT |
| state_attestations | methodology_version | VARCHAR(20) | TEXT |
| discovery_signals | domain | VARCHAR(30) | TEXT |
| discovery_signals | methodology_version | VARCHAR(20) | TEXT |
| assessment_events | methodology_version | VARCHAR(20) | TEXT |
| component_batch_hashes | methodology_version | VARCHAR(20) | TEXT |
| cqi_attestations | methodology_version | VARCHAR(20) | TEXT |
| report_attestations | methodology_version | VARCHAR(20) | TEXT |
| rpi_score_history | methodology_version | VARCHAR(20) | TEXT |
| rpi_scores | methodology_version | VARCHAR(20) | TEXT |

`cycle_errors` columns are already TEXT — no action needed there.

Per v9.10 amendment: `ALTER COLUMN TYPE` from VARCHAR(n) → TEXT is safe on the pooler endpoint. Postgres TEXT and VARCHAR(n) share identical storage — the type change is metadata-only, no table rewrite. Idempotent via `information_schema.columns` data_type check inside a single DO block.

## Applied to prod (substrate verification per lesson 7)

Migration applied directly via run_sql on prod Neon (`small-scene-57890564`) at `2026-05-11T15:40:54Z`.

```sql
-- 1. information_schema.columns: all 10 cols
SELECT table_name, column_name, data_type, character_maximum_length FROM ...
→ all 10 rows show data_type='text', character_maximum_length=NULL

-- 2. cycle_errors truncation in last hour
SELECT COUNT(*) FROM cycle_errors WHERE error_message LIKE '%value too long%' AND occurred_at > NOW() - INTERVAL '1 hour'
→ 0 (was 2/24h pre-migration)

-- 3. migrations table
SELECT name, applied_at FROM migrations WHERE name = '107_widen_attestation_columns_to_text'
→ 107_widen_attestation_columns_to_text @ 2026-05-11T15:40:54.978Z
```

## Deferred per lesson 7

Long-named-domain attestation (entity_snapshots_hourly, market_chart_history, wallet_chain_presence) needs a worker cycle to elapse post-migration. Will not claim full closure until those domains appear in `state_attestations`.

## Punchlist update

Op follow-up #2 updated from "queued" to "FIXED in migration 107" with substrate verification quoted inline.

https://claude.ai/code/session_01T9JSBB6E4rxjLUssCLk5X3

---
_Generated by [Claude Code](https://claude.ai/code/session_01T9JSBB6E4rxjLUssCLk5X3)_