### PR TITLE
docs(phase-a1): local dev environment inventories — read-only

### DIFF
--- a/docs/development/dockerfile-inventory.md
+++ b/docs/development/dockerfile-inventory.md
@@ -1,0 +1,172 @@
+# Dockerfile Inventory
+
+## Summary Table
+
+| File | Base Image | Exposed Ports | Entrypoint | Multistage |
+|------|-----------|---------------|-----------|-----------|
+| Dockerfile.api | python:3.11-slim | None | CMD only | No |
+| Dockerfile.worker | python:3.11-slim | None | CMD only | No |
+| Dockerfile.keeper | node:22-slim | None | CMD only | No |
+
+---
+
+## Dockerfile.api
+
+**Path:** `Dockerfile.api`
+
+### Base Image(s)
+- `python:3.11-slim`
+
+### Multi-stage
+No
+
+### WORKDIR
+- `/app`
+
+### EXPOSE
+None
+
+### ENTRYPOINT / CMD
+- **CMD:** `["python", "main.py"]`
+
+### Environment Variables (hardcoded)
+- `WORKER_ENABLED=false`
+- `KEEPER_ENABLED=false`
+- `PORT=8000`
+
+### System Dependencies (apt-get/pip)
+- **apt-get:** `libpq-dev`, `gcc` (database client dev libs and C compiler)
+- **pip:** dependencies from `requirements.txt`, plus explicitly `x402>=2.6.0`
+
+### COPY/ADD
+- `requirements.txt` → `/app/`
+- `app/` → `/app/app/`
+- `frontend/dist/` → `/app/frontend/dist/` (pre-built frontend)
+- `migrations/` → `/app/migrations/`
+- `public/` → `/app/public/`
+- `fonts/` → `/app/fonts/`
+- `main.py` → `/app/`
+
+### USER
+None (runs as root)
+
+### HEALTHCHECK
+None
+
+### Build Args (ARG)
+None declared
+
+### .dockerignore
+Yes (shared at repo root)
+
+---
+
+## Dockerfile.worker
+
+**Path:** `Dockerfile.worker`
+
+### Base Image(s)
+- `python:3.11-slim`
+
+### Multi-stage
+No
+
+### WORKDIR
+- `/app`
+
+### EXPOSE
+None
+
+### ENTRYPOINT / CMD
+- **CMD:** `["python", "-m", "app.worker", "--loop"]`
+
+### Environment Variables (hardcoded)
+None
+
+### System Dependencies (apt-get/pip)
+- **apt-get:** `libpq-dev`, `gcc` (database client dev libs and C compiler)
+- **pip:** dependencies from `requirements.txt`
+
+### COPY/ADD
+- `requirements.txt` → `/app/`
+- `app/` → `/app/app/` (cache bust comment dated 2026-04-14T01:40Z)
+
+### USER
+None (runs as root)
+
+### HEALTHCHECK
+None
+
+### Build Args (ARG)
+None declared
+
+### .dockerignore
+Yes (shared at repo root)
+
+---
+
+## Dockerfile.keeper
+
+**Path:** `Dockerfile.keeper`
+
+### Base Image(s)
+- `node:22-slim`
+
+### Multi-stage
+No
+
+### WORKDIR
+- `/app`
+
+### EXPOSE
+None
+
+### ENTRYPOINT / CMD
+- **CMD:** `["npx", "tsx", "keeper/index.ts"]`
+
+### Environment Variables (hardcoded)
+None
+
+### System Dependencies (apt-get/npm)
+- **npm:** dependencies from `package.json` and `package-lock.json`
+
+### COPY/ADD
+- `package.json`, `package-lock.json*` → `/app/`
+- `keeper/` → `/app/keeper/`
+- `tsconfig.base.json*`, `tsconfig.json*` → `/app/` (optional files)
+
+### USER
+None (runs as root)
+
+### HEALTHCHECK
+None
+
+### Build Args (ARG)
+None declared
+
+### .dockerignore
+Yes (shared at repo root)
+
+---
+
+## Gaps & Notes
+
+1. **No exposed ports:** None of the three containers declare EXPOSE directives. Service port configuration likely happens at orchestration/deployment layer (e.g., docker-compose, Kubernetes manifests, or Railway config).
+
+2. **Port environment variable:** Only `Dockerfile.api` hardcodes `PORT=8000`. The actual HTTP port exposure is not declared in any Dockerfile.
+
+3. **No HEALTHCHECK directives:** None of the Dockerfiles define health checks. Consider adding if these are deployed in a managed orchestration environment.
+
+4. **All run as root:** No USER directive in any Dockerfile—all services run as root UID inside containers. This is a security consideration for production deployments.
+
+5. **Cache bust comment:** `Dockerfile.worker` contains a cache-bust comment dated 2026-04-14, suggesting intentional rebuild forcing.
+
+6. **Optional tsconfig files:** `Dockerfile.keeper` uses wildcard `*` for tsconfig files—they are optional and may not exist.
+
+7. **Shared .dockerignore:** All three Dockerfiles rely on a single `.dockerignore` at repo root (not per-Dockerfile). The .dockerignore excludes markdown files globally (`*.md`) but preserves `README.md`, which may affect build context size.
+
+8. **No ARG declarations:** No build-time arguments in any Dockerfile—all configuration is hardcoded or passed via environment at runtime.
+
+9. **Requirements verification:** `requirements.txt` and `package.json` are confirmed to exist in repo root. All COPY targets (`app/`, `frontend/dist/`, `migrations/`, `public/`, `fonts/`, `keeper/`) are confirmed to exist.
+
+10. **Keeper missing lock file risk:** `Dockerfile.keeper` uses `package-lock.json*` (optional) which could lead to non-deterministic npm installs if the lock file is not present.

