### PR TITLE
fix(phase-a2): anvil entrypoint override + env.dev quoting

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -103,9 +103,12 @@ services:
     # Foundry's Anvil — local EVM node forked from Base mainnet so the
     # keeper hits realistic chain state without spending real gas.
     image: ghcr.io/foundry-rs/foundry:latest
-    # The foundry image has ENTRYPOINT ["anvil"] — we pass flags only,
-    # NOT the literal "anvil" again, and NOT a single shell string (which
-    # would arrive as one arg with embedded spaces and fail to parse).
+    # The foundry image's entrypoint is sh-based, NOT ["anvil"]. Without an
+    # explicit override the compose `command:` list gets handed to sh, which
+    # rejects `--host` with `/bin/sh: 0: Illegal option --` (observed in the
+    # Codespace boot on 2026-05-12). Pin the entrypoint to anvil and pass
+    # flags through `command:` so each flag is a discrete argv entry.
+    entrypoint: ["anvil"]
     command:
       - "--host"
       - "0.0.0.0"

--- a/docs/development/compose-design-notes.md
+++ b/docs/development/compose-design-notes.md
@@ -39,6 +39,15 @@ Chain ID is pinned to 8453 so the keeper's chain-id assertions pass.
 Arbitrum is not forked — single-fork keeps RAM use bounded; operators
 testing Arbitrum-specific paths should override `ARBITRUM_RPC_URL`.
 
+**Entrypoint override.** Empirically, `ghcr.io/foundry-rs/foundry:latest`
+ships with an sh-based entrypoint rather than `["anvil"]`. Passing a list
+`command:` of anvil flags without an explicit `entrypoint:` override sends
+those flags through sh and produces `/bin/sh: 0: Illegal option --` at
+container start (caught during Codespace boot on 2026-05-12). The compose
+file therefore pins `entrypoint: ["anvil"]` on the anvil service. If a
+future foundry release breaks the override, fall back to a single
+string-form `command:` (shell form) and re-document here.
+
 ## Backfills: why a profile
 
 The eight backfill services on Railway have `restartPolicyType: NEVER` —

--- a/docs/development/env-var-inventory.md
+++ b/docs/development/env-var-inventory.md
@@ -41,7 +41,7 @@ Complete record of all environment variables that basis-hub reads at runtime. Th
 | CORS_ORIGINS | METADATA | No | `*` | CORS allowed origins (comma-separated) |
 | CDP_API_KEY_ID | SECRET | No | `""` | Coinbase Developer Platform API key ID |
 | CDP_API_KEY_SECRET | SECRET | No | `""` | Coinbase Developer Platform API secret |
-| DATABASE_URL | INFRASTRUCTURE | No | `""` | PostgreSQL connection string |
+| DATABASE_URL | INFRASTRUCTURE | No | `""` | PostgreSQL connection string. **Always wrap the value in double quotes in `env.dev` / `env.dev.example`** — Neon pooled URLs contain `&` (e.g. `channel_binding=require`), and an unquoted `&` is a bash job-control separator that silently truncates the value when downstream tools run `source env.dev` / `. ./env.dev`. |
 | DWELLIR_API_KEY | SECRET | No | `""` | Dwellir RPC provider API key |
 | DWELLIR_ETH_URL | SECRET | No | none | Full Dwellir Ethereum RPC URL (overrides API key) |
 | DWELLIR_BASE_URL | SECRET | No | none | Full Dwellir Base RPC URL (overrides API key) |

--- a/env.dev.example
+++ b/env.dev.example
@@ -147,7 +147,11 @@ ADMIN_KEY=dev-admin-key-unsafe
 # Category: INFRASTRUCTURE
 # Required: N (functionally required for production; required for any DB-backed dev work)
 # Inventory dev default: Neon dev branch or local PostgreSQL (e.g. postgresql://user:pass@localhost:5432/basis_dev)
-DATABASE_URL=REPLACE_ME_NEON_DEV_BRANCH_URL
+# NOTE: Neon pooled URLs contain `&` (channel_binding=require).
+# Always quote DATABASE_URL — unquoted & is a bash job separator
+# and silently breaks env sourcing in any downstream tool that uses
+# `source env.dev` or `. ./env.dev`.
+DATABASE_URL="REPLACE_ME_NEON_DEV_BRANCH_URL"
 
 # HTTP server listening port (same as API_PORT)
 # Category: INFRASTRUCTURE

--- a/scripts/dev-bootstrap.sh
+++ b/scripts/dev-bootstrap.sh
@@ -76,13 +76,14 @@ echo "    $ENV_FILE exists."
 # Step 3: DATABASE_URL filled in?
 # -----------------------------------------------------------------------------
 echo "==> Validating DATABASE_URL in $ENV_FILE..."
-# Source env.dev in a subshell so we don't pollute this shell.
-set +u
-# shellcheck disable=SC1090
-. "./$ENV_FILE"
-set -u
-
-DB_URL="${DATABASE_URL:-}"
+# Do NOT `source` env.dev. Neon pooled URLs contain `&` (channel_binding=require),
+# which is a bash job-control separator when unquoted — sourcing silently
+# splits the URL and leaves DATABASE_URL empty (observed in the Codespace
+# boot on 2026-05-12). Parse the value out of the file instead. Strips
+# matching outer single/double quotes if present, takes the first match
+# if the key is duplicated.
+DB_URL=$(grep '^DATABASE_URL=' "$ENV_FILE" | head -1 | cut -d= -f2- \
+         | sed -e 's/^"//' -e 's/"$//' -e "s/^'//" -e "s/'$//")
 if [ -z "$DB_URL" ] || [ "$DB_URL" = "REPLACE_ME_NEON_DEV_BRANCH_URL" ] || echo "$DB_URL" | grep -q "REPLACE_ME"; then
   cat <<EOF
 ERROR: DATABASE_URL in $ENV_FILE is unset or still contains a REPLACE_ME placeholder.


