### PR TITLE
fix(enrichment): bump class-(a) task budgets per audit

### DIFF
--- a/app/enrichment_worker.py
+++ b/app/enrichment_worker.py
@@ -514,7 +514,7 @@ async def run_enrichment_pipeline() -> dict:
 
     pipeline.add(EnrichmentTask(
         name="onchain_governance_reads", func=_run_gov_reads,
-        timeout_seconds=300, group="data_collection", priority=3,
+        timeout_seconds=600, group="data_collection", priority=3,
     ))
 
     # ---- Web research ----
@@ -682,7 +682,7 @@ async def run_enrichment_pipeline() -> dict:
 
     pipeline.add(EnrichmentTask(
         name="treasury_flows", func=_run_treasury_flows,
-        timeout_seconds=300, group="data_collection", priority=3,
+        timeout_seconds=600, group="data_collection", priority=3,
     ))
 
     # ---- Edge building ----
@@ -757,7 +757,7 @@ async def run_enrichment_pipeline() -> dict:
 
     pipeline.add(EnrichmentTask(
         name="divergence_detection", func=_run_divergence,
-        timeout_seconds=300, group="analysis", priority=3,
+        timeout_seconds=600, group="analysis", priority=3,
     ))
 
     # ---- PSI expansion pipeline ----
@@ -848,7 +848,7 @@ async def run_enrichment_pipeline() -> dict:
 
     pipeline.add(EnrichmentTask(
         name="governance_activity", func=_run_governance_collection,
-        timeout_seconds=600, group="data_layer", priority=3,
+        timeout_seconds=900, group="data_layer", priority=3,
         gate_check=_db_gate(
             "SELECT MAX(captured_at) AS latest FROM governance_proposals",
             min_hours=24,
@@ -1121,7 +1121,7 @@ async def run_enrichment_pipeline() -> dict:
 
     pipeline.add(EnrichmentTask(
         name="entity_discovery", func=_run_entity_discovery,
-        timeout_seconds=300, group="growth", priority=5,
+        timeout_seconds=600, group="growth", priority=5,
         gate_check=_db_gate(
             "SELECT MAX(detected_at) AS latest FROM discovery_signals WHERE signal_type = 'entity_discovery'",
             min_hours=168,  # weekly
@@ -1171,7 +1171,7 @@ async def run_enrichment_pipeline() -> dict:
 
     pipeline.add(EnrichmentTask(
         name="materialized_compositions", func=_run_materialized,
-        timeout_seconds=120, group="computed", priority=4,
+        timeout_seconds=300, group="computed", priority=4,
     ))
 
     # ---- Daily pulse generation ----
@@ -1233,7 +1233,7 @@ async def run_enrichment_pipeline() -> dict:
 
     pipeline.add(EnrichmentTask(
         name="data_catalog_update", func=_run_catalog_update,
-        timeout_seconds=60, group="housekeeping", priority=10,
+        timeout_seconds=300, group="housekeeping", priority=10,
     ))
 
     # ---- Run the pipeline ----


### PR DESCRIPTION
## Summary

Per `docs/audits/2026-05-11-enrichment-task-budget-audit.md` follow-up F1. Seven mechanical literal-bumps for tasks classified (a) "budget too tight" — work is bounded, the budget literal just didn't reflect it.

| task | from | to | timeouts/7d |
| --- | --- | --- | --- |
| data_catalog_update | 60s | 300 | 42 |
| materialized_compositions | 120s | 300 | 42 |
| treasury_flows | 300s | 600 | 43 |
| divergence_detection | 300s | 600 | 36 |
| onchain_governance_reads | 300s | 600 | 30 |
| entity_discovery | 300s | 600 | 20 |
| governance_activity | 600s | 900 | 8 |

Bundled into one PR per orchestrator §5 escape hatch — would have been seven separate PRs but bundling keeps the session PR count under the 15-PR ceiling. Each hunk is a one-line change at a known file:line, independently revertable.

## Substrate verification

### Pre-deploy

Pre-bump baseline quoted in the audit doc (PR #176). Expected post-deploy (24h): each task's timeout count in `cycle_errors` drops to ≤ 50% of the pre-bump rate.

```sql
SELECT cycle_phase, COUNT(*) AS n_24h
FROM cycle_errors
WHERE error_type = 'enrichment_task_timeout'
  AND occurred_at > NOW() - INTERVAL '24 hours'
  AND cycle_phase IN (
    'enrichment_data_catalog_update',
    'enrichment_materialized_compositions',
    'enrichment_treasury_flows',
    'enrichment_divergence_detection',
    'enrichment_onchain_governance_reads',
    'enrichment_entity_discovery',
    'enrichment_governance_activity'
  )
GROUP BY 1 ORDER BY 2 DESC;
```

Tasks that stay above 50% of pre-bump rate get promoted to class (b) per the audit's F4 follow-up (re-run on 2026-05-18).

## Test plan

- [ ] Verify 24h post-deploy that each task's `cycle_errors` timeout count drops ≥ 50%.
- [ ] If any task stays high, open a Wave-N prompt and reclassify as (b) in the audit doc.

Cross-references: PR #176 (audit), PR #160 (class-(b) exemplar).

https://claude.ai/code/session_orchestrator_2026_05_11

Co-authored-by: Claude <noreply@anthropic.com>

---
_Generated by [Claude Code](https://claude.ai/code/session_01MiWTwLQZW4GaDDeUQRucLv)_