### PR TITLE
refactor(v9-13): peg_monitor scheduled wrapper — freshness gate + scheduler-side abstraction

### DIFF
--- a/app/data_layer/peg_monitor.py
+++ b/app/data_layer/peg_monitor.py
@@ -506,3 +506,74 @@ async def run_peg_monitoring() -> dict:
         "micro_depegs": micro_depegs,
         "volatility_surfaces_computed": vol_surfaces,
     }
+
+
+_PEG_FRESHNESS_MINUTES = 50
+
+
+async def run_peg_monitoring_scheduled() -> dict:
+    """Module-canonical scheduler entry per v9.13: freshness gate + work + attestation.
+
+    Mirrors the v9.12 ohlcv pattern (PR #179). Returns a status dict
+    regardless of branch:
+      - {"status": "skipped_fresh", "table_age_minutes": X}
+      - {"status": "ran", ...run_peg_monitoring() result}
+      - {"status": "error", "error": str}
+
+    The state_attestations rows for all three coupled-write domains
+    (peg_snapshots_5m, market_chart_history, volatility_surfaces) fire
+    inside this function (skipped/error branches) or inside
+    run_peg_monitoring() (work branch). Schedulers MUST NOT re-attest.
+    """
+    from app.database import fetch_one
+    from app.data_layer.provenance_scaling import attest_data_batch
+
+    table_age_minutes: float = float(_PEG_FRESHNESS_MINUTES)
+    try:
+        latest = await asyncio.to_thread(
+            fetch_one, "SELECT MAX(timestamp) AS t FROM peg_snapshots_5m"
+        )
+        if latest and latest.get("t"):
+            _t = latest["t"]
+            if hasattr(_t, "tzinfo") and _t.tzinfo is None:
+                _t = _t.replace(tzinfo=timezone.utc)
+            if hasattr(_t, "timestamp"):
+                table_age_minutes = (
+                    datetime.now(timezone.utc) - _t
+                ).total_seconds() / 60
+    except Exception as e:
+        logger.warning(f"[peg_monitor] freshness check failed: {e}")
+        table_age_minutes = float(_PEG_FRESHNESS_MINUTES)
+
+    if table_age_minutes < _PEG_FRESHNESS_MINUTES:
+        skipped_payload = {
+            "status": "skipped_fresh",
+            "table_age_minutes": round(table_age_minutes, 2),
+        }
+        try:
+            for domain in ("peg_snapshots_5m", "market_chart_history", "volatility_surfaces"):
+                await asyncio.to_thread(attest_data_batch, domain, [skipped_payload])
+        except Exception as e:
+            logger.warning(f"[peg_monitor] skipped-fresh attest failed: {e}")
+        return skipped_payload
+
+    try:
+        result = await run_peg_monitoring()
+        return {
+            "status": "ran",
+            "table_age_minutes": round(table_age_minutes, 2),
+            **result,
+        }
+    except Exception as e:
+        logger.warning(f"[peg_monitor] scheduled run failed: {e}")
+        error_payload = {
+            "status": "error",
+            "table_age_minutes": round(table_age_minutes, 2),
+            "error": str(e)[:200],
+        }
+        try:
+            for domain in ("peg_snapshots_5m", "market_chart_history", "volatility_surfaces"):
+                await asyncio.to_thread(attest_data_batch, domain, [error_payload])
+        except Exception:
+            pass
+        return {"status": "error", "error": str(e)[:500]}

--- a/app/enrichment_worker.py
+++ b/app/enrichment_worker.py
@@ -900,8 +900,11 @@ async def run_enrichment_pipeline() -> dict:
     # ---- 5-minute peg monitoring + volatility surfaces ----
 
     async def _run_peg_monitoring():