--- a/docs/development/env-var-inventory.md
+++ b/docs/development/env-var-inventory.md
@@ -1,0 +1,452 @@
+# Environment Variable Inventory
+
+Complete record of all environment variables that basis-hub reads at runtime. This document is the single source of truth for configuration requirements across the application stack.
+
+**Last Updated:** 2026-05-12  
+**Total Unique Variables:** 51
+
+---
+
+## Summary Table
+
+| Variable Name | Category | Required | Default | Controls |
+|---|---|---|---|---|
+| ADMIN_KEY | SECRET | No | `""` | Admin endpoint authentication |
+| ALERT_EMAIL | METADATA | No | `shlok@basisprotocol.xyz` | Alert recipient email address |
+| ALCHEMY_API_KEY | SECRET | No | `""` | Ethereum RPC provider primary key |
+| ANTHROPIC_API_KEY | SECRET | No | `""` | Claude API access for analysis/drafting |
+| ARBITRUM_ORACLE_ADDRESS | METADATA | No | none | Arbitrum oracle contract address |
+| ATTESTOR_PUBLIC_KEY | METADATA | No | `""` | State attestation public key verification |
+| BACKLOG_COLLATERAL_THRESHOLD | TUNING | No | `500000` | Collateral floor to promote protocol to backlog |
+| BACKLOG_PROMOTE_THRESHOLD | TUNING | No | `1000000` | Value floor for backlog → index promotion |
+| BACKLOG_VALUE_FILTER | FEATURE_FLAG | No | `false` | Enable value-based backlog filtering |
+| BASE_ORACLE_ADDRESS | METADATA | No | none | Base chain oracle contract address |
+| BASE_SBT_ADDRESS | METADATA | No | `""` | Base chain SBT contract address |
+| BASIS_PAYMENT_WALLET | METADATA | No | `""` | USDC payment receiver wallet (Base) |
+| BASIS_ENGINE_GITHUB_PAT | SECRET | No | `""` | GitHub personal access token for engine commits |
+| BASIS_ENGINE_LLM_DAILY_CALL_CEILING | TUNING | No | `50` | Max Claude API calls per UTC day |
+| BASIS_ENGINE_LLM_MONTHLY_BUDGET_USD | TUNING | No | `200.0` | Max monthly USD spend on Claude API |
+| BASIS_ENGINE_TEST_MODE | FEATURE_FLAG | No | `false` | Bypass git operations in engine approval flow |
+| BASIS_API_BASE | METADATA | No | none | Local API base URL for scripts |
+| BASIS_API_URL | METADATA | No | `https://basisprotocol.xyz` | Public API URL for client scripts |
+| BLOCKSCOUT_API_KEY | SECRET | No | `""` | Blockscout block explorer API key |
+| BLOCKSCOUT_COMPARISON_ENABLED | FEATURE_FLAG | No | `true` | Enable Etherscan ↔ Blockscout comparison |
+| BLOCKSCOUT_CONCURRENCY | TUNING | No | `10` | Max concurrent Blockscout API requests |
+| BLOCK_EXPLORER_PROVIDER | METADATA | No | `blockscout` | Primary block explorer (`blockscout` or `etherscan`) |
+| CANONICAL_BASE_URL | METADATA | No | `https://basisprotocol.xyz` | Public-facing domain for page rendering |
+| CDA_COLLECTION_INTERVAL_HOURS | TUNING | No | `24` | Hours between CDA extraction cycles |
+| CHAIN_EXPANSION_TVL_THRESHOLD | TUNING | No | `500000000` | TVL threshold ($USD) for chain inclusion |
+| COINGECKO_API_KEY | SECRET | No | `""` | CoinGecko API key for price/market data |
+| COLLECTION_INTERVAL | TUNING | No | `60` | Minutes between data collection cycles |
+| CORS_ORIGINS | METADATA | No | `*` | CORS allowed origins (comma-separated) |
+| CDP_API_KEY_ID | SECRET | No | `""` | Coinbase Developer Platform API key ID |
+| CDP_API_KEY_SECRET | SECRET | No | `""` | Coinbase Developer Platform API secret |
+| DATABASE_URL | INFRASTRUCTURE | No | `""` | PostgreSQL connection string |
+| DWELLIR_API_KEY | SECRET | No | `""` | Dwellir RPC provider API key |
+| DWELLIR_ETH_URL | SECRET | No | none | Full Dwellir Ethereum RPC URL (overrides API key) |
+| DWELLIR_BASE_URL | SECRET | No | none | Full Dwellir Base RPC URL (overrides API key) |
+| ETHERSCAN_API_KEY | SECRET | No | `""` | Etherscan API key for contract/tx data |
+| FIRECRAWL_API_KEY | SECRET | No | none | Firecrawl web scraping API key |
+| HELIUS_API_KEY | SECRET | No | `""` | Helius Solana RPC provider API key |
+| INDEXER_HOLDERS_PER_COIN | TUNING | No | `5000` | Max holders to index per coin on startup |
+| KEEPER_ENABLED | FEATURE_FLAG | No | `true` | Enable on-chain keeper service |
+| KEEPER_PRIVATE_KEY | SECRET | No | none | Keeper service private key (enables keeper) |
+| MEMPOOL_WATCHER_ENABLED | FEATURE_FLAG | No | `true` | Enable mempool transaction monitoring |
+| MORPHO_BLUE_COLLECTOR_ENABLED | FEATURE_FLAG | No | `true` | Enable Morpho Blue protocol collection |
+| PARALLEL_API_KEY | SECRET | No | `""` | Parallel RPC/data provider API key |
+| PORT | INFRASTRUCTURE | No | `5000` | HTTP server listening port |
+| PROTOCOL_PROMOTE_COVERAGE_PCT | TUNING | No | `52` | Coverage % threshold for protocol promotion |
+| PUBLIC_URL | METADATA | No | `https://basisprotocol.xyz` | Public base URL for health checks |
+| REDUCTO_API_KEY | SECRET | No | none | Reducto OCR API key |
+| RESEND_API_KEY | SECRET | No | none | Resend email delivery service API key |
+| SCORING_COLLECTORS_DISABLED | FEATURE_FLAG | No | `""` | Comma-separated collector names to disable |
+| SCORING_INTERVAL | TUNING | No | `60` | Minutes between scoring cycles |
+| SII_API_BASE | METADATA | No | `http://localhost:5000` | SII service base URL |
+| SLACK_ENGINE_WEBHOOK_URL | SECRET | No | none | Slack webhook for engine artifact notifications |
+| TALLY_API_KEY | SECRET | No | none | Tally governance API key |
+| TELEGRAM_BOT_TOKEN | SECRET | No | none | Telegram bot token for alerting |
+| TELEGRAM_CHAT_ID | SECRET | No | none | Telegram chat ID for alerts |
+| WEB_WORKERS | TUNING | No | `2` | Number of uvicorn worker processes |
+| X402_FACILITATOR_URL | METADATA | No | `https://x402.org/facilitator` | x402 payment facilitator endpoint |
+| X402_NETWORK | METADATA | No | Dynamic | x402 network chain (`eip155:8453` or `eip155:84532`) |
+| API_HOST | INFRASTRUCTURE | No | `0.0.0.0` | HTTP server bind address |
+| API_PORT | INFRASTRUCTURE | No | `5000` | HTTP server port (alias for PORT) |
+
+---
+
+## By Category
+
+### SECRET (Private Keys, API Keys, Credentials)
+
+These variables contain sensitive material and must never be committed or logged. Treat as security boundaries.
+
+- **ADMIN_KEY** — Line 101, 201, 250, etc. (app/server.py, app/ops/routes.py, app/indexer/api.py)  
+  Default: `""`  
+  Controls: Authentication for admin-only endpoints (budget approval, engine control)  
+
+- **ALCHEMY_API_KEY** — app/config.py:17, app/utils/rpc_provider.py:101  
+  Default: `""`  
+  Controls: Primary Ethereum JSON-RPC provider; used for all chains when present  
+
+- **ANTHROPIC_API_KEY** — app/content_engine.py:ANTHROPIC_API_KEY, app/ops/tools/{analyzer,drafter,investor_monitor}.py  
+  Default: `""`  
+  Controls: Claude API access for text generation in content engine and analysis tooling  
+
+- **BLOCKSCOUT_API_KEY** — app/utils/blockscout_client.py:BLOCKSCOUT_API_KEY  
+  Default: `""`  
+  Controls: Blockscout block explorer API access (contract source, transaction details)  
+
+- **COINGECKO_API_KEY** — app/config.py:15, multiple collectors  
+  Default: `""`  
+  Controls: CoinGecko market data, price histories, liquidity metrics  
+
+- **CDP_API_KEY_ID** — app/payments.py:54  
+  Default: `""`  
+  Controls: Coinbase Developer Platform API key ID for x402 payments (part 1/2)  
+
+- **CDP_API_KEY_SECRET** — app/payments.py:55  
+  Default: `""`  
+  Controls: Coinbase Developer Platform API secret for x402 payments (part 2/2); must be base64-encoded 64-byte seed+pub  
+
+- **DWELLIR_API_KEY** — app/utils/rpc_provider.py:120  
+  Default: `""`  
+  Controls: Dwellir RPC secondary provider; enables trace/debug methods unavailable on Alchemy free tier  
+
+- **DWELLIR_ETH_URL** — app/utils/rpc_provider.py:116  
+  Default: none (if not set, composed from DWELLIR_API_KEY)  
+  Controls: Full Ethereum endpoint URL for Dwellir (overrides API key composition); allows auth in URL instead of query string  
+
+- **DWELLIR_BASE_URL** — app/utils/rpc_provider.py:116  
+  Default: none (if not set, composed from DWELLIR_API_KEY)  
+  Controls: Full Base endpoint URL for Dwellir (overrides API key composition)  
+
+- **ETHERSCAN_API_KEY** — app/config.py:16, 30+ files across collectors/indexer/data_layer  
+  Default: `""`  
+  Controls: Etherscan API for contract source, transaction tracing, holder enumeration; heavily used for EVM indexing  
+
+- **FIRECRAWL_API_KEY** — app/services/firecrawl_client.py  
+  Default: none  
+  Controls: Web scraping service API key for research document extraction  
+
+- **HELIUS_API_KEY** — app/config.py:18, solana collectors, indexer  
+  Default: `""`  
+  Controls: Helius Solana RPC provider; enables Solana realm and program monitoring  
+
+- **KEEPER_PRIVATE_KEY** — main.py:832, 851  
+  Default: none  
+  Controls: Private key for on-chain keeper operations; **required to enable keeper service**  
+
+- **PARALLEL_API_KEY** — app/services/parallel_client.py, collectors/web_research.py  
+  Default: `""`  
+  Controls: Parallel RPC aggregator API key (fallback for node queries)  
+
+- **REDUCTO_API_KEY** — app/services/reducto_client.py  
+  Default: none  
+  Controls: Reducto OCR service for document text extraction  
+
+- **RESEND_API_KEY** — app/ops/routes.py, app/ops/tools/alerter.py  
+  Default: none  
+  Controls: Resend email delivery service; enables email alerting when set  
+
+- **SLACK_ENGINE_WEBHOOK_URL** — app/engine/slack.py:_WEBHOOK_ENV  
+  Default: none  
+  Controls: Slack incoming webhook for engine artifact notifications; falls back to stdout when unset  
+
+- **TALLY_API_KEY** — app/ops/tools/governance_monitor.py, scripts/backfill/backfill_dohi.py  
+  Default: none  
+  Controls: Tally governance data API for DAO event tracking  
+
+- **TELEGRAM_BOT_TOKEN** — app/ops/tools/alerter.py  
+  Default: none  
+  Controls: Telegram bot token; enables Telegram alerting when set  
+
+- **TELEGRAM_CHAT_ID** — app/ops/tools/alerter.py  
+  Default: none  
+  Controls: Telegram destination chat ID; enables Telegram alerting when set  
+
+- **BASIS_ENGINE_GITHUB_PAT** — app/engine/git_commit.py:_PAT_ENV (line 48, 156)  
+  Default: `""`  
+  Controls: GitHub personal access token for engine approval flow (commit artifacts to basis-protocol/basis-hub)  
+
+### INFRASTRUCTURE (Connectivity, Storage, Deployment)
+
+Configuration for databases, APIs, networking layers.
+
+- **DATABASE_URL** — app/config.py:14, app/discovery.py, app/database.py, multiple files  
+  Default: `""`  
+  Controls: PostgreSQL connection string; **critical for startup**  
+
+- **PORT** — main.py:835  
+  Default: `5000`  
+  Controls: HTTP server listening port (same as API_PORT)  
+
+- **API_HOST** — app/config.py:21  
+  Default: `0.0.0.0`  
+  Controls: HTTP server bind address  
+
+- **API_PORT** — app/config.py:22  
+  Default: `5000`  
+  Controls: HTTP server port (same as PORT)  
+
+- **X402_FACILITATOR_URL** — app/payments.py:57  
+  Default: `https://x402.org/facilitator`  
+  Controls: x402 payment protocol facilitator endpoint for USDC transactions  
+
+### FEATURE_FLAG (Toggles for Optional Components)
+
+Boolean-like switches that enable/disable major features or data sources.
+
+- **BASIS_ENGINE_TEST_MODE** — app/engine/git_commit.py:_TEST_MODE_ENV (line 47, 77)  
+  Default: `false`  
+  Values: `1`, `true`, `yes` → enabled; otherwise disabled  
+  Controls: Bypass actual git clone/commit/push in engine approval flow (returns fake URLs instead)  
+
+- **BACKLOG_VALUE_FILTER** — app/indexer/backlog.py  
+  Default: `false`  
+  Values: `true`, `1`, `yes` → enabled  
+  Controls: Filter backlog protocols by value threshold before promotion  
+
+- **BLOCKSCOUT_COMPARISON_ENABLED** — app/utils/data_source_comparator.py  
+  Default: `true`  
+  Controls: Enable side-by-side Etherscan ↔ Blockscout API validation  
+
+- **KEEPER_ENABLED** — main.py:831  
+  Default: `true`  
+  Values: `true` → enabled; requires KEEPER_PRIVATE_KEY to actually run  
+  Controls: Enable keeper on-chain service (harmless if KEEPER_PRIVATE_KEY unset)  
+
+- **MEMPOOL_WATCHER_ENABLED** — app/data_layer/mempool_watcher.py  
+  Default: `true`  
+  Values: `0`, `false`, `no` → disabled  
+  Controls: Monitor pending transactions in mempool (requires ALCHEMY_API_KEY)  
+
+- **MORPHO_BLUE_COLLECTOR_ENABLED** — app/collectors/morpho_blue.py  
+  Default: `true`  
+  Values: `true` → enabled  
+  Controls: Enable Morpho Blue lending protocol data collection  
+
+- **SCORING_COLLECTORS_DISABLED** — app/collectors/registry.py  
+  Default: `""` (none disabled)  
+  Format: Comma-separated collector class names  
+  Controls: Temporarily disable specific data collectors during scoring cycles  
+
+### TUNING (Performance, Intervals, Limits)
+
+Configuration for batch sizes, timeouts, polling intervals, and thresholds.
+
+- **BACKLOG_COLLATERAL_THRESHOLD** — app/indexer/backlog.py  
+  Default: `500000` (USD)  
+  Controls: Minimum collateral value to include protocol in backlog candidates  
+
+- **BACKLOG_PROMOTE_THRESHOLD** — app/indexer/backlog.py  
+  Default: `1000000` (USD)  
+  Controls: Value threshold for automatic backlog → index promotion  
+
+- **BASIS_ENGINE_LLM_DAILY_CALL_CEILING** — app/engine/cost_tracker.py:_env_int (line 65-76)  
+  Default: `50`  
+  Controls: Maximum number of Claude API calls per UTC day; blocks subsequent calls once hit  
+
+- **BASIS_ENGINE_LLM_MONTHLY_BUDGET_USD** — app/engine/cost_tracker.py:_env_float (line 51-62)  
+  Default: `200.0` (USD)  
+  Controls: Monthly spend cap on Claude API at Sonnet 4.6 rates ($3 input / $15 output per 1M tokens)  
+
+- **BASIS_ENGINE_DEFILLAMA_POLL_MINUTES** — app/engine/scheduler.py:_interval_minutes (line 57-69, 80)  
+  Default: `15`  
+  Controls: Minutes between DeFiLlama hack polling; env var overridable without deploy  
+
+- **BASIS_ENGINE_WATCHLIST_INTERVAL_MINUTES** — app/engine/scheduler.py  
+  Default: `15`  
+  Controls: Minutes between watchlist evaluation cycles (offset from DeFiLlama poll)  
+
+- **BLOCKSCOUT_CONCURRENCY** — app/indexer/config.py  
+  Default: `10`  
+  Controls: Max concurrent Blockscout API requests to prevent rate-limit issues  
+
+- **CDA_COLLECTION_INTERVAL_HOURS** — main.py:135, app/worker.py  
+  Default: `24`  
+  Controls: Hours between off-chain data availability (CDA) extraction cycles  
+
+- **CHAIN_EXPANSION_TVL_THRESHOLD** — app/collectors/psi_collector.py  
+  Default: `500000000` (USD, i.e., $500M)  
+  Controls: TVL threshold above which chains are eligible for protocol expansion  
+
+- **COLLECTION_INTERVAL** — app/config.py:27, main.py:35  
+  Default: `60` (minutes)  
+  Controls: Base interval for data collection and scoring cycles  
+
+- **INDEXER_HOLDERS_PER_COIN** — app/indexer/pipeline.py  
+  Default: `5000`  
+  Controls: Max holders to fetch and index per coin on first initialization  
+
+- **PROTOCOL_PROMOTE_COVERAGE_PCT** — app/collectors/psi_collector.py  
+  Default: `52`  
+  Controls: Coverage % threshold (out of which denominator?) for auto-promoting protocols  
+
+- **SCORING_INTERVAL** — app/config.py:28  
+  Default: `60` (minutes)  
+  Controls: Minutes between full stablecoin scoring cycles  
+
+- **WEB_WORKERS** — main.py:838  
+  Default: `2`  
+  Controls: Number of uvicorn worker processes (⚠ see scheduler.py module docstring for multi-worker scheduler duplication issue)  
+
+### METADATA (Service Identity, URLs, Addresses)
+
+Configuration that identifies the service, sets canonical URLs, or references on-chain addresses.
+
+- **ALERT_EMAIL** — app/ops/tools/alerter.py  
+  Default: `shlok@basisprotocol.xyz`  
+  Controls: Default email address for alert notifications  
+
+- **ARBITRUM_ORACLE_ADDRESS** — app/ops/routes.py  
+  Default: none  
+  Controls: On-chain Arbitrum oracle contract address (checked for existence to report capability)  
+
+- **ATTESTOR_PUBLIC_KEY** — app/server.py  
+  Default: `""`  
+  Controls: Public key for verifying state attestations (signatures from state_attestation.py)  
+
+- **BASE_ORACLE_ADDRESS** — app/ops/routes.py  
+  Default: none  
+  Controls: On-chain Base oracle contract address (checked for existence to report capability)  
+
+- **BASE_SBT_ADDRESS** — scripts/mint_initial_sbts.py  
+  Default: `""`  
+  Controls: Base chain Soulbound Token contract address for NFT minting  
+
+- **BASIS_PAYMENT_WALLET** — app/payments.py:51  
+  Default: `""`  
+  Controls: USDC payment receiver wallet address on Base chain (x402 protocol)  
+
+- **BASIS_API_BASE** — scripts/populate_incident_rseth_2026_04_18.py  
+  Default: none (must be operator-provided for script use)  
+  Controls: Local API base URL used by backfill/incident scripts  
+
+- **BASIS_API_URL** — scripts/diagnose_psi_state.ts (TypeScript/Node)  
+  Default: `https://basisprotocol.xyz`  
+  Controls: Public API URL for client-side scripts; used by Node.js helper scripts  
+
+- **BLOCK_EXPLORER_PROVIDER** — app/indexer/config.py  
+  Default: `blockscout`  
+  Values: `blockscout` or `etherscan`  
+  Controls: Primary block explorer for contract/holder queries (influences API routing)  
+
+- **CANONICAL_BASE_URL** — app/publisher/page_renderer.py, app/server.py, app/templates/_html.py  
+  Default: `https://basisprotocol.xyz`  
+  Controls: Public-facing domain URL inserted into rendered pages, email bodies, etc.  
+
+- **CORS_ORIGINS** — app/config.py:23-24  
+  Default: `*`  
+  Format: `*` or comma-separated URLs (e.g., `https://example.com,https://app.example.com`)  
+  Controls: CORS allowlist for browser-initiated requests  
+
+- **PUBLIC_URL** — app/ops/tools/health_checker.py  
+  Default: `https://basisprotocol.xyz`  
+  Controls: Public base URL used in health check endpoints  
+
+- **SII_API_BASE** — app/content_engine.py  
+  Default: `http://localhost:5000`  
+  Controls: Base URL for local SII (?) service used by content engine  
+
+- **X402_NETWORK** — app/payments.py:64, 66  
+  Default: `eip155:8453` (Base mainnet) if CDP credentials present; `eip155:84532` (Base Sepolia) if not  
+  Controls: EIP-155 chain identifier for x402 payment network selection  
+
+---
+
+## Safe-for-Dev Defaults
+
+For local development and testing, use these values to avoid requiring real API keys or connecting to production:
+
+| Variable | Dev Default | Rationale |
+|---|---|---|
+| ADMIN_KEY | `dev-admin-key-unsafe` | Enables admin endpoints locally; never use in production |
+| ALCHEMY_API_KEY | Skip or `operator-provided` | Public RPC endpoints (e.g., Infura free tier) for local chains only |
+| ANTHROPIC_API_KEY | Skip (cost tracker blocks calls gracefully) | Paid API; use only when testing engine approval flow |
+| ARBITRUM_ORACLE_ADDRESS | Skip | Not required for dev; oracle capability check will report false |
+| ATTESTOR_PUBLIC_KEY | Skip | Not required for dev |
+| BACKLOG_COLLATERAL_THRESHOLD | `100000` | Lower threshold for quicker backlog testing |
+| BACKLOG_PROMOTE_THRESHOLD | `500000` | Lower threshold for quicker promotion testing |
+| BASIS_ENGINE_GITHUB_PAT | Skip or create test PAT | Skip if testing without actual commits; create test PAT for PR testing |
+| BASIS_ENGINE_LLM_DAILY_CALL_CEILING | `10` | Reduce to catch budget-limit bugs in testing |
+| BASIS_ENGINE_LLM_MONTHLY_BUDGET_USD | `50.0` | Low budget for testing cost guardrails |
+| BASIS_ENGINE_TEST_MODE | `true` | Bypass git operations, return fake URLs |
+| BASE_ORACLE_ADDRESS | Skip | Not required for dev |
+| BASE_SBT_ADDRESS | Skip | Not required unless testing SBT mint flow |
+| BASIS_PAYMENT_WALLET | Skip | Not required for dev |
+| BLOCKSCOUT_API_KEY | Skip | Use public endpoints or local explorer |
+| BLOCKSCOUT_COMPARISON_ENABLED | `false` | Disable to avoid comparing against external services |
+| BLOCKSCOUT_CONCURRENCY | `2` | Lower for lighter test runs |
+| CANONICAL_BASE_URL | `http://localhost:5000` | Point to local server |
+| CDA_COLLECTION_INTERVAL_HOURS | `6` | Faster iteration for local tests |
+| CHAIN_EXPANSION_TVL_THRESHOLD | `1000000` | Low threshold for dev (quick protocol discovery) |
+| COINGECKO_API_KEY | Skip (free tier no auth) | Use free CoinGecko API without key |
+| COLLECTION_INTERVAL | `10` | Fast iteration for testing scoring cycles |
+| CORS_ORIGINS | `*` | Allow local frontend dev |
+| CDP_API_KEY_ID, CDP_API_KEY_SECRET | Skip | Not required unless testing x402 payments |
+| DATABASE_URL | Neon dev branch or local PostgreSQL | Use `postgresql://user:pass@localhost:5432/basis_dev` |
+| DWELLIR_API_KEY | Skip | Use Alchemy or free RPC |
+| ETHERSCAN_API_KEY | Skip or `operator-provided` | Limited free tier; use only if testing heavy contract work |
+| FIRECRAWL_API_KEY | Skip | Not required for core functionality |
+| HELIUS_API_KEY | Skip | Not required unless testing Solana collectors |
+| INDEXER_HOLDERS_PER_COIN | `100` | Small batch for quick wallet indexing tests |
+| KEEPER_ENABLED | `false` | Disable keeper locally |
+| KEEPER_PRIVATE_KEY | Skip | Not required if keeper disabled |
+| MEMPOOL_WATCHER_ENABLED | `false` | Avoid mempool watcher in dev |
+| MORPHO_BLUE_COLLECTOR_ENABLED | `false` | Disable expensive collectors in dev |
+| PARALLEL_API_KEY | Skip | Not required for dev |
+| PORT | `5000` | Standard local port |
+| PROTOCOL_PROMOTE_COVERAGE_PCT | `10` | Very low for quick testing |
+| PUBLIC_URL | `http://localhost:5000` | Point to local server |
+| REDUCTO_API_KEY | Skip | Not required for core functionality |
+| RESEND_API_KEY | Skip | Falls back safely; no email in dev |
+| SCORING_COLLECTORS_DISABLED | `web_research,solana_program_monitor` | Disable expensive/slow collectors |
+| SCORING_INTERVAL | `15` | Fast iteration for dev |
+| SII_API_BASE | `http://localhost:5000` | Adjust if SII runs elsewhere |
+| SLACK_ENGINE_WEBHOOK_URL | Skip | Falls back to stdout |
+| TALLY_API_KEY | Skip | Not required for dev |
+| TELEGRAM_BOT_TOKEN, TELEGRAM_CHAT_ID | Skip | Not required for dev |
+| WEB_WORKERS | `1` | Single worker avoids scheduler duplication issue in dev |
+| X402_FACILITATOR_URL | `https://x402.org/facilitator` | Default is fine |
+| X402_NETWORK | `eip155:84532` | Use Base Sepolia testnet for dev |
+
+---
+
+## Required-Without-Default
+
+The following variables have **no default** and **must be set** or the service will fail at runtime:
+
+None. Every environment variable in basis-hub has a default (often empty string, which allows graceful degradation). However, the following are **functionally required** for production:
+
+| Variable | Why | Impact if Missing |
+|---|---|---|
+| DATABASE_URL | PostgreSQL connection string | Service fails to start; database operations unavailable |
+| KEEPER_PRIVATE_KEY | Enables keeper service | Keeper service skipped (unless explicitly disabled); on-chain operations unavailable |
+| BASIS_ENGINE_GITHUB_PAT | GitHub write access | Engine approval flow fails at commit stage (unless TEST_MODE enabled) |
+| ALCHEMY_API_KEY | Primary RPC for EVM chains | RPC calls fail; all on-chain indexing / scoring unavailable |
+
+---
+
+## Gaps & Ambiguities
+
+### Unresolved Questions
+
+1. **Dwellir URL composition** — DWELLIR_ETH_URL and DWELLIR_BASE_URL can override the API key, but does the override happen automatically or does the operator need to construct the full URL manually? (Assumption: automatic composition if only key is set.)
+
+2. **PROTOCOL_PROMOTE_COVERAGE_PCT denominator** — Default `52` is described as "coverage percentage" but the denominator is unclear. Is it `52%` of all existing protocols, or some other baseline? Code reference: app/collectors/psi_collector.py line 114.
+
+3. **WEB_WORKERS scheduler duplication** — app/engine/scheduler.py module docstring warns that multi-worker setups cause duplicate polling (each worker runs the scheduler). No mitigation is currently in place; recommendation is WEB_WORKERS=1 or moving scheduler to a separate service. This should be documented in Railway config.
+
+4. **MORPHO_GRAPHQL_ENDPOINT** — app/collectors/morpho_blue.py references `MORPHO_GRAPHQL_ENDPOINT` but defaults to a hardcoded URL; no environment variable override found. Should this be configurable?
+
+5. **X402_NETWORK dynamic default** — X402_NETWORK defaults to mainnet or testnet based on whether CDP credentials are present. This coupling is implicit and could cause confusion if credentials are partially set. Recommend explicit env var in dev/staging.
+
+6. **RPC provider chain support** — RPC URLs are hardcoded for ethereum, base, and arbitrum in rpc_provider.py. Other chains (Solana, Polygon, etc.) are not routed through the RPC provider abstraction; they have separate collectors and RPC URLs (e.g., HELIUS_API_KEY for Solana). This is architecturally sound but means new chains require code changes, not just env var additions.
+
+7. **Cost tracker pricing hardcoded** — INPUT_PRICE_PER_M_USD and OUTPUT_PRICE_PER_M_USD are hardcoded as Sonnet 4.6 rates in cost_tracker.py. If Claude models upgrade or pricing changes, the values won't auto-update. Consider making these environment-overridable (BASIS_ENGINE_LLM_INPUT_PRICE_USD, etc.).
+
+---
+
+## Changelog
+
+- **2026-05-12** — Initial inventory created; captured all 51 unique variables across app/, main.py, keeper/, scripts/

