### PR TITLE
fix(p1): migration 109 — replay exchange_snapshots schema drift

### DIFF
--- a/migrations/109_exchange_snapshots_drift_replay.sql
+++ b/migrations/109_exchange_snapshots_drift_replay.sql
@@ -1,0 +1,57 @@
+-- Migration 109: Replay 4 columns dropped from exchange_snapshots
+--   by pg_dump silent drift.
+--
+-- 2026-05-12 substrate audit (Blocker 2 of the v9.12 P0 sweep — see
+-- docs/audits/2026-05-11-module-canonical-migration-plan.md):
+--
+--   Migration 058 (`058_universal_data_layer.sql:208-224`) declared
+--   exchange_snapshots with 14 columns:
+--       id, exchange_id, name, trust_score, trust_score_rank,
+--       trade_volume_24h_btc, trade_volume_24h_usd, year_established,
+--       country, trading_pairs, has_trading_incentive,
+--       stablecoin_pairs, raw_data, snapshot_at
+--
+--   `information_schema.columns` on prod (2026-05-12 09:15Z) shows 11:
+--   the four below are MISSING:
+--       trade_volume_24h_usd  NUMERIC
+--       has_trading_incentive BOOLEAN
+--       stablecoin_pairs      JSONB
+--       raw_data              JSONB
+--
+--   `migrations` records `058_universal_data_layer` as applied
+--   2026-04-13. Same root cause as the 2026-05-10 / Wave 9c incident:
+--   the Replit→owned-Neon pg_dump preserved the `migrations` tracking
+--   table but silently lost partial DDL content for tables created
+--   outside Replit's UI. Mirrors migration 108's pattern; this one
+--   replays columns instead of tables.
+--
+-- Consumer impact (lesson 10):
+--   - app/server.py:7886 (`/api/data/exchanges` list mode) selects
+--     `trade_volume_24h_usd` and ORDER BYs it — currently throws
+--     `column "trade_volume_24h_usd" does not exist` on every call.
+--     Confirmed by running the exact query against prod Neon
+--     (2026-05-12 09:10Z).
+--   - app/data_layer/exchange_collector.py:153-171 inserts all 4 of
+--     these columns; failures are silently swallowed by
+--     `main.py:342-344` (try/except without _record_cycle_error)
+--     and gated out of enrichment_worker.py:880 in steady state.
+--
+-- After this migration runs:
+--   - server.py:7886 unbroken.
+--   - The exchange_collector module's INSERT path no longer raises
+--     missing-column errors. (List-reconciliation + _EX_FIX port
+--     for the canonical-writer refactor stay separate concerns —
+--     handled by the v9.12 module-canonical refactor PR that
+--     follows.)
+--
+-- Idempotency: each ALTER uses ADD COLUMN IF NOT EXISTS (PostgreSQL
+-- 9.6+). Safe to re-run; safe on prod whether or not any of the
+-- columns happen to already be present.
+
+ALTER TABLE exchange_snapshots
+  ADD COLUMN IF NOT EXISTS trade_volume_24h_usd NUMERIC,
+  ADD COLUMN IF NOT EXISTS has_trading_incentive BOOLEAN,
+  ADD COLUMN IF NOT EXISTS stablecoin_pairs JSONB,
+  ADD COLUMN IF NOT EXISTS raw_data JSONB;
+
+INSERT INTO migrations (name) VALUES ('109_exchange_snapshots_drift_replay') ON CONFLICT DO NOTHING;


### PR DESCRIPTION
**P1 production bug fix.** `/api/data/exchanges` list mode at `app/server.py:7886` currently throws `NeonDbError: column "trade_volume_24h_usd" does not exist`. Verified against prod Neon by running the endpoint's exact query.

Root cause
----------

Migration 058 (`058_universal_data_layer.sql:208-224`) declared `exchange_snapshots` with 14 columns. Prod schema (verified 2026-05-12 09:15Z) has only 11. `migrations` records 058 as applied 2026-04-13 — same pg_dump silent-drift pattern as Wave 2.5 / Wave 9c (migration 108).

