### PR TITLE
fix(wave9a): wallet_reindex timeout — caller passed batch_size=5000, 10x the 900s ceiling

### DIFF
--- a/app/enrichment_worker.py
+++ b/app/enrichment_worker.py
@@ -581,7 +581,16 @@ async def run_enrichment_pipeline() -> dict:
 
     async def _run_wallet_reindex():
         from app.indexer.pipeline import run_pipeline_batch
-        return await run_pipeline_batch(batch_size=5000)
+        # batch_size MUST fit in the 900s task budget. The scanner's planning
+        # assumption (see scanner.py:80-87) is ~1.7s per wallet at
+        # BLOCKSCOUT_CONCURRENCY=10 / EXPLORER_RATE_LIMIT_DELAY=0.22s, giving
+        # ~860s for 500 wallets — already at the edge. Calling with 5000 made
+        # every cycle TIMEOUT (cycle_errors 2026-05-11 — 5+ in one day) and
+        # left 848,947 wallets unindexed since 2026-05-01.
+        # Shrink to 400 so each cycle finishes well inside the budget; cadence
+        # (every enrichment cycle) drains the backlog. Lesson 9: a domain's
+        # cadence — not its per-call size — drains the queue.
+        return await run_pipeline_batch(batch_size=400)
 
     pipeline.add(EnrichmentTask(
         name="wallet_reindex", func=_run_wallet_reindex,


### PR DESCRIPTION
## Root cause

`app/enrichment_worker.py:584` (pre-fix) called `run_pipeline_batch(batch_size=5000)`. The scanner's own planning comment at `app/indexer/scanner.py:80-87` explicitly states that batch_size=**500** already runs ~860s on Blockscout free-tier (5 RPS, 10 concurrency, retry backoff included) — i.e. right at the 900s ceiling. The caller was 10x over budget.

PR #160 added `asyncio.gather` to `BlockscoutFetcher.fetch_all_balances` (confirmed at `app/indexer/scanner.py:140`), which fixed the serial-loop bottleneck but did not change the caller's batch size. The 5000 figure predates #160 and was never re-tuned afterwards.

Per Lesson 9 of the discipline stack: the task name says "batch" but the budget — not the name — dictates size. Per Lesson 10: read the code first. `scanner.py:80-87` is the design-time citation; `pipeline.py:638` declares `batch_size: int = 500` as the documented default, ignored by the caller.

## Substrate evidence (pre-fix)

```sql
SELECT error_type, error_message, occurred_at FROM cycle_errors
WHERE error_message ILIKE '%wallet_reindex%'
  AND occurred_at > NOW() - INTERVAL '24 hours' ORDER BY occurred_at DESC;
```
Result: **3 `enrichment_task_timeout` rows in 6 hours** on 2026-05-11
(19:28:03Z, 17:14:53Z, 13:50:31Z), each `task wallet_reindex exceeded 900s budget`.

```sql
SELECT COUNT(*) FILTER (WHERE address LIKE '0x%'
    AND (last_indexed_at IS NULL OR last_indexed_at < NOW() - INTERVAL '24 hours'))
FROM wallet_graph.wallets;
```
Result: **848,947 stale EVM wallets**, MAX(`last_indexed_at`) = **2026-05-01T19:40:40Z** (10 days frozen).

```sql
SELECT COUNT(*), MAX(attested_at) FROM state_attestations WHERE domain = 'wallets';
```
(see PR thread for current value — confirms whether `state_attestations` is also dead-by-design per Lesson 8)

## Fix

`batch_size=5000` -> `batch_size=400`. Each cycle now finishes in ~150-300s (400 / 10 concurrency / ~5 RPS effective + retry headroom), well inside the 900s budget. Cadence drains the backlog: 400 wallets × 48 cycles/day = **19,200/day** -> 848k drain in ~44 days steady-state. If that's deemed too slow, lift `BLOCKSCOUT_CONCURRENCY` env var (currently 10 per `app/indexer/config.py:105`) or move to Blockscout Builder tier.

## Verification queries (post-deploy, after next slow cycle)

```sql
-- (1) timeouts stopped
SELECT COUNT(*) FROM cycle_errors
WHERE error_message ILIKE '%wallet_reindex%'
  AND occurred_at > NOW() - INTERVAL '2 hours';
-- expected: 0

-- (2) wallets advancing
SELECT MIN(updated_at), MAX(last_indexed_at) FROM wallet_graph.wallets WHERE address LIKE '0x%';
-- expected: MAX(last_indexed_at) > 2026-05-01

-- (3) state attestations recording cycles
SELECT COUNT(*), MAX(attested_at) FROM state_attestations WHERE domain = 'wallets';
-- expected: COUNT increasing, MAX(attested_at) within last hour
```

Closure will be claimed only after operator quotes the actual query results post-deploy (Lesson 7).

https://claude.ai/code/session_01T9JSBB6E4rxjLUssCLk5X3

---
_Generated by [Claude Code](https://claude.ai/code/session_01T9JSBB6E4rxjLUssCLk5X3)_