--- a/docs/development/external-services-recon.md
+++ b/docs/development/external-services-recon.md
@@ -1,0 +1,91 @@
+# External Services Recon — basis-state & basis-provenance
+
+**Date:** 2026-05-12
+**Source:** Railway project `valiant-celebration` (`736af3ec-ed9d-41d5-a8b6-c778393dd12b`), environment `production` (`e50bf3e2-ee86-445d-b934-ad44098d040a`), plus basis-hub repo grep.
+**My GitHub MCP scope:** `basis-protocol/basis-hub` only. I cannot read source from the two sibling repos described below; everything here comes from the Railway service config and basis-hub side-references.
+
+---
+
+## basis-state — what it is, runtime, source location, integration shape
+
+### Identity
+- **Railway service ID:** `61d5cb8c-7441-4db8-bfda-ad466f39497a`
+- **Railway service name:** `basis-state`
+- **Region / replicas:** `us-west2`, 1 replica
+- **Public domain:** none configured (internal-only)
+
+### Source location
+- **Sibling GitHub repo:** `basis-protocol/basis-state` (branch `main`)
+- NOT in basis-hub. NOT a third-party SaaS.
+- The repo is not accessible to this session's GitHub MCP (basis-hub-scoped).
+
+### Runtime
+- **Builder:** Dockerfile at repository root: `/Dockerfile`
+- **Start/build commands:** none configured (uses image defaults)
+- **Env vars set on the service (names only):**
+  - `BASIS_API_URL` — points back at the hub API (hub-spoke pattern)
+  - `PORT` — HTTP listen port
+
+### Integration shape
+- Pure spoke. Talks to the hub via HTTP through `BASIS_API_URL`. No `DATABASE_URL`, so it does not touch Postgres directly.
+- Public-facing domain is `basisstate.xyz` per `/home/user/basis-hub/BASISSTATE_ANALYTICS_TODO.md` (which calls out adding Plausible analytics there). That TODO file also notes "the basis-state repo is separate and not available in this workspace."
+- Punchlist confirms it required a force-redeploy from its own `main` after the 2026-05-10 Neon incident — verifying it is auto-deployed from `basis-protocol/basis-state`, not from basis-hub.
+- Described in CLAUDE.md as "state subgraph" — likely serves a public read-only view over hub data via the API.
+
+---
+
+## basis-provenance — what it is, runtime, source location, integration shape
+
+### Identity
+- **Railway service ID:** `7eb5b894-2107-439c-9c53-00e99fc37b72`
+- **Railway service name:** `basis-provenance`
+- **Region / replicas:** `us-west2`, 1 replica
+- **Public domain:** none configured (internal-only)
+
+### Source location
+- **Sibling GitHub repo:** `basis-protocol/basis-provenance` (branch `main`)
+- NOT in basis-hub. NOT a third-party SaaS.
+- Per `docs/canon-update-2026-05-10.md`: "If the canon doc currently calls it 'prover', rename to `basis-provenance`." The service used to be named "prover".
+
+### Runtime
+- **Builder:** Dockerfile at `/Dockerfile.prover` in the basis-provenance repo
+- **Start/build commands:** none configured
+- **Env vars set on the service (names only):**
+  - `NOTARY_HOST`, `NOTARY_PORT` — its own bind config
+  - `HUB_API_URL`, `HUB_API_KEY` — calls hub API (hub-spoke)
+  - `ATTESTOR_PRIVATE_KEY` — signs attestations
+  - `R2_ENDPOINT`, `R2_PUBLIC_URL`, `R2_BUCKET`, `R2_ACCESS_KEY_ID`, `R2_SECRET_ACCESS_KEY` — Cloudflare R2 for archived proofs
+  - `COINGECKO_API_KEY`, `COINGECKO_BASE_URL`, `ETHERSCAN_API_KEY` — independent data fetches
+  - `POLL_INTERVAL_SECONDS` — its own polling cadence
+
+### Integration shape
+- Pure spoke. Calls hub via `HUB_API_URL` with `HUB_API_KEY` for auth.
+- Independently fetches CoinGecko + Etherscan to corroborate hub-published scores, then signs the result with `ATTESTOR_PRIVATE_KEY` and archives to Cloudflare R2 (the "R2-archived proofs" referenced in CLAUDE.md).
+- Hub side recognizes attestor signatures via `ATTESTOR_PUBLIC_KEY` (see env inventory line 19, used in `app/server.py` for attestation verification).
+- R2 itself is third-party SaaS (Cloudflare). The notary/prover service is in-org code.
+
+---
+
+## Implications for Phase A docker-compose
+
+| Service | Recommendation | Why |
+|---|---|---|
+| **basis-state** | **Stub with a fixture** (do not containerize) | Source repo not accessible to this session. Hub does not call basis-state — basis-state calls hub. From basis-hub's perspective it is a downstream read-only consumer that has no impact on local dev of hub features. Phase A should focus on running the hub, worker, keeper locally; basis-state can simply not exist in compose. |
+| **basis-provenance** | **Stub with a fixture** (do not containerize) | Same direction of dependency: basis-provenance calls hub, hub never calls basis-provenance. Hub only consumes attestor signatures it has already received and stored. For local dev, leave `ATTESTOR_PUBLIC_KEY` unset (or set to a dev keypair) and the relevant endpoint paths will simply report no attestations. R2 access (third-party SaaS) is not needed for hub dev. |
+
+**Specific Phase A guidance:**
+- **Do not** attempt to add `Dockerfile.state` or `Dockerfile.provenance` to basis-hub. Both have their own Dockerfiles in their own repos (`/Dockerfile` and `/Dockerfile.prover` respectively).
+- **Do not** add them to docker-compose as `build:` services. If a future Phase wants integration testing, use `image:` pulling pre-built images from a registry, or `git clone` the sibling repos out of band. That is out of scope for Phase A.
+- **Do** document in the compose README that these two services are sibling repos and intentionally omitted from local compose.
+- **Optional:** if anyone needs to mock the hub-side surface that basis-provenance writes to (e.g. signed attestation payloads), commit a small JSON fixture under `tests/fixtures/attestations/` and a fake `ATTESTOR_PUBLIC_KEY` matching it. This unblocks rendering `/api/state-root/latest` etc. in a dev environment.
+
+---
+
+## Gaps
+
+1. **Exact API surface basis-state exposes** — I know it has a `PORT` and a `BASIS_API_URL`. I do not know which endpoints it serves or what shape `basisstate.xyz` presents. Would require reading `basis-protocol/basis-state` source.
+2. **basis-provenance polling logic** — I know it polls (`POLL_INTERVAL_SECONDS`) and fetches CoinGecko + Etherscan. I do not know the exact verification algorithm, which hub endpoints it calls, or what proof artifact format it writes to R2.
+3. **Hub endpoints called by basis-provenance** — `HUB_API_KEY` implies authenticated calls but the route(s) are not visible from this side. Likely candidates based on hub code: `/api/scores/...`, `/api/state-root/latest`, `/api/provenance/*`, but unconfirmed.
+4. **Whether basis-state shares the hub DB** — `BASISSTATE_ANALYTICS_TODO.md` line 69 raises this as an open question: "If basis-state shares the hub database (same DATABASE_URL), you could log to `api_request_log` instead." So even the local docs are uncertain. From the Railway env-var list, basis-state has NO `DATABASE_URL`, so currently it does not share the DB — but the doc author wasn't sure.
+5. **Canon repo state** — `docs/canon-update-2026-05-10.md` lists proposed updates to the canon repo to add these two services; whether the canon was actually updated is unknown to me (canon repo not accessible).
+6. **Whether either service has historical Dockerfile changes that we'd want mirrored in a local compose** — not visible.