Missing on prod:
- `trade_volume_24h_usd` NUMERIC
- `has_trading_incentive` BOOLEAN
- `stablecoin_pairs` JSONB
- `raw_data` JSONB

Citations + the brokenness chain are documented in #195's "Blocker 2" investigation findings.

Fix
---

`ALTER TABLE … ADD COLUMN IF NOT EXISTS` for the four columns. Idempotent (PostgreSQL 9.6+). Mirrors migration 108's structure: header comment block citing the dropped surface, substrate cite for the gap, consumer-impact note, closes with the standard `INSERT INTO migrations` seed.

`schema_heal.py` edit — halt-condition surfaced
-----------------------------------------------

The brief called for adding the 4 column names to an "expected-columns entry" in `app/schema_heal.py`, citing PR #183's pattern. Reading the file (lesson 10) shows the structure is **table-existence only** — `EXPECTED_TABLES: frozenset[tuple[str, str]]` of `(schema, name)` pairs. PR #183 added `("public", "contract_dependencies")` at line 86; no column-level structure currently exists in `schema_heal.py`. `exchange_snapshots` is already in `EXPECTED_TABLES` at `schema_heal.py:111`.

Adding column-level verification would be a structural change to the fail-loud boot contract and should be its own PR — not bundled into a P1 production fix.

## Substrate verification

### Pre-deploy (temp Neon branch `migration-109-test`)

**Pre-migration:**
```sql
SELECT column_name, data_type FROM information_schema.columns
WHERE table_name='exchange_snapshots' AND table_schema='public'
  AND column_name IN ('trade_volume_24h_usd', 'has_trading_incentive',
                       'stablecoin_pairs', 'raw_data');
```
→ `0 rows`

**After applying the `ALTER` on the temp branch:**
```
has_trading_incentive   boolean
raw_data                jsonb
stablecoin_pairs        jsonb
trade_volume_24h_usd    numeric
```

**Re-running the previously-broken `server.py:7886` query on the temp branch:**
```sql
SELECT exchange_id, name, trust_score, trade_volume_24h_usd,
       year_established, trading_pairs, snapshot_at
FROM exchange_snapshots
WHERE snapshot_at > NOW() - INTERVAL '3 hours'
ORDER BY trade_volume_24h_usd DESC NULLS LAST LIMIT 3;
```
→ 3 rows (coinbase-exchange, okx, binance). `trade_volume_24h_usd = NULL` for all (as expected — worker.py inline doesn't populate this column). No `NeonDbError`. Endpoint unbroken.

**Idempotency:** re-ran the `ALTER` against the same branch → no error, no duplicate-column complaint.

Temp branch deleted after verification.

### Post-deploy

```sql
-- Confirms the 4 columns are present in prod after deploy.
SELECT column_name, data_type FROM information_schema.columns
WHERE table_name='exchange_snapshots' AND table_schema='public'
  AND column_name IN ('trade_volume_24h_usd', 'has_trading_incentive',
                       'stablecoin_pairs', 'raw_data')
ORDER BY column_name;

-- Confirms migrations row inserted.
SELECT name, applied_at FROM migrations
WHERE name = '109_exchange_snapshots_drift_replay';
```

Out of scope
------------

- `main.py:342-344` swallowing `exchange_collector` exceptions without `_record_cycle_error` — surfaced as separate issue in #195's findings.
- Q2 (15 vs 50 exchanges + `_EX_FIX` port) — blocker for the v9.12 module-canonical refactor, not this PR.
- `exchange_collector.py` module-canonical refactor itself — separate PR, gated on Q2.

Unblocks
--------

- `/api/data/exchanges` list mode (`server.py:7886`) — broken since the Neon migration.
- Q1 of the v9.12 `exchange_snapshots` refactor (replay vs trim) — this is Q1's answer in **replay** form.

https://claude.ai/code/session_01T9JSBB6E4rxjLUssCLk5X3

---
_Generated by [Claude Code](https://claude.ai/code/session_01T9JSBB6E4rxjLUssCLk5X3)_