-        from app.data_layer.peg_monitor import run_peg_monitoring
-        return await run_peg_monitoring()
+        # v9.13 module-canonical: scheduled wrapper owns freshness gate +
+        # 3-domain (peg/mchart/vol) attestation. Mirrors PR #182's
+        # dex_pool_ohlcv pattern.
+        from app.data_layer.peg_monitor import run_peg_monitoring_scheduled
+        return await run_peg_monitoring_scheduled()
 
     pipeline.add(EnrichmentTask(
         name="peg_5m_monitoring", func=_run_peg_monitoring,

--- a/app/worker.py
+++ b/app/worker.py
@@ -1291,18 +1291,18 @@ async def run_fast_cycle():
     # Table schema retained for future backfill. See basis_protocol_v9_3_constitution_amendment.md.
 
     # ==== 5. PEG 5-MIN + MARKET CHART + VOLATILITY SURFACES ====
-    # v9.13 coupled-write: app/data_layer/peg_monitor.run_peg_monitoring()
-    # is the canonical writer for all three domains (peg_snapshots_5m,
-    # market_chart_history, volatility_surfaces). Module attests each
-    # domain independently. Inline path retired per refactor PR; see
-    # docs/basis_protocol_v9_13_constitution_amendment.md.
+    # v9.13 coupled-write: app/data_layer/peg_monitor.run_peg_monitoring_scheduled()
+    # is the canonical scheduler entry for all three domains (peg_snapshots_5m,
+    # market_chart_history, volatility_surfaces). Module owns the freshness
+    # gate + 3-domain attestation. Worker is scheduler-only.
     _peg_coins = await fetch_all_async("SELECT id, coingecko_id FROM stablecoins WHERE scoring_enabled = TRUE AND coingecko_id IS NOT NULL") or []
     try:
         _peg_start = time.time()
-        from app.data_layer.peg_monitor import run_peg_monitoring
-        _peg_summary = await run_peg_monitoring()
+        from app.data_layer.peg_monitor import run_peg_monitoring_scheduled
+        _peg_summary = await run_peg_monitoring_scheduled()
         logger.error(
-            f"=== PEG_MONITOR: peg={_peg_summary.get('total_5m_snapshots', 0)}, "
+            f"=== PEG_MONITOR: status={_peg_summary.get('status')}, "
+            f"peg={_peg_summary.get('total_5m_snapshots', 0)}, "
             f"mchart={_peg_summary.get('total_mchart_rows', 0)}, "
             f"vs={_peg_summary.get('volatility_surfaces_computed', 0)}, "
             f"elapsed={time.time()-_peg_start:.1f}s ==="

--- a/docs/audits/2026-05-11-module-canonical-migration-plan.md
+++ b/docs/audits/2026-05-11-module-canonical-migration-plan.md
@@ -29,7 +29,7 @@ schedule the module from worker.py.
 | domain | worker/main site | module site | priority¹ | notes |
 |---|---|---|---|---|
 | `psi_discoveries` | `worker.py:2548`, `main.py:262` | (none — enrichment task wraps `app/discovery.py`) | **P0** | 3-PR history (#137, #150, #157). Highest-friction case. |
-| `data_layer:peg_snapshots_5m` | `worker.py:1371`, also Wave 5b heartbeat at 2787 | `app/data_layer/peg_monitor.py:382` | **P0** | Wave 5a + 5b both touched it. |
+| ~~`data_layer:peg_snapshots_5m` (+ `market_chart_history` + `volatility_surfaces`)~~ ✅ | ~~worker.py:1310-1373 inline~~ removed | `app/data_layer/peg_monitor.py::run_peg_monitoring_scheduled` | **P0 → DONE** | First v9.13 coupled-write refactor. #188 made the module canonical writer for all 3 domains; this PR adds the scheduled wrapper (freshness gate + 3-domain skip/error attest) and routes worker, enrichment_worker, and main.py through it. Dispatcher heartbeat at worker.py:2787 left in place until Phase 2.3. |
 | `data_layer:exchange_snapshots` | `worker.py:1261` | `app/data_layer/exchange_collector.py:274` | **P0** | Wave 5a hoist. |
 | ~~`data_layer:dex_pool_ohlcv`~~ ✅ | ~~worker.py inline~~ removed | `app/data_layer/ohlcv_collector.py::run_ohlcv_collection_scheduled` | **P0 → DONE** | Pilot landed this session; module-canonical via `run_ohlcv_collection_scheduled()`. Dispatcher heartbeat at worker.py:2778 left in place until Phase 2.3. |
 | `wallets` | `worker.py:2082`, also `worker.py:2787` (heartbeat) | — (driven by `app/indexer/pipeline.py`) | **P1** | Wave 1 + Wave 3 + Wave 5b. |

--- a/main.py
+++ b/main.py
@@ -352,7 +352,7 @@ def run_worker_loop():
                 ("bridge_flows", "SELECT MAX(snapshot_at) AS latest FROM bridge_flows",
                  lambda: __import__('app.data_layer.bridge_flow_collector', fromlist=['run_bridge_flow_collection']).run_bridge_flow_collection()),
                 ("peg_5m", "SELECT MAX(timestamp) AS latest FROM peg_snapshots_5m",
-                 lambda: __import__('app.data_layer.peg_monitor', fromlist=['run_peg_monitoring']).run_peg_monitoring()),
+                 lambda: __import__('app.data_layer.peg_monitor', fromlist=['run_peg_monitoring_scheduled']).run_peg_monitoring_scheduled()),
                 ("market_chart", "SELECT MAX(timestamp) AS latest FROM market_chart_history",
                  lambda: __import__('app.data_layer.market_chart_backfill', fromlist=['run_market_chart_backfill']).run_market_chart_backfill(backfill_days=90)),
                 ("governance", "SELECT MAX(collected_at) AS latest FROM governance_proposals WHERE source = 'snapshot'",


### PR DESCRIPTION
**Supersedes #192 (rebased onto post-#188 main).** #192's branch was based pre-#188, so its diff showed phantom deletions of code #188 already removed and a duplicate `_store_market_chart` function. Force-push to update #192 was blocked at the remote, so opening this PR fresh. #192 will be closed.

Sits on top of #188 which made `app/data_layer/peg_monitor.py` the canonical writer for `peg_snapshots_5m` + `market_chart_history` + `volatility_surfaces` (coupled-write per v9.13). This PR adds the scheduler-side abstraction that #188 left out.

What this adds
--------------

- **`run_peg_monitoring_scheduled()` wrapper** in peg_monitor.py mirroring the v9.12 ohlcv pattern (PR #179):
  - 50-min freshness gate on `peg_snapshots_5m` MAX(timestamp).
  - `skipped_fresh` and `error` branches each attest all 3 domains so cadence stays measurable when work is skipped or fails.
  - Work branch delegates to existing `run_peg_monitoring()` (which #188 already wired up for 3-domain attestation).
- **3 caller switches** to route through the wrapper:
  - `worker.py:1302-1303` — `run_peg_monitoring` → `run_peg_monitoring_scheduled`; log carries `status`.
  - `app/enrichment_worker.py:902-904` — same switch (mirrors PR #182). 20h slow-cycle gate stays as outer skip-stale optimization.
  - `main.py:355` — daily-gated lambda switched.
- **Migration plan doc** — peg row flipped from P0 DUAL_WRITER to DONE.

Why
---

Without this PR, every `run_fast_cycle` hits CoinGecko regardless of whether `peg_snapshots_5m` is fresh — #188 made the module canonical but each invocation always does work.

Diff shape
----------

```
 app/data_layer/peg_monitor.py                      | 71 +++++++++++++++++++++
 app/enrichment_worker.py                           |  7 ++-
 app/worker.py                                      | 16 ++---
 main.py                                            |  2 +-
 docs/audits/2026-05-11-module-canonical-migration-plan.md | 2 +-
 5 files changed, 86 insertions(+), 12 deletions(-)
```

No deletions of code already removed by #188. No duplicate helpers. Wrapper is purely additive.

## Substrate verification

### Pre-deploy

#188 already routes through `run_peg_monitoring()` with 3-domain attestation. Verification post-deploy is about cadence shape and skipped/ran/error mix.

### Post-deploy (operator runs after first `run_fast_cycle`, ~1h)

```sql
SELECT domain,
       COUNT(*) AS rows_total,
       MAX(cycle_timestamp) AS last_attest,
       NOW() - MAX(cycle_timestamp) AS staleness,
       COUNT(*) FILTER (WHERE payload->>'status' = 'skipped_fresh') AS skipped_count,
       COUNT(*) FILTER (WHERE payload->>'status' = 'ran') AS ran_count,
       COUNT(*) FILTER (WHERE payload->>'status' = 'error') AS error_count
FROM state_attestations
WHERE domain IN ('peg_snapshots_5m', 'market_chart_history', 'volatility_surfaces')
  AND cycle_timestamp > NOW() - INTERVAL '2 hours'
GROUP BY domain
ORDER BY domain;
```

Expected:
- All 3 domains have at least one fresh row within last 1h.
- `skipped_count > 0` once the wrapper runs while a previous cycle's data is still <50 min old (freshness gate is doing its job).
- `volatility_surfaces` row total past the 261-row / 4-day-stale baseline.

Halt condition: if any of the 3 domains shows ZERO rows in the 2h window post-deploy, halt the v9.13 sweep — the wrapper is not on the live path (lesson 6 family).

https://claude.ai/code/session_01T9JSBB6E4rxjLUssCLk5X3

---
_Generated by [Claude Code](https://claude.ai/code/session_01T9JSBB6E4rxjLUssCLk5X3)_