### PR TITLE
refactor(v9.12): peg_monitor coupled-write — peg+mchart+vs

### DIFF
--- a/app/data_layer/peg_monitor.py
+++ b/app/data_layer/peg_monitor.py
@@ -40,6 +40,11 @@ def _safe_float(val):
 API_KEY = os.environ.get("COINGECKO_API_KEY", "")
 CG_BASE = "https://pro-api.coingecko.com/api/v3" if API_KEY else "https://api.coingecko.com/api/v3"
 
+# CoinGecko id remaps (mirrors the pre-v9.13 worker.py inline path; needed
+# because a few stablecoins.coingecko_id values diverge from CG's canonical
+# id for the /market_chart endpoint).
+_CG_ID_REMAP = {"susd": "nusd", "spark": "spark-protocol"}
+
 
 def _headers() -> dict:
     h = {"Accept": "application/json"}
@@ -151,6 +156,43 @@ def _store_peg_snapshots(stablecoin_id: str, price_points: list[tuple]):
 
     elapsed = _t.monotonic() - _start
     logger.error(f"peg {stablecoin_id}: {stored} rows in {elapsed:.1f}s (skipped={skipped})")
+
+
+def _store_market_chart_history(coin_id: str, stablecoin_id: str, price_points: list[tuple]):
+    """Store 5-min market_chart_history rows — batched into one transaction.
+
+    Mirrors the pre-v9.13 worker.py inline path: same coin_id/stablecoin_id/
+    timestamp/price/granularity columns, ON CONFLICT DO NOTHING semantics.
+    """
+    if not price_points:
+        return 0
+
+    from psycopg2.extras import execute_values
+    from app.database import get_cursor
+
+    rows = []
+    for ts_ms, price in price_points:
+        safe_price = _safe_float(price)
+        if safe_price is None:
+            continue
+        ts = datetime.fromtimestamp(ts_ms / 1000, tz=timezone.utc)
+        rows.append((coin_id, stablecoin_id, ts, safe_price, "5min"))
+
+    if not rows:
+        return 0
+
+    try:
+        with get_cursor() as cur:
+            execute_values(cur,
+                "INSERT INTO market_chart_history "
+                "(coin_id, stablecoin_id, timestamp, price, granularity) "
+                "VALUES %s ON CONFLICT DO NOTHING",
+                rows, page_size=500,
+            )
+        return len(rows)
+    except Exception as e:
+        logger.warning(f"[peg_monitor] mchart insert failed for {stablecoin_id}: {e}")
+        return 0
 
 
 def _compute_volatility_surface(
@@ -290,98 +332,132 @@ async def run_peg_monitoring() -> dict:
         return {"error": "no stablecoins found"}
 
     total_snapshots = 0
+    total_mchart_rows = 0
     micro_depegs = []
     vol_surfaces = 0
+    block_error: Optional[str] = None
 
-    async with httpx.AsyncClient(timeout=30) as client:
-        for row in rows:
-            cg_id = row.get("coingecko_id")
-            stablecoin_id = row["id"]
-            symbol = row.get("symbol", "").upper()
+    try:
+        async with httpx.AsyncClient(timeout=30) as client:
+            for row in rows:
+                cg_id_raw = row.get("coingecko_id")
+                stablecoin_id = row["id"]
+                symbol = row.get("symbol", "").upper()
 
-            if not cg_id:
-                continue
-
-            try:
-                data = await _fetch_market_chart(client, cg_id, days=1)
-                prices_raw = data.get("prices", [])
-
-                if not prices_raw:
+                if not cg_id_raw:
                     continue
 
-                # Store 5-minute snapshots
-                await asyncio.to_thread(_store_peg_snapshots, stablecoin_id, prices_raw)
-                total_snapshots += len(prices_raw)
+                cg_id = _CG_ID_REMAP.get(cg_id_raw, cg_id_raw)
 
-                # Detect micro-depegs (>50bps deviation for 3+ consecutive points)
-                prices = [p[1] for p in prices_raw]
-                consecutive_depeg = 0
-                max_deviation = 0
-
-                for price in prices:
-                    deviation_bps = abs(price - 1.0) * 10000
-                    if deviation_bps > 50:  # >0.5% from peg
-                        consecutive_depeg += 1
-                        max_deviation = max(max_deviation, deviation_bps)
-                    else:
-                        if consecutive_depeg >= 3:
-                            micro_depegs.append({
-                                "stablecoin": symbol,
-                                "stablecoin_id": stablecoin_id,
-                                "consecutive_5m_intervals": consecutive_depeg,
-                                "max_deviation_bps": round(max_deviation, 2),
-                                "duration_minutes": consecutive_depeg * 5,
-                            })
-                        consecutive_depeg = 0
-                        max_deviation = 0
-
-                # Compute volatility surface from 1-day data
-                vol = _compute_volatility_surface(prices, stablecoin_id)
-                if vol:
-                    await asyncio.to_thread(_store_volatility_surface, vol)
-                    vol_surfaces += 1
-
-                # Also fetch 90-day data for deep volatility surfaces
                 try:
-                    data_90d = await _fetch_market_chart(client, cg_id, days=90)
-                    prices_90d = [p[1] for p in data_90d.get("prices", [])]
-                    if len(prices_90d) > 50:
-                        vol_90d = _compute_volatility_surface(prices_90d, stablecoin_id)
-                        if vol_90d:
-                            await asyncio.to_thread(
-                                _store_volatility_surface_90d_sync, stablecoin_id, vol_90d
-                            )
-                except asyncio.CancelledError:
-                    raise
-                except Exception as e:
-                    logger.warning(f"90d vol surface failed for {stablecoin_id}: {e}")
+                    data = await _fetch_market_chart(client, cg_id, days=1)
+                    prices_raw = data.get("prices", [])
+
+                    if not prices_raw:
+                        continue
+
+                    # Store 5-minute snapshots + market_chart_history (coupled
+                    # write per v9.13: both derive from the same days=1 fetch).
+                    await asyncio.to_thread(_store_peg_snapshots, stablecoin_id, prices_raw)
+                    total_snapshots += len(prices_raw)
+                    mchart_written = await asyncio.to_thread(
+                        _store_market_chart_history, cg_id_raw, stablecoin_id, prices_raw,
+                    )
+                    total_mchart_rows += mchart_written
+
+                    # Detect micro-depegs (>50bps deviation for 3+ consecutive points)
+                    prices = [p[1] for p in prices_raw]
+                    consecutive_depeg = 0
+                    max_deviation = 0
+
+                    for price in prices:
+                        deviation_bps = abs(price - 1.0) * 10000
+                        if deviation_bps > 50:  # >0.5% from peg
+                            consecutive_depeg += 1
+                            max_deviation = max(max_deviation, deviation_bps)
+                        else:
+                            if consecutive_depeg >= 3:
+                                micro_depegs.append({
+                                    "stablecoin": symbol,
+                                    "stablecoin_id": stablecoin_id,
+                                    "consecutive_5m_intervals": consecutive_depeg,
+                                    "max_deviation_bps": round(max_deviation, 2),
+                                    "duration_minutes": consecutive_depeg * 5,
+                                })
+                            consecutive_depeg = 0
+                            max_deviation = 0
+
+                    # Compute volatility surface from 1-day data
+                    vol = _compute_volatility_surface(prices, stablecoin_id)
+                    if vol:
+                        await asyncio.to_thread(_store_volatility_surface, vol)
+                        vol_surfaces += 1
+
+                    # Also fetch 90-day data for deep volatility surfaces
                     try:
-                        from app.worker import _record_cycle_error
-                        _record_cycle_error(
-                            error_type="data_layer_run_peg_monitoring_vol_90d_failure",
-                            error_message=str(e)[:500],
-                            cycle_phase="peg_monitor",
-                        )
-                    except Exception:
-                        pass
+                        data_90d = await _fetch_market_chart(client, cg_id, days=90)
+                        prices_90d = [p[1] for p in data_90d.get("prices", [])]
+                        if len(prices_90d) > 50:
+                            vol_90d = _compute_volatility_surface(prices_90d, stablecoin_id)
+                            if vol_90d:
+                                await asyncio.to_thread(
+                                    _store_volatility_surface_90d_sync, stablecoin_id, vol_90d
+                                )
+                    except asyncio.CancelledError:
+                        raise
+                    except Exception as e:
+                        logger.warning(f"90d vol surface failed for {stablecoin_id}: {e}")
+                        try:
+                            from app.worker import _record_cycle_error
+                            _record_cycle_error(
+                                error_type="data_layer_run_peg_monitoring_vol_90d_failure",
+                                error_message=str(e)[:500],
+                                cycle_phase="peg_monitor",
+                            )
+                        except Exception:
+                            pass
 
-            except Exception as e:
-                logger.warning(f"Peg monitoring failed for {stablecoin_id}: {e}")
+                except Exception as e:
+                    logger.warning(f"Peg monitoring failed for {stablecoin_id}: {e}")
+    except asyncio.CancelledError:
+        raise
+    except Exception as e:
+        # Block-level failure (e.g. AsyncClient setup, DB connection
+        # mid-loop). Per v9.13, every owned domain attests with the same
+        # block_failed status so monitors flag all three together.
+        block_error = f"{type(e).__name__}: {e}"[:200]
+        logger.error(f"peg_monitor block-level failure: {block_error}")
 
-    # Provenance — always attest, even when total_snapshots=0. Previously
-    # gated on `if total_snapshots > 0`, which let the domain go silent
-    # whenever the cycle ran but produced zero snapshots (CoinGecko 429,
-    # geofenced response, all stablecoins skipped). Same family as
-    # #141 (dex_pool_ohlcv). link_batch_to_proof is still conditional
-    # because there are no rows to correlate when snapshots=0.
+    # Provenance — coupled-write per v9.13: this module owns three live
+    # data-layer domains (peg_snapshots_5m, market_chart_history,
+    # volatility_surfaces), all derived from the shared /market_chart fetch.
+    # Attest each independently with its own status payload, so a partial
+    # failure in one write doesn't silence the others.
     try:
         from app.data_layer.provenance_scaling import attest_data_batch, link_batch_to_proof
-        payload = {"snapshots": total_snapshots, "vol_surfaces": vol_surfaces}
-        if total_snapshots == 0:
-            payload["status"] = "ran_no_snapshots"
-        await asyncio.to_thread(attest_data_batch, "peg_snapshots_5m", [payload])
+
+        def _status(rows_written: int) -> str:
+            if block_error:
+                return "block_failed"
+            return "ok" if rows_written > 0 else "ran_no_inserts"
+
+        peg_payload: dict = {"status": _status(total_snapshots), "rows": total_snapshots}
+        mchart_payload: dict = {"status": _status(total_mchart_rows), "rows": total_mchart_rows}
+        vs_payload: dict = {"status": _status(vol_surfaces), "rows": vol_surfaces}
+        if block_error:
+            peg_payload["error"] = block_error
+            mchart_payload["error"] = block_error
+            vs_payload["error"] = block_error
+
+        await asyncio.to_thread(attest_data_batch, "peg_snapshots_5m", [peg_payload])
+        await asyncio.to_thread(attest_data_batch, "market_chart_history", [mchart_payload])
+        await asyncio.to_thread(attest_data_batch, "volatility_surfaces", [vs_payload])
+
         if total_snapshots > 0:
             await link_batch_to_proof("peg_snapshots_5m", "peg_snapshots_5m")
+        if total_mchart_rows > 0:
+            await link_batch_to_proof("market_chart_history", "market_chart_history")
+        if vol_surfaces > 0:
             await link_batch_to_proof("volatility_surfaces", "volatility_surfaces")
     except asyncio.CancelledError:
         raise
@@ -398,7 +474,8 @@ async def run_peg_monitoring() -> dict:
             pass
 
     logger.info(
-        f"Peg monitoring complete: {total_snapshots} snapshots, "
+        f"Peg monitoring complete: {total_snapshots} peg snapshots, "
+        f"{total_mchart_rows} mchart rows, "
         f"{len(micro_depegs)} micro-depegs detected, "
         f"{vol_surfaces} volatility surfaces computed"
     )
@@ -424,6 +501,7 @@ async def run_peg_monitoring() -> dict:
     return {
         "stablecoins_monitored": len(rows),
         "total_5m_snapshots": total_snapshots,
+        "total_mchart_rows": total_mchart_rows,
         "micro_depegs_detected": len(micro_depegs),
         "micro_depegs": micro_depegs,
         "volatility_surfaces_computed": vol_surfaces,

--- a/app/worker.py
+++ b/app/worker.py
@@ -968,23 +968,6 @@ def _bulk_insert_yield_snapshots(rows_with_ts):
         )
 
 
-def _bulk_insert_peg_and_mchart(peg_rows, mc_rows):
-    """Sync helper: bulk insert peg snapshots and market chart history (called via to_thread)."""
-    from psycopg2.extras import execute_values as _ev
-    from app.database import get_cursor as _gc
-    with _gc() as _c:
-        _ev(_c,
-            "INSERT INTO peg_snapshots_5m(stablecoin_id,price,timestamp,deviation_bps) "
-            "VALUES %s ON CONFLICT DO NOTHING",
-            peg_rows, page_size=500,
-        )
-        _ev(_c,
-            "INSERT INTO market_chart_history(coin_id,stablecoin_id,timestamp,price,granularity) "
-            "VALUES %s ON CONFLICT DO NOTHING",
-            [r + ('5min',) for r in mc_rows], page_size=500,
-        )
-
-
 # =============================================================================
 # Orchestrator: Fast cycle — critical scoring + lightweight tasks (<15 min)
 # =============================================================================
@@ -1307,70 +1290,25 @@ async def run_fast_cycle():
     # Deferred to Phase 2: direct contract monitoring using existing Etherscan quota.
     # Table schema retained for future backfill. See basis_protocol_v9_3_constitution_amendment.md.
 
-    # ==== 5. PEG 5-MIN + MARKET CHART ====
-    _pg_ok, _mc_ok = 0, 0
-    _peg_block_error: str | None = None
+    # ==== 5. PEG 5-MIN + MARKET CHART + VOLATILITY SURFACES ====
+    # v9.13 coupled-write: app/data_layer/peg_monitor.run_peg_monitoring()
+    # is the canonical writer for all three domains (peg_snapshots_5m,
+    # market_chart_history, volatility_surfaces). Module attests each
+    # domain independently. Inline path retired per refactor PR; see
+    # docs/basis_protocol_v9_13_constitution_amendment.md.
+    _peg_coins = await fetch_all_async("SELECT id, coingecko_id FROM stablecoins WHERE scoring_enabled = TRUE AND coingecko_id IS NOT NULL") or []
     try:
-        _mc_start = time.time()
-        _peg_coins = await fetch_all_async("SELECT id, coingecko_id FROM stablecoins WHERE scoring_enabled = TRUE AND coingecko_id IS NOT NULL") or []
-        _cg_fix_mc = {"susd": "nusd", "spark": "spark-protocol"}
-        async with httpx.AsyncClient(timeout=30) as _pc:
-            for _sc in _peg_coins:
-                _coin_start = time.time()
-                _cg = _cg_fix_mc.get(_sc["coingecko_id"], _sc["coingecko_id"])
-                try:
-                    _r = await _pc.get(f"{CG_BASE}/coins/{_cg}/market_chart",
-                        params={"vs_currency":"usd","days":1}, headers=CG_HDR)
-                    if _r.status_code != 200:
-                        await asyncio.sleep(0.15)
-                        continue
-                    from datetime import datetime as _pdt
-                    _peg_rows = []
-                    _mc_rows = []
-                    for _pt in _r.json().get("prices",[]):
-                        _ts = _pdt.fromtimestamp(_pt[0]/1000, tz=timezone.utc)
-                        _peg_rows.append((_sc["id"], _pt[1], _ts, round(abs(_pt[1]-1.0)*10000, 2)))
-                        _mc_rows.append((_sc["coingecko_id"], _sc["id"], _ts, _pt[1]))
-                    if _peg_rows:
-                        try:
-                            await asyncio.to_thread(
-                                _bulk_insert_peg_and_mchart, _peg_rows, _mc_rows,
-                            )
-                            _pg_ok += len(_peg_rows)
-                            _mc_ok += len(_mc_rows)
-                        except Exception as _ei:
-                            logger.error(f"peg/mchart bulk insert fail {_sc['id']}: {_ei}")
-                    logger.error(f"peg/mchart {_sc['id']}: {len(_peg_rows)} rows in {time.time()-_coin_start:.1f}s")
-                except Exception as _e: logger.error(f"peg fail {_sc['id']}: {_e}")
-                await asyncio.sleep(0.15)
-        logger.error(f"=== PEG: {_pg_ok}, MCHART: {_mc_ok}, elapsed={time.time()-_mc_start:.1f}s ===")
+        _peg_start = time.time()
+        from app.data_layer.peg_monitor import run_peg_monitoring
+        _peg_summary = await run_peg_monitoring()
+        logger.error(
+            f"=== PEG_MONITOR: peg={_peg_summary.get('total_5m_snapshots', 0)}, "
+            f"mchart={_peg_summary.get('total_mchart_rows', 0)}, "
+            f"vs={_peg_summary.get('volatility_surfaces_computed', 0)}, "
+            f"elapsed={time.time()-_peg_start:.1f}s ==="
+        )
     except Exception as _e5:
-        _peg_block_error = f"{type(_e5).__name__}: {_e5}"[:200]
-        logger.error(f"=== PEG FAILED: {_e5} ===")
-
-    # Attest from the live worker.py path. Lives OUTSIDE the outer try
-    # (Wave 5a fix): Wave 3 #153 placed this inside the try, so any
-    # failure of the per-coin loop or the bulk-insert wrapper swallowed
-    # the attest too — domain went 2.7d stale despite the table being
-    # written every cycle. Status carries the block outcome.
-    try:
-        from app.data_layer.provenance_scaling import attest_data_batch
-        if _peg_block_error:
-            _peg_status = "block_failed"
-        elif _pg_ok:
-            _peg_status = "ok"
-        else:
-            _peg_status = "ran_no_inserts"
-        _peg_payload: dict = {
-            "status": _peg_status,
-            "peg_rows": _pg_ok,
-            "mchart_rows": _mc_ok,
-        }
-        if _peg_block_error:
-            _peg_payload["error"] = _peg_block_error
-        await asyncio.to_thread(attest_data_batch, "peg_snapshots_5m", [_peg_payload])
-    except Exception as _e_attest:
-        logger.warning(f"peg_snapshots_5m worker attest failed: {_e_attest}")
+        logger.error(f"=== PEG_MONITOR FAILED: {_e5} ===")
 
     # ==== 6. LIQUIDITY DEPTH (CEX tickers) ====
     try:


### PR DESCRIPTION
## Summary

First application of the v9.13 coupled-write rule (#186). `app/data_layer/peg_monitor.py` becomes the canonical writer for **all three** of its derived domains, attesting each independently:

- `peg_snapshots_5m`
- `market_chart_history` (added to module — was inline-only pre-v9.13)
- `volatility_surfaces` (already module-only — restored to live by retiring the inline path that skipped it)

The `worker.py` Section 5 inline (lines 1310-1373) and the `_bulk_insert_peg_and_mchart` helper are deleted. Worker now calls `run_peg_monitoring()` on the same `run_fast_cycle` cadence the inline previously occupied.

## Why now (link to amendment)

Per `docs/basis_protocol_v9_13_constitution_amendment.md` (merged in #186):

> Coupled-write modules are AUTHORIZED under v9.12 module-canonical when (1) shared upstream fetch and (2) module owns ALL attestation domains it writes to.

The `peg_snapshots_5m + market_chart_history + volatility_surfaces` group meets both criteria:

| Criterion | Evidence |
|---|---|
| Shared fetch | `/coins/{cg}/market_chart` drives all three (days=1 → peg+mchart, days=90 → vs) |
| Live consumers for vs | `server.py:7916` API endpoint; `catalog.py`, `index_simulator.py`, `component_replay.py` treat as first-class; `storage_evaluation.py`, `state_growth.py` count it in capacity planning |
| API budget | Paid CG tier (500/min, 500k credits/month, currently ~12.8% used) — 2x fetch is trivial (~+216 credits/day) |

## Changes

**`app/data_layer/peg_monitor.py`**
- Add `_store_market_chart_history(coin_id, stablecoin_id, prices)` — 5min granularity, `ON CONFLICT DO NOTHING`, mirrors retired inline schema
- Add `_CG_ID_REMAP = {"susd": "nusd", "spark": "spark-protocol"}` — preserves the worker.py id-fixup that the module previously lacked
- `run_peg_monitoring`: writes peg + mchart from same days=1 fetch, vs from days=90 fetch
- Three independent `attest_data_batch` calls (`peg_snapshots_5m`, `market_chart_history`, `volatility_surfaces`) with per-domain `status` (`ok` / `ran_no_inserts` / `block_failed`) + per-domain `rows`
- Three `link_batch_to_proof` calls, each gated on its own row count
- Block-level try/except so a mid-loop crash still emits `block_failed` for all three domains (no silent stale-domain pattern)

**`app/worker.py`**
- Section 5 inline replaced with `await run_peg_monitoring()`
- `_peg_coins` fetch retained (Section 6 LIQUIDITY DEPTH still iterates it)
- `_bulk_insert_peg_and_mchart` helper removed (no other callers — verified by grep)

## Substrate verification queries

Run after first post-deploy fast cycle (~within 4h of merge):

```sql
-- (a) all three domains advance within cadence after deploy
SELECT domain,
       MAX(cycle_timestamp) AS last_attest,
       NOW() - MAX(cycle_timestamp) AS staleness,
       COUNT(*) FILTER (WHERE cycle_timestamp > NOW() - INTERVAL '4 hours') AS attests_last_4h
FROM state_attestations
WHERE domain IN ('data_layer:peg_snapshots_5m',
                 'data_layer:market_chart_history',
                 'data_layer:volatility_surfaces')
GROUP BY domain;

-- (b) volatility_surfaces row count advances past 261 (the pre-refactor stale baseline)
SELECT COUNT(*) AS rows_total,
       COUNT(*) FILTER (WHERE computed_at > NOW() - INTERVAL '4 hours') AS rows_fresh,
       MAX(computed_at) AS last_write
FROM volatility_surfaces;

-- (c) CoinGecko credit usage stays trivial
-- (Monitor externally on CG dashboard; expect ~+216 credits/day,
--  trivial vs 500k/month budget.)
```

## Halt conditions

- CoinGecko credit usage suddenly spikes (rate-limit misconfiguration) → revert
- `server.py:7916` endpoint starts erroring (consumer-side change required) → revert
- Any of the three domains regress (last_attest stops advancing, or row counts go backwards) → revert

## Test plan

- [ ] Both files parse (`python -c "import ast; ast.parse(...)"`) — verified locally
- [ ] After deploy: query (a) shows all three domains attesting within ~4h
- [ ] After deploy: query (b) shows `volatility_surfaces` rows_fresh > 0 and rows_total > 261
- [ ] CG credit usage on dashboard stays within budget envelope
- [ ] No regression in `run_fast_cycle` total elapsed time (peg block was already a meaningful chunk)

## References

- v9.13 amendment: #186 (`docs/basis_protocol_v9_13_constitution_amendment.md`)
- v9.12 pilot (1:1 case): #179 (dex_pool_ohlcv)
- P0 sweep blockers doc: #185


---
_Generated by [Claude Code](https://claude.ai/code/session_014BubUrGgeKGGiJKRmCLJ8F)_