### PR TITLE
docs(pr-template): require substrate-verification section

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,51 @@
+## Summary
+
+<!-- 1–3 bullets on what changed and why. -->
+
+## Substrate verification
+
+Per lesson 7 (verification must cite substrate, not expectation), no PR
+claims its change took without quoting substrate. Fill exactly one of
+the two sections below. If neither applies (pure docs/refactor with no
+runtime contract), state that explicitly under "N/A" and explain why.
+
+### Pre-deploy (theoretical / pure docs / no runtime contract)
+
+The query the substrate should answer after deploy, and the elapsed
+cadence to wait before checking:
+
+```sql
+-- query the deploy verifier will run after the next cadence elapses
+```
+
+Expected post-deploy: <!-- e.g. "domain X freshness < 30 min, COUNT(*) increments" -->
+
+### Post-deploy (code touches a running system; result already known)
+
+```sql
+-- query
+```
+
+Result:
+
+```
+-- output
+```
+
+### N/A
+
+<!-- Leave the two sections above blank and explain why no substrate is
+applicable. The CI gate (.github/workflows/pr-substrate-gate.yml)
+requires this section header to appear when the others are empty. -->
+
+## Test plan
+
+<!-- Bulleted checklist of TODOs for testing this PR. -->
+
+- [ ]
+
+<!--
+Reminder: don't push to `main` directly. One thing per PR. After merge,
+update docs/sessions/<date>-<context>.md if this PR was part of an
+orchestrated session.
+-->

--- a/.github/workflows/pr-substrate-gate.yml
+++ b/.github/workflows/pr-substrate-gate.yml
@@ -1,0 +1,51 @@
+name: pr-substrate-gate
+# Enforces lesson 7 (verification must cite substrate, not expectation).
+# Every PR body must contain a "## Substrate verification" section
+# AND at least one of the three subsections: Pre-deploy / Post-deploy /
+# N/A. Failure means the operator forgot to fill in the template.
+#
+# Bypass: this check only runs on `pull_request` events, not on
+# direct pushes to main (those are blocked by branch protection
+# elsewhere). Bot accounts (dependabot, etc.) can be added to the
+# ALLOWLIST below if needed.
+
+on:
+  pull_request:
+    types: [opened, edited, reopened, synchronize, ready_for_review]
+
+jobs:
+  substrate-section-present:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check PR body contains substrate-verification section
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+        run: |
+          ALLOWLIST="dependabot[bot] github-actions[bot]"
+          for bot in $ALLOWLIST; do
+            if [ "$PR_AUTHOR" = "$bot" ]; then
+              echo "Bypass: PR author $PR_AUTHOR is allowlisted."
+              exit 0
+            fi
+          done
+
+          if [ -z "$PR_BODY" ]; then
+            echo "::error::PR body is empty — substrate verification section required."
+            exit 1
+          fi
+
+          # The required outer header.
+          if ! grep -qE '^##[[:space:]]+Substrate verification' <<<"$PR_BODY"; then
+            echo "::error::PR body missing '## Substrate verification' section. See .github/PULL_REQUEST_TEMPLATE.md."
+            exit 1
+          fi
+
+          # Must include at least one of the three subsection headers.
+          if grep -qE '^###[[:space:]]+(Pre-deploy|Post-deploy|N/A)' <<<"$PR_BODY"; then
+            echo "Substrate verification section present with at least one subsection."
+            exit 0
+          fi
+
+          echo "::error::'## Substrate verification' present, but no '### Pre-deploy', '### Post-deploy', or '### N/A' subsection found."
+          exit 1


### PR DESCRIPTION
## Summary

Codifies lesson 7 (verification must cite substrate, not expectation) as a CI gate. Every PR body must contain `## Substrate verification` and at least one of `### Pre-deploy`, `### Post-deploy`, or `### N/A` subsections.

- `.github/PULL_REQUEST_TEMPLATE.md` — scaffolds the section so contributors fill it in.
- `.github/workflows/pr-substrate-gate.yml` — runs on `pull_request` events, greps for the headers, fails the check on absence.

Bot allowlist (dependabot, github-actions) so vendor-bumped PRs don't trip the gate.

## Substrate verification

### Pre-deploy

The gate is enforced by the CI workflow itself. Expected after merge: any PR opened on basis-hub without the section header fails the `pr-substrate-gate / substrate-section-present` check; PRs including the template pass.

This PR's body intentionally exercises the template — the very headers we're enforcing are present here, so this PR is a live positive test.

## Test plan

- [ ] Open a sample PR with the template intact — CI passes.
- [ ] Open a sample PR with the template stripped — CI fails on `pr-substrate-gate`.
- [ ] dependabot PR (when one next opens) — CI bypasses.

Orchestrator item: Phase 1 / C.

https://claude.ai/code/session_orchestrator_2026_05_11

Co-authored-by: Claude <noreply@anthropic.com>

---
_Generated by [Claude Code](https://claude.ai/code/session_01MiWTwLQZW4GaDDeUQRucLv)_