--- a/docs/development/service-runtime-matrix.md
+++ b/docs/development/service-runtime-matrix.md
@@ -1,0 +1,141 @@
+# Service Runtime Matrix
+
+Mapping of the 13 Railway services in the `valiant-celebration` project
+(`projectId: 736af3ec-ed9d-41d5-a8b6-c778393dd12b`, production environment
+`e50bf3e2-ee86-445d-b934-ad44098d040a`) to Dockerfiles and start commands.
+
+Data captured 2026-05-12 via Railway MCP `railway-agent` against the live
+service configs. The repo contains only three Dockerfiles
+(`Dockerfile.api`, `Dockerfile.worker`, `Dockerfile.keeper`). Two services
+(`basis-state`, `basis-provenance`) deploy from sibling repos
+(`basis-protocol/basis-state`, `basis-protocol/basis-provenance`) and use
+Dockerfiles that live in those repos, not in `basis-hub`.
+
+---
+
+## Summary Table
+
+| Service | Service ID | Source repo | Dockerfile | Effective start command | Notable env | Notes |
+|---|---|---|---|---|---|---|
+| api-server | 39defdfc-cfa8-4929-9e17-6dfe86d7d791 | basis-protocol/basis-hub @ main | `/Dockerfile.api` | (Dockerfile CMD) `python main.py` | `PORT`, `WORKER_ENABLED`, `KEEPER_ENABLED`, `WEB_CONCURRENCY`, `WEB_WORKERS`, `COLLECTION_INTERVAL`, `DATABASE_URL`, `ADMIN_KEY`, many vendor keys | Healthcheck `/healthz` (300s). Dockerfile hardcodes `WORKER_ENABLED=false`, `KEEPER_ENABLED=false`, `PORT=8000`; runtime env overrides these. |
+| Scoring-Worker | 8da95cc8-e389-460c-9efa-0f77a19de6fc | basis-protocol/basis-hub @ main | `/Dockerfile.worker` | (Dockerfile CMD) `python -m app.worker --loop` | `WORKER_ENABLED`, `COLLECTION_INTERVAL`, `DATABASE_URL`, `ALCHEMY_API_KEY`, `HELIUS_API_KEY`, `DWELLIR_*`, `PYTHONASYNCIODEBUG` | Long-running scoring loop. No `--loop` override needed because CMD already supplies it. |
+| Keeper (note trailing space in name) | f3b9fe6e-3e15-46b1-bdde-a919574d4732 | basis-protocol/basis-hub @ main, rootDir `/` | `/Dockerfile.keeper` | (Railway override, identical to CMD) `npx tsx keeper/index.ts` | `KEEPER_PRIVATE_KEY`, `BASE_RPC_URL`, `ARBITRUM_RPC_URL`, `BASE_ORACLE_ADDRESS`, `ARBITRUM_ORACLE_ADDRESS`, `BASE_SBT_ADDRESS`, `MAX_GAS_PRICE_GWEI`, `POLL_INTERVAL_SECONDS`, `BASIS_API_URL` | No `KEEPER_ENABLED` flag here; this container is always-on. The flag only gates the in-process keeper subprocess on api-server. |
+| basis-state | 61d5cb8c-7441-4db8-bfda-ad466f39497a | basis-protocol/basis-state @ main | `/Dockerfile` (in sibling repo) | (Dockerfile CMD; not visible from hub repo) | `PORT`, `BASIS_API_URL` | Dockerfile lives in the `basis-state` repo. TBD; investigated separately by subagent 4. |
+| basis-provenance | 7eb5b894-2107-439c-9c53-00e99fc37b72 | basis-protocol/basis-provenance @ main | `/Dockerfile.prover` (in sibling repo) | (Dockerfile CMD; not visible from hub repo) | `POLL_INTERVAL_SECONDS`, `NOTARY_HOST`, `NOTARY_PORT`, `HUB_API_URL`, `HUB_API_KEY`, `ATTESTOR_PRIVATE_KEY`, `R2_*`, `COINGECKO_API_KEY`, `ETHERSCAN_API_KEY` | Dockerfile lives in the `basis-provenance` repo. TBD; investigated separately by subagent 4. |
+| basis-backfill-tti | cd68915b-0618-454b-8019-c2a66fa9b9af | (no `source.repo` set on service) | inherited image (see "Backfill family resolution") | `python -m scripts.backfill.backfill_tti` (Railway override) | `DATABASE_URL` (refs psi service) | `restartPolicyType: NEVER` (one-shot). |
+| basis-backfill-cxri | ed93b492-6aab-4b38-b3da-856455fd9e70 | basis-protocol/basis-hub @ main | inherits hub build | `python -m scripts.backfill.backfill_cxri` | `DATABASE_URL` | One-shot. |
+| basis-backfill-vsri | 016d7a54-044b-4b8f-9e38-091cf58b578a | basis-protocol/basis-hub @ main | inherits hub build | `python -m scripts.backfill.backfill_vsri` | `DATABASE_URL`, `COINGECKO_API_KEY` | One-shot. |
+| basis-backfill-dohi | 8ef9bdf4-5694-4493-ab5b-c702fcc833e0 | (no `source.repo` set on service) | inherited image | `python -m scripts.backfill.backfill_dohi` | `DATABASE_URL` | One-shot. |
+| basis-backfill-bri | 5681954e-4267-412f-8672-7a06f283b86f | (no `source.repo` set on service) | inherited image | `python -m scripts.backfill.backfill_bri` | `DATABASE_URL` | One-shot. |
+| basis-backfill-lsti | 43b17a89-59d3-457e-9546-552a12d02844 | basis-protocol/basis-hub @ main | inherits hub build | `python -m scripts.backfill.backfill_lsti` | `DATABASE_URL`, `COINGECKO_API_KEY` | One-shot. |
+| basis-backfill-rpi | fd19df20-21b9-4640-b2a3-9c3c40c36b52 | (no `source.repo` set on service) | inherited image | `python -m scripts.backfill.backfill_rpi` | `DATABASE_URL` | One-shot. |
+| basis-backfill-psi | f84eea5d-c2c4-4db5-b16a-b8bf70000a23 | basis-protocol/basis-hub @ main | inherits hub build | `python -m scripts.backfill.backfill_psi` | `DATABASE_URL` (shared) | One-shot. The psi service's `DATABASE_URL` is referenced by all other backfill services via `${{f84eea5d-...DATABASE_URL}}`. |
+
+---
+
+## api-server
+
+- **Service ID:** `39defdfc-cfa8-4929-9e17-6dfe86d7d791`
+- **Source:** `basis-protocol/basis-hub`, branch `main`
+- **Build:** `dockerfilePath: /Dockerfile.api`
+- **Start command:** unset on Railway → falls back to the Dockerfile CMD `python main.py`.
+- **Healthcheck:** `GET /healthz`, 300s timeout.
+- **Port:** `PORT` env var (Dockerfile sets `PORT=8000`; Railway-provided value overrides at runtime).
+- **Runtime env quirks:**
+  - Dockerfile hardcodes `WORKER_ENABLED=false` and `KEEPER_ENABLED=false`, but **both keys are present in the Railway env**, so the runtime values win. Confirm flag intent before redeploy — running the worker inside api-server is wasteful when `Scoring-Worker` exists.
+  - Has `WEB_CONCURRENCY` + `WEB_WORKERS` (uvicorn tuning).
+  - Has a stray env var `" SLACK_ENGINE_WEBHOOK_URL"` with a leading space (likely typo, harmless unless code expects the unstripped key).
+- **Replicas:** 1 in `us-west2`.
+
+## Scoring-Worker
+
+- **Service ID:** `8da95cc8-e389-460c-9efa-0f77a19de6fc`
+- **Source:** `basis-protocol/basis-hub`, branch `main`
+- **Build:** `dockerfilePath: /Dockerfile.worker`
+- **Start command:** unset → Dockerfile CMD `python -m app.worker --loop`.
+- **Env:** `WORKER_ENABLED=true` (required for the loop to do work — `app.worker` reads this), `COLLECTION_INTERVAL` (minutes between cycles), `DATABASE_URL`, plus vendor keys (`COINGECKO_API_KEY`, `HELIUS_API_KEY`, `ETHERSCAN_API_KEY`, `ALCHEMY_API_KEY`, `BLOCKSCOUT_API_KEY`, `DWELLIR_API_KEY`, `DWELLIR_ETH_URL`, `FIRECRAWL_API_KEY`, `PARALLEL_API_KEY`, `REDUCTO_API_KEY`, `RESEND_API_KEY`).
+- **Port:** none (background service).
+- **Notes:** This is the real background scorer. It does NOT run via the in-process worker thread in `main.py` (that thread is gated by `WORKER_ENABLED` on api-server, which should be `false` in production to avoid double scoring).
+
+## Keeper
+
+- **Service ID:** `f3b9fe6e-3e15-46b1-bdde-a919574d4732` (display name has a trailing space: `"Keeper "`)
+- **Source:** `basis-protocol/basis-hub`, branch `main`, `rootDirectory: /`
+- **Build:** `dockerfilePath: /Dockerfile.keeper` (node:22-slim, installs `package.json`, copies `keeper/`).
+- **Start command:** Railway sets `npx tsx keeper/index.ts` explicitly — this matches Dockerfile CMD verbatim, so the override is redundant but harmless.
+- **`preDeployCommand`:** empty array (explicitly set).
+- **Env:** `KEEPER_PRIVATE_KEY` (signer), `BASE_RPC_URL`, `ARBITRUM_RPC_URL`, `BASE_ORACLE_ADDRESS`, `ARBITRUM_ORACLE_ADDRESS`, `BASE_SBT_ADDRESS`, `MAX_GAS_PRICE_GWEI`, `POLL_INTERVAL_SECONDS`, `BASIS_API_URL`.
+- **Notes:** This is the on-chain oracle publisher described in `CLAUDE.md`. It reads scores from the hub API (`BASIS_API_URL`) and submits transactions to Base + Arbitrum oracle contracts.
+
+## basis-state
+
+- **Service ID:** `61d5cb8c-7441-4db8-bfda-ad466f39497a`
+- **Source:** `basis-protocol/basis-state`, branch `main` (sibling repo, NOT this hub).
+- **Build:** `dockerfilePath: /Dockerfile` (default name; lives in the sibling repo, not visible from `basis-hub`).
+- **Start command:** unknown from hub side — depends on the sibling repo's Dockerfile CMD.
+- **Env:** `PORT`, `BASIS_API_URL` (so it consumes the hub's REST API).
+- **Status:** **TBD; investigated separately by subagent 4.** Likely a state-attestation publishing service, but cannot confirm from this repo.
+
+## basis-provenance
+
+- **Service ID:** `7eb5b894-2107-439c-9c53-00e99fc37b72`
+- **Source:** `basis-protocol/basis-provenance`, branch `main` (sibling repo, NOT this hub).
+- **Build:** `dockerfilePath: /Dockerfile.prover` (lives in the sibling repo).
+- **Start command:** unknown from hub side.
+- **Env:** `NOTARY_HOST`, `NOTARY_PORT`, `POLL_INTERVAL_SECONDS`, `HUB_API_URL`, `HUB_API_KEY`, `ATTESTOR_PRIVATE_KEY`, `R2_ENDPOINT`/`R2_PUBLIC_URL`/`R2_BUCKET`/`R2_ACCESS_KEY_ID`/`R2_SECRET_ACCESS_KEY`, `COINGECKO_API_KEY`, `ETHERSCAN_API_KEY`.
+- **Status:** **TBD; investigated separately by subagent 4.** Appears to be a provenance/notary service that polls the hub API and persists evidence to Cloudflare R2 with an attestor signature.
+
+---
+
+## Backfill family resolution
+
+All eight `basis-backfill-*` services are **one-shot Python jobs** (`restartPolicyType: NEVER`) that share the same runtime contract:
+
+```
+START: python -m scripts.backfill.backfill_<index>
+ENV:   DATABASE_URL (+ COINGECKO_API_KEY for vsri & lsti)
+BUILD: inherits the hub repo's build (no explicit dockerfilePath set on the service)
+```
+
+Concretely:
+
+| Service | Module invoked | Index target | Source repo on service config |
+|---|---|---|---|
+| basis-backfill-tti | `scripts.backfill.backfill_tti` | TTI (`app/index_definitions/tti_v01.py`) | not set on service |
+| basis-backfill-cxri | `scripts.backfill.backfill_cxri` | CXRI (`app/index_definitions/cxri_v01.py`) | basis-protocol/basis-hub @ main |
+| basis-backfill-vsri | `scripts.backfill.backfill_vsri` | VSRI (`app/index_definitions/vsri_v01.py`) | basis-protocol/basis-hub @ main |
+| basis-backfill-dohi | `scripts.backfill.backfill_dohi` | DOHI (`app/index_definitions/dohi_v01.py`) | not set on service |
+| basis-backfill-bri | `scripts.backfill.backfill_bri` | BRI (`app/index_definitions/bri_v01.py`) | not set on service |
+| basis-backfill-lsti | `scripts.backfill.backfill_lsti` | LSTI (`app/index_definitions/lsti_v01.py`) | basis-protocol/basis-hub @ main |
+| basis-backfill-rpi | `scripts.backfill.backfill_rpi` | RPI (`app/index_definitions/rpi_v2.py`) | not set on service |
+| basis-backfill-psi | `scripts.backfill.backfill_psi` | PSI (`app/index_definitions/psi_v01.py`) | basis-protocol/basis-hub @ main |
+
+**The hub repo confirms these modules exist** under `/home/user/basis-hub/scripts/backfill/`:
+`backfill_tti.py`, `backfill_cxri.py`, `backfill_vsri.py`, `backfill_dohi.py`,
+`backfill_bri.py`, `backfill_lsti.py`, `backfill_rpi.py`, `backfill_psi.py`,
+plus shared `base.py` and `__init__.py`.
+
+**Important quirk — inconsistent `source.repo` on backfill services:**
+Four services (cxri, vsri, lsti, psi) have `source.repo` set to `basis-protocol/basis-hub@main`, but the other four (tti, dohi, bri, rpi) have no `source` block at all. None of the eight has an explicit `build.dockerfilePath`. In practice Railway will rebuild from the hub repo on push for the four configured services and rely on the last-cached image / nixpacks default for the other four. This is fragile — the four without `source.repo` will not auto-redeploy when `scripts/backfill/*` changes. Worth normalizing.
+
+**No `BACKFILL_INDEX` / `INDEX_ID` / `BACKFILL_TARGET` env vars exist** — the index family is selected purely by which module the start command names. So the eight services are clones differing only by their `deploy.startCommand`.
+
+**Shared DATABASE_URL:** Seven of the eight backfill services reference
+`${{f84eea5d-c2c4-4db5-b16a-b8bf70000a23.DATABASE_URL}}` (the `basis-backfill-psi`
+service's `DATABASE_URL`), and `basis-backfill-psi` itself references
+`${{shared.DATABASE_URL}}`. So `basis-backfill-psi`'s var is a fan-out point for
+the family — changing it propagates to all seven siblings.
+
+---
+
+## Gaps
+
+1. **basis-state Dockerfile/CMD:** Service deploys from `basis-protocol/basis-state` using `/Dockerfile`. The actual CMD, exposed port, and runtime entrypoint are defined in that sibling repo and cannot be confirmed from `basis-hub`. **TBD; investigated separately by subagent 4.**
+2. **basis-provenance Dockerfile/CMD:** Service deploys from `basis-protocol/basis-provenance` using `/Dockerfile.prover`. Same situation as basis-state. **TBD; investigated separately by subagent 4.**
+3. **Backfill services without `source.repo`** (tti, dohi, bri, rpi): no source block visible on the service config. Possibilities: (a) historically deployed by image push and never re-attached to a repo; (b) the agent's view omitted the field. The start command and `DATABASE_URL` are confirmed, but it's not certain which commit/build of `scripts/backfill/*.py` they currently run.
+4. **Port mapping / public domains:** the `networking` blocks returned by the agent are empty or omitted. Only `api-server` has a healthcheck (`/healthz`); no service surfaces a public domain in the captured config. If the api-server's Railway-managed domain is required, it must be looked up via the dashboard or `gh`-style introspection.
+5. **`WORKER_ENABLED` on api-server:** the env var is set but its current value was hidden. If it is `true`, api-server is double-running the worker alongside `Scoring-Worker`. Should be verified out-of-band.
+6. **`KEEPER_ENABLED` on api-server:** likewise hidden. If `true`, api-server spawns a keeper subprocess in addition to the dedicated `Keeper` service.
+7. **Display-name whitespace:** the keeper service is literally named `"Keeper "` (trailing space). Cosmetic, but breaks naive name matching.
+8. **Stray env-var key on api-server:** `" SLACK_ENGINE_WEBHOOK_URL"` has a leading space. Likely unused; should be cleaned up.
+9. **`Dockerfile.worker` cache-bust** (dated 2026-04-14) suggests past trouble re-pulling layers. Not a current problem but worth noting if redeploys behave oddly.


### PR DESCRIPTION
## Summary

Phase A1 of the local-dev-environment plan (operator-attached spec 2026-05-12). Per operator's "A1 inventories only" decision: produce the four inventory docs needed before any docker-compose / Makefile / env.dev.example authoring lands, then stop. **A2 authoring is gated on review.**

Four read-only investigations run in parallel as subagents:

| # | Doc | Findings |
|---|-----|----------|
| 1 | `dockerfile-inventory.md` | 3 Dockerfiles, none multistage, all run as root, no EXPOSE (port via env) |
| 2 | `service-runtime-matrix.md` | 13 Railway services mapped. Backfill path is `scripts.backfill.backfill_{family}` (spec was wrong about `app.backfill.{family}`). 4 of 8 backfills have no source.repo set on Railway. |
| 3 | `env-var-inventory.md` | 51 unique env vars. `X402_NETWORK` has dynamic default. `KEEPER_PRIVATE_KEY` is both SECRET + FEATURE_FLAG. |
| 4 | `external-services-recon.md` | basis-state + basis-provenance are sibling repos (`basis-protocol/basis-state`, `basis-protocol/basis-provenance`). Hub never calls them — recommend omit or stub for compose, do not containerize. |

## Phase A2 blockers (needed before docker-compose authoring)

a) **Backfill module path correction:** compose service commands must use `scripts.backfill.backfill_{family}`, not the spec's assumed `app.backfill.{family}`.

b) **4 backfills missing source.repo on Railway** (tti, dohi, bri, rpi) — fragile, won't auto-redeploy. Independent of Phase A but flagged.