### PR DESCRIPTION
## Context

Two operator-side bugs found during Codespace boot **2026-05-12 ~02:25 UTC** while exercising the Phase A2 local-dev stack (`make dev-bootstrap` → `make dev`). Both are mechanical; no substrate impact, no scoring-path changes.

## Bug 1 — Anvil container exits at boot

**Symptom**

```
$ docker logs basis-hub-anvil-1
/bin/sh: 0: Illegal option --
```

**Root cause**

The `ghcr.io/foundry-rs/foundry:latest` image's entrypoint is sh-based, not `["anvil"]` as the inline comment in `docker-compose.dev.yml` claimed. The list-form `command:` was therefore arriving as sh args, and sh rejects `--host`.

**Fix**

Pin `entrypoint: ["anvil"]` on the anvil service so the flags reach anvil directly. Rewrite the inline comment to describe what the foundry image actually does and why the override is required. Document the same decision in `docs/development/compose-design-notes.md` with a fallback recipe (string-form `command:`) in case a future foundry release breaks the override.

## Bug 2 — `make dev-bootstrap` reports DATABASE_URL empty

**Symptom**

After pasting a Neon pooled URL into `env.dev`, the validator step said `DATABASE_URL is unset or still contains a REPLACE_ME placeholder` and aborted.

**Root cause**

`scripts/dev-bootstrap.sh` ran `. ./env.dev` (bash source). Every Neon pooled URL contains `&` (e.g. `channel_binding=require`); unquoted `&` is a bash job-control separator and silently truncates the value at source time. Unless the operator wrapped the value in quotes themselves, `DATABASE_URL` was empty after sourcing.

**Fix — both paths, complementary**

- **A. Script (`scripts/dev-bootstrap.sh`).** Replace the `source` block with a `grep | head -1 | cut | sed` extractor that strips matching outer single/double quotes and takes the first match if the key is duplicated. Tolerates unquoted, single-quoted, and double-quoted values.
- **B. Template (`env.dev.example`).** Wrap the `DATABASE_URL` placeholder in double quotes and add a comment explaining why downstream tools that still rely on `source env.dev` need the value quoted.

Also adds a quoting note on the `DATABASE_URL` row of `docs/development/env-var-inventory.md`.

## Files

| File | What changed |
|---|---|
| `docker-compose.dev.yml` | `entrypoint: ["anvil"]` + rewritten inline comment |
| `scripts/dev-bootstrap.sh` | source block → grep+cut extractor |
| `env.dev.example` | `DATABASE_URL` quoted + note above |
| `docs/development/compose-design-notes.md` | Document entrypoint override decision |
| `docs/development/env-var-inventory.md` | Quoting note on `DATABASE_URL` row |

## Verification

Run locally on the branch.

**1. Compose YAML still parses, entrypoint pinned, command intact:**

```
$ python3 -c "import yaml; d = yaml.safe_load(open('docker-compose.dev.yml')); a = d['services']['anvil']; print('entrypoint:', a.get('entrypoint')); print('command:', a.get('command'))"
entrypoint: ['anvil']
command: ['--host', '0.0.0.0', '--chain-id', '8453', '--fork-url', '${BASE_FORK_URL:-https://mainnet.base.org}']
```

**2. dev-bootstrap.sh passes `bash -n`:**

```
$ bash -n scripts/dev-bootstrap.sh && echo OK
OK
```

**3. grep+cut extractor against quoted / unquoted / single-quoted / duplicate cases:**

```
--- unquoted ---
postgresql://user:pass@host/db?sslmode=require&channel_binding=require
--- double-quoted ---
postgresql://user:pass@host/db?sslmode=require&channel_binding=require
--- single-quoted ---
postgresql://user:pass@host/db?sslmode=require&channel_binding=require
--- duplicate (expect first) ---
postgresql://first/db?a=1&b=2
```

**4. Contrast — demonstrates the original bug:**

```
--- source on unquoted (the bug) ---
sourced DATABASE_URL=[]
--- source on double-quoted (path B) ---
sourced DATABASE_URL=[postgresql://user:pass@host/db?sslmode=require&channel_binding=require]
```

Path A makes the validator robust regardless of how the operator quotes the value; path B teaches future operators (and any other downstream tool that still uses `source`) the convention.

## Halt conditions — not triggered

- **Other env.dev.example vars with special-char issues:** I scanned the template; the remaining unquoted values are alphanumeric / boolean / numeric / simple URLs without `&`. No other variable currently needs the same fix, so per the brief I have **not** changed them in this PR. Flagging here in case operators want a follow-up sweep.
- **entrypoint override breaking foundry:** Not observed. Compose still loads, image reference unchanged.

## Out of scope

No substrate / scoring / SII-PSI-RPI changes. No production rollout. Dev-only path.


---
_Generated by [Claude Code](https://claude.ai/code/session_01S6LxvbnVAQbnUeFxL7Fgk9)_