### PR TITLE
refactor(v9-13): peg_monitor → module-canonical (coupled-write)

### DIFF
--- a/app/data_layer/peg_monitor.py
+++ b/app/data_layer/peg_monitor.py
@@ -153,6 +153,51 @@ def _store_peg_snapshots(stablecoin_id: str, price_points: list[tuple]):
     logger.error(f"peg {stablecoin_id}: {stored} rows in {elapsed:.1f}s (skipped={skipped})")
 
 
+def _store_market_chart(stablecoin_id: str, coingecko_id: str, price_points: list[tuple]):
+    """Store same days=1 price points to market_chart_history (granularity='5min').
+
+    Coupled-write per v9.13: the /market_chart fetch in run_peg_monitoring
+    already produces this data; mirroring it to market_chart_history avoids
+    a duplicate fetch against CoinGecko.
+    """
+    if not price_points:
+        return 0
+
+    from app.database import get_cursor
+    rows = []
+    for ts_ms, price in price_points:
+        safe_price = _safe_float(price)
+        if safe_price is None:
+            continue
+        ts = datetime.fromtimestamp(ts_ms / 1000, tz=timezone.utc)
+        rows.append((coingecko_id, stablecoin_id, ts, safe_price, "5min"))
+    if not rows:
+        return 0
+
+    try:
+        from psycopg2.extras import execute_values
+        with get_cursor() as cur:
+            execute_values(cur,
+                """INSERT INTO market_chart_history
+                   (coin_id, stablecoin_id, timestamp, price, granularity)
+                   VALUES %s ON CONFLICT DO NOTHING""",
+                rows, page_size=500,
+            )
+        return len(rows)
+    except Exception as e:
+        logger.warning(f"[peg_monitor] mchart batch insert failed for {stablecoin_id}: {e}")
+        try:
+            from app.worker import _record_cycle_error
+            _record_cycle_error(
+                error_type="data_layer__store_market_chart_insert_failure",
+                error_message=str(e)[:500],
+                cycle_phase="peg_monitor",
+            )
+        except Exception:
+            pass
+        return 0
+
+
 def _compute_volatility_surface(
     prices: list[float],
     asset_id: str,
@@ -290,6 +335,7 @@ async def run_peg_monitoring() -> dict:
         return {"error": "no stablecoins found"}
 
     total_snapshots = 0
+    mchart_rows = 0
     micro_depegs = []
     vol_surfaces = 0
 
@@ -309,9 +355,14 @@ async def run_peg_monitoring() -> dict:
                 if not prices_raw:
                     continue
 
-                # Store 5-minute snapshots
+                # Coupled-write per v9.13: same price points feed both
+                # peg_snapshots_5m and market_chart_history. One fetch,
+                # two domains.
                 await asyncio.to_thread(_store_peg_snapshots, stablecoin_id, prices_raw)
                 total_snapshots += len(prices_raw)
+                mchart_rows += await asyncio.to_thread(
+                    _store_market_chart, stablecoin_id, cg_id, prices_raw,
+                )
 
                 # Detect micro-depegs (>50bps deviation for 3+ consecutive points)
                 prices = [p[1] for p in prices_raw]
@@ -368,20 +419,34 @@ async def run_peg_monitoring() -> dict:
             except Exception as e:
                 logger.warning(f"Peg monitoring failed for {stablecoin_id}: {e}")
 
-    # Provenance — always attest, even when total_snapshots=0. Previously
-    # gated on `if total_snapshots > 0`, which let the domain go silent
-    # whenever the cycle ran but produced zero snapshots (CoinGecko 429,
-    # geofenced response, all stablecoins skipped). Same family as
-    # #141 (dex_pool_ohlcv). link_batch_to_proof is still conditional
-    # because there are no rows to correlate when snapshots=0.
+    # Provenance — coupled-write attestation per v9.13: this module owns
+    # all three write tables (peg_snapshots_5m, market_chart_history,
+    # volatility_surfaces) and must attest to one domain per table.
+    # Always attest, even on zero-write cycles (CoinGecko 429, geofence,
+    # all stablecoins skipped). link_batch_to_proof stays conditional
+    # because there are no rows to correlate when counts are zero.
     try:
         from app.data_layer.provenance_scaling import attest_data_batch, link_batch_to_proof
-        payload = {"snapshots": total_snapshots, "vol_surfaces": vol_surfaces}
+
+        peg_payload: dict = {"snapshots": total_snapshots, "vol_surfaces": vol_surfaces}
         if total_snapshots == 0:
-            payload["status"] = "ran_no_snapshots"
-        await asyncio.to_thread(attest_data_batch, "peg_snapshots_5m", [payload])
+            peg_payload["status"] = "ran_no_snapshots"
+        mchart_payload: dict = {"rows": mchart_rows, "granularity": "5min"}
+        if mchart_rows == 0:
+            mchart_payload["status"] = "ran_no_rows"
+        vs_payload: dict = {"surfaces": vol_surfaces}
+        if vol_surfaces == 0:
+            vs_payload["status"] = "ran_no_surfaces"
+
+        await asyncio.to_thread(attest_data_batch, "peg_snapshots_5m", [peg_payload])
+        await asyncio.to_thread(attest_data_batch, "market_chart_history", [mchart_payload])
+        await asyncio.to_thread(attest_data_batch, "volatility_surfaces", [vs_payload])
+
         if total_snapshots > 0:
             await link_batch_to_proof("peg_snapshots_5m", "peg_snapshots_5m")
+        if mchart_rows > 0:
+            await link_batch_to_proof("market_chart_history", "market_chart_history")
+        if vol_surfaces > 0:
             await link_batch_to_proof("volatility_surfaces", "volatility_surfaces")
     except asyncio.CancelledError:
         raise
@@ -424,7 +489,78 @@ async def run_peg_monitoring() -> dict:
     return {
         "stablecoins_monitored": len(rows),
         "total_5m_snapshots": total_snapshots,
+        "mchart_rows": mchart_rows,
         "micro_depegs_detected": len(micro_depegs),
         "micro_depegs": micro_depegs,
         "volatility_surfaces_computed": vol_surfaces,
     }
+
+
+_PEG_FRESHNESS_MINUTES = 50
+
+
+async def run_peg_monitoring_scheduled() -> dict:
+    """Module-canonical entry per v9.13: freshness gate + work + 3-domain attestation.
+
+    Mirrors the v9.12 ohlcv pattern (PR #179). Returns a status dict regardless
+    of branch:
+      - {"status": "skipped_fresh", "table_age_minutes": X}
+      - {"status": "ran", ...run_peg_monitoring() result}
+      - {"status": "error", "error": str}
+
+    The state_attestations rows fire inside this function (skipped/error
+    branches) or inside run_peg_monitoring() (work branch). Schedulers
+    (worker.py, enrichment_worker.py, main.py) MUST NOT re-attest.
+    """
+    from app.database import fetch_one
+    from app.data_layer.provenance_scaling import attest_data_batch
+
+    table_age_minutes: float = float(_PEG_FRESHNESS_MINUTES)
+    try:
+        latest = await asyncio.to_thread(
+            fetch_one, "SELECT MAX(timestamp) AS t FROM peg_snapshots_5m"
+        )
+        if latest and latest.get("t"):
+            _t = latest["t"]
+            if hasattr(_t, "tzinfo") and _t.tzinfo is None:
+                _t = _t.replace(tzinfo=timezone.utc)
+            if hasattr(_t, "timestamp"):
+                table_age_minutes = (
+                    datetime.now(timezone.utc) - _t
+                ).total_seconds() / 60
+    except Exception as e:
+        logger.warning(f"[peg_monitor] freshness check failed: {e}")
+        table_age_minutes = float(_PEG_FRESHNESS_MINUTES)
+
+    if table_age_minutes < _PEG_FRESHNESS_MINUTES:
+        skipped_payload = {
+            "status": "skipped_fresh",
+            "table_age_minutes": round(table_age_minutes, 2),
+        }
+        try:
+            for domain in ("peg_snapshots_5m", "market_chart_history", "volatility_surfaces"):
+                await asyncio.to_thread(attest_data_batch, domain, [skipped_payload])
+        except Exception as e:
+            logger.warning(f"[peg_monitor] skipped-fresh attest failed: {e}")
+        return skipped_payload
+
+    try:
+        result = await run_peg_monitoring()
+        return {
+            "status": "ran",
+            "table_age_minutes": round(table_age_minutes, 2),
+            **result,
+        }
+    except Exception as e:
+        logger.warning(f"[peg_monitor] scheduled run failed: {e}")
+        error_payload = {
+            "status": "error",
+            "table_age_minutes": round(table_age_minutes, 2),
+            "error": str(e)[:200],
+        }
+        try:
+            for domain in ("peg_snapshots_5m", "market_chart_history", "volatility_surfaces"):
+                await asyncio.to_thread(attest_data_batch, domain, [error_payload])
+        except Exception:
+            pass
+        return {"status": "error", "error": str(e)[:500]}

--- a/app/enrichment_worker.py
+++ b/app/enrichment_worker.py
@@ -900,8 +900,11 @@ async def run_enrichment_pipeline() -> dict:
     # ---- 5-minute peg monitoring + volatility surfaces ----
 
     async def _run_peg_monitoring():
-        from app.data_layer.peg_monitor import run_peg_monitoring
-        return await run_peg_monitoring()
+        # v9.13 module-canonical: call the scheduled wrapper so the
+        # freshness gate + 3-domain (peg/mchart/vol) attestation live
+        # inside the module, not the scheduler.
+        from app.data_layer.peg_monitor import run_peg_monitoring_scheduled
+        return await run_peg_monitoring_scheduled()
 
     pipeline.add(EnrichmentTask(
         name="peg_5m_monitoring", func=_run_peg_monitoring,

--- a/app/worker.py
+++ b/app/worker.py
@@ -968,23 +968,6 @@ def _bulk_insert_yield_snapshots(rows_with_ts):
         )
 
 
-def _bulk_insert_peg_and_mchart(peg_rows, mc_rows):
-    """Sync helper: bulk insert peg snapshots and market chart history (called via to_thread)."""
-    from psycopg2.extras import execute_values as _ev
-    from app.database import get_cursor as _gc
-    with _gc() as _c:
-        _ev(_c,
-            "INSERT INTO peg_snapshots_5m(stablecoin_id,price,timestamp,deviation_bps) "
-            "VALUES %s ON CONFLICT DO NOTHING",
-            peg_rows, page_size=500,
-        )
-        _ev(_c,
-            "INSERT INTO market_chart_history(coin_id,stablecoin_id,timestamp,price,granularity) "
-            "VALUES %s ON CONFLICT DO NOTHING",
-            [r + ('5min',) for r in mc_rows], page_size=500,
-        )
-
-
 # =============================================================================
 # Orchestrator: Fast cycle — critical scoring + lightweight tasks (<15 min)
 # =============================================================================
@@ -1307,70 +1290,22 @@ async def run_fast_cycle():
     # Deferred to Phase 2: direct contract monitoring using existing Etherscan quota.
     # Table schema retained for future backfill. See basis_protocol_v9_3_constitution_amendment.md.
 
-    # ==== 5. PEG 5-MIN + MARKET CHART ====
-    _pg_ok, _mc_ok = 0, 0
-    _peg_block_error: str | None = None
+    # ==== 5. PEG 5-MIN + MARKET CHART + VOLATILITY (v9.13 module-canonical) ====
+    # Inline implementation removed — peg_monitor.run_peg_monitoring_scheduled
+    # is the canonical writer for peg_snapshots_5m + market_chart_history +
+    # volatility_surfaces (coupled-write per v9.13). Freshness gate +
+    # 3-domain attest live inside the module. Worker is scheduler-only.
     try:
-        _mc_start = time.time()
-        _peg_coins = await fetch_all_async("SELECT id, coingecko_id FROM stablecoins WHERE scoring_enabled = TRUE AND coingecko_id IS NOT NULL") or []
-        _cg_fix_mc = {"susd": "nusd", "spark": "spark-protocol"}
-        async with httpx.AsyncClient(timeout=30) as _pc:
-            for _sc in _peg_coins:
-                _coin_start = time.time()
-                _cg = _cg_fix_mc.get(_sc["coingecko_id"], _sc["coingecko_id"])
-                try:
-                    _r = await _pc.get(f"{CG_BASE}/coins/{_cg}/market_chart",
-                        params={"vs_currency":"usd","days":1}, headers=CG_HDR)
-                    if _r.status_code != 200:
-                        await asyncio.sleep(0.15)
-                        continue
-                    from datetime import datetime as _pdt
-                    _peg_rows = []
-                    _mc_rows = []
-                    for _pt in _r.json().get("prices",[]):
-                        _ts = _pdt.fromtimestamp(_pt[0]/1000, tz=timezone.utc)
-                        _peg_rows.append((_sc["id"], _pt[1], _ts, round(abs(_pt[1]-1.0)*10000, 2)))
-                        _mc_rows.append((_sc["coingecko_id"], _sc["id"], _ts, _pt[1]))
-                    if _peg_rows:
-                        try:
-                            await asyncio.to_thread(
-                                _bulk_insert_peg_and_mchart, _peg_rows, _mc_rows,
-                            )
-                            _pg_ok += len(_peg_rows)
-                            _mc_ok += len(_mc_rows)
-                        except Exception as _ei:
-                            logger.error(f"peg/mchart bulk insert fail {_sc['id']}: {_ei}")
-                    logger.error(f"peg/mchart {_sc['id']}: {len(_peg_rows)} rows in {time.time()-_coin_start:.1f}s")
-                except Exception as _e: logger.error(f"peg fail {_sc['id']}: {_e}")
-                await asyncio.sleep(0.15)
-        logger.error(f"=== PEG: {_pg_ok}, MCHART: {_mc_ok}, elapsed={time.time()-_mc_start:.1f}s ===")
+        from app.data_layer.peg_monitor import run_peg_monitoring_scheduled
+        _peg_result = await run_peg_monitoring_scheduled()
+        logger.error(
+            f"=== PEG: status={_peg_result.get('status')}, "
+            f"snapshots={_peg_result.get('total_5m_snapshots', 0)}, "
+            f"mchart={_peg_result.get('mchart_rows', 0)}, "
+            f"vol_surfaces={_peg_result.get('volatility_surfaces_computed', 0)} ==="
+        )
     except Exception as _e5:
-        _peg_block_error = f"{type(_e5).__name__}: {_e5}"[:200]
-        logger.error(f"=== PEG FAILED: {_e5} ===")
-
-    # Attest from the live worker.py path. Lives OUTSIDE the outer try
-    # (Wave 5a fix): Wave 3 #153 placed this inside the try, so any
-    # failure of the per-coin loop or the bulk-insert wrapper swallowed
-    # the attest too — domain went 2.7d stale despite the table being
-    # written every cycle. Status carries the block outcome.
-    try:
-        from app.data_layer.provenance_scaling import attest_data_batch
-        if _peg_block_error:
-            _peg_status = "block_failed"
-        elif _pg_ok:
-            _peg_status = "ok"
-        else:
-            _peg_status = "ran_no_inserts"
-        _peg_payload: dict = {
-            "status": _peg_status,
-            "peg_rows": _pg_ok,
-            "mchart_rows": _mc_ok,
-        }
-        if _peg_block_error:
-            _peg_payload["error"] = _peg_block_error
-        await asyncio.to_thread(attest_data_batch, "peg_snapshots_5m", [_peg_payload])
-    except Exception as _e_attest:
-        logger.warning(f"peg_snapshots_5m worker attest failed: {_e_attest}")
+        logger.error(f"=== PEG SCHEDULED FAILED: {_e5} ===")
 
     # ==== 6. LIQUIDITY DEPTH (CEX tickers) ====
     try:

--- a/docs/audits/2026-05-11-module-canonical-migration-plan.md
+++ b/docs/audits/2026-05-11-module-canonical-migration-plan.md
@@ -29,7 +29,7 @@ schedule the module from worker.py.
 | domain | worker/main site | module site | priority¹ | notes |
 |---|---|---|---|---|
 | `psi_discoveries` | `worker.py:2548`, `main.py:262` | (none — enrichment task wraps `app/discovery.py`) | **P0** | 3-PR history (#137, #150, #157). Highest-friction case. |
-| `data_layer:peg_snapshots_5m` | `worker.py:1371`, also Wave 5b heartbeat at 2787 | `app/data_layer/peg_monitor.py:382` | **P0** | Wave 5a + 5b both touched it. |
+| ~~`data_layer:peg_snapshots_5m` (+ `market_chart_history` + `volatility_surfaces`)~~ ✅ | ~~worker.py:1310-1373 inline~~ removed | `app/data_layer/peg_monitor.py::run_peg_monitoring_scheduled` | **P0 → DONE** | First v9.13 coupled-write refactor. Module attests all 3 domains. Worker, enrichment_worker, and main.py all routed through the scheduled wrapper. Dispatcher heartbeat at worker.py:2787 left in place until Phase 2.3. |
 | `data_layer:exchange_snapshots` | `worker.py:1261` | `app/data_layer/exchange_collector.py:274` | **P0** | Wave 5a hoist. |
 | ~~`data_layer:dex_pool_ohlcv`~~ ✅ | ~~worker.py inline~~ removed | `app/data_layer/ohlcv_collector.py::run_ohlcv_collection_scheduled` | **P0 → DONE** | Pilot landed this session; module-canonical via `run_ohlcv_collection_scheduled()`. Dispatcher heartbeat at worker.py:2778 left in place until Phase 2.3. |
 | `wallets` | `worker.py:2082`, also `worker.py:2787` (heartbeat) | — (driven by `app/indexer/pipeline.py`) | **P1** | Wave 1 + Wave 3 + Wave 5b. |

--- a/main.py
+++ b/main.py
@@ -352,7 +352,7 @@ def run_worker_loop():
                 ("bridge_flows", "SELECT MAX(snapshot_at) AS latest FROM bridge_flows",
                  lambda: __import__('app.data_layer.bridge_flow_collector', fromlist=['run_bridge_flow_collection']).run_bridge_flow_collection()),
                 ("peg_5m", "SELECT MAX(timestamp) AS latest FROM peg_snapshots_5m",
-                 lambda: __import__('app.data_layer.peg_monitor', fromlist=['run_peg_monitoring']).run_peg_monitoring()),
+                 lambda: __import__('app.data_layer.peg_monitor', fromlist=['run_peg_monitoring_scheduled']).run_peg_monitoring_scheduled()),
                 ("market_chart", "SELECT MAX(timestamp) AS latest FROM market_chart_history",
                  lambda: __import__('app.data_layer.market_chart_backfill', fromlist=['run_market_chart_backfill']).run_market_chart_backfill(backfill_days=90)),
                 ("governance", "SELECT MAX(collected_at) AS latest FROM governance_proposals WHERE source = 'snapshot'",


### PR DESCRIPTION
First v9.13 refactor (PR #186). Replaces the worker.py inline peg
block (lines 1310-1373) plus its dispatcher-side attest with a single
call to a new module function
`app/data_layer/peg_monitor.py::run_peg_monitoring_scheduled()`.

Per v9.13 §"Implication for peg_monitor", peg_monitor.py becomes the
canonical writer for all three coupled-write domains:

| domain | pre-refactor writer | post-refactor writer |
|---|---|---|
| `peg_snapshots_5m` | worker.py inline + module (race) | module only |
| `market_chart_history` | worker.py inline only | module only (now attests) |
| `volatility_surfaces` | module only (rare-fire) | module only (every cycle) |

Coupled-write criteria check (v9.13 §Decision):

1. **Shared upstream fetch** — `/coins/{cg}/market_chart` drives both
   days=1 (peg + mchart) and days=90 (vol). One fetch, three writes. ✓
2. **Module owns ALL attestation domains** — `attest_data_batch()` now
   fires for all 3 domains in every branch (work / skipped_fresh /
   error). ✓

Changes
-------

`+ app/data_layer/peg_monitor.py`
- Add `_store_market_chart()` helper (execute_values bulk insert).
- `run_peg_monitoring()` now writes peg_snapshots_5m + mchart in
  the same per-coin loop and tracks `mchart_rows`.
- Provenance section attests all 3 domains with status fields
  reflecting per-domain write counts. Always attests, even on
  zero-write cycles.
- Add `run_peg_monitoring_scheduled()` wrapper mirroring the v9.12
  ohlcv pattern (PR #179). 50-min freshness gate; skip-fresh and
  error branches each attest 3 domains.

`- app/worker.py`
- Delete the 64-line inline peg block (1310-1373).
- Replace with a 9-line call to `run_peg_monitoring_scheduled()`.
- Remove now-orphaned `_bulk_insert_peg_and_mchart` helper.

`= app/enrichment_worker.py`
- `_run_peg_monitoring` switched to call the scheduled wrapper
  (mirrors PR #182 dex_pool_ohlcv). 20h slow-cycle gate stays as
  outer skip-stale optimization.

`= main.py`
- Daily-gated dispatcher's `peg_5m` lambda switched to the scheduled
  wrapper.

`= docs/audits/2026-05-11-module-canonical-migration-plan.md`
- Flip the peg row from DUAL_WRITER (P0) to DONE.

Out-of-scope (kept for Phase 2.3)
---------------------------------

The dispatcher-level heartbeat at `worker.py:2787`
(`_emit_slow_cycle_heartbeats`) still attests `peg_snapshots_5m` on
every slow-cycle completion. Same disposition as PR #179 — separate
concern, comes out in the Phase 2.3 dispatcher collapse once every
P0/P1 domain has migrated.

## Substrate verification

### Pre-deploy

Pre-refactor baseline (2026-05-12 00:38 UTC):

```
data_layer:peg_snapshots_5m       — last attest from worker.py inline,
                                     status="ok"/"ran_no_inserts"/"block_failed"
data_layer:market_chart_history   — NOT a current attestation domain
                                     (no writer attests; first attest
                                     fires after this PR's deploy)
data_layer:volatility_surfaces    — only module-path attests; per
                                     v9.13 substrate cite, last write
                                     2026-05-08 (3+ days stale,
                                     exhibiting v9.11 dead-module pattern)
```

### Post-deploy (operator runs after first run_fast_cycle, ~1h)

```sql
SELECT domain,
       COUNT(*) AS rows_total,
       MAX(cycle_timestamp) AS last_attest,
       NOW() - MAX(cycle_timestamp) AS staleness
FROM state_attestations
WHERE domain IN ('peg_snapshots_5m', 'market_chart_history', 'volatility_surfaces')
GROUP BY domain
ORDER BY domain;
```

Expected:
- All 3 domains have a fresh row within last 1h with
  `payload->>'status'` ∈ {ran, skipped_fresh, error}.
- `peg_snapshots_5m` and `market_chart_history` row counts
  incrementing each fast cycle.
- `volatility_surfaces` row count incrementing at the same cadence
  (was 261 rows / 4-day stale baseline).

Halt condition
--------------

If after 2h there is NO new row for any of the 3 domains, halt the
v9.13 sweep. That would indicate the worker.py inline replacement is
not on the live path (a still-undiscovered run_slow_cycle dispatcher
duplication, similar to the lesson 6 pattern), and the next refactor
(exchange_snapshots) should not proceed until peg verifies.

https://claude.ai/code/session_01T9JSBB6E4rxjLUssCLk5X3

---
_Generated by [Claude Code](https://claude.ai/code/session_01T9JSBB6E4rxjLUssCLk5X3)_