c) **basis-state / basis-provenance handling:** omit from compose, or stub them? Hub doesn't call either, so omission is simpler. Stubs only matter if local integration tests need to exercise inbound spoke→hub calls.

## Quirks surfaced (worth fixing independent of Phase A)

- Keeper service name has trailing space (`"Keeper "`)
- api-server has a stray env key with leading space (`" SLACK_ENGINE_WEBHOOK_URL"`)
- api-server has both `WORKER_ENABLED` and `KEEPER_ENABLED` env vars set (values hidden by Railway MCP). If either is `true`, work is duplicated with the dedicated Scoring-Worker / Keeper services.
- `WEB_WORKERS > 1` causes APScheduler to fire N× per cycle (in-process). Workaround: keep `WEB_WORKERS=1`.

## Substrate verification

### Pre-deploy

Docs PR — no runtime contract. The substrate IS the inventories themselves: each cites file:line / Railway service-ID / env-var default for independent re-verification. Phase A2 authoring should not start until operator confirms inventory accuracy (lesson 10 / lesson 7).

## Test plan

- [ ] Operator confirms inventory accuracy (spot-check 2-3 entries against Railway/repo)
- [ ] Operator decides on A2 blocker (c): omit basis-state/basis-provenance from compose, or stub
- [ ] Phase A2 starts (3 parallel authoring agents per spec) only after operator confirms

Orchestrator item: Phase A / A1 (4 of 4 inventories complete; A2 awaiting go-ahead).

https://claude.ai/code/session_orchestrator_2026_05_12_phase_a

Co-authored-by: Claude <noreply@anthropic.com>

---
_Generated by [Claude Code](https://claude.ai/code/session_01MiWTwLQZW4GaDDeUQRucLv)_