### PR TITLE
refactor(v9.12): exchange_snapshots → module-canonical (15-list, _EX_FIX ported)

### DIFF
--- a/app/data_layer/exchange_collector.py
+++ b/app/data_layer/exchange_collector.py
@@ -26,21 +26,28 @@ logger = logging.getLogger(__name__)
 API_KEY = os.environ.get("COINGECKO_API_KEY", "")
 CG_BASE = "https://pro-api.coingecko.com/api/v3" if API_KEY else "https://api.coingecko.com/api/v3"
 
-# Top 50 exchanges by volume (CoinGecko IDs)
+# The 15 exchanges here match worker.py's _EX (the pre-v9.12 inline list).
+# The module's original TOP_EXCHANGES had 50; the additional 35 (upbit,
+# bithumb, whitebit, etc.) are deferred per the Q2 design call (#195
+# findings). See docs/audits/2026-05-11-module-canonical-migration-plan.md
+# "Blocker 2 / Q2-extension" for the deferred list.
 TOP_EXCHANGES = [
     "binance", "coinbase-exchange", "okx", "bybit_spot",
     "kraken", "kucoin", "gate", "bitget",
     "htx", "crypto_com", "mexc", "bitfinex",
     "bitstamp", "gemini", "lbank",
-    # Extended to 50
-    "upbit", "bithumb", "whitebit", "bitrue", "poloniex",
-    "hashkey-exchange", "bitmart", "phemex", "deribit", "bitflyer",
-    "indodax", "korbit", "exmo", "btcturk", "tidex",
-    "coinone", "probit-exchange", "bitbank", "zaif", "coincheck",
-    "okcoin", "gopax", "liquid", "btcbox", "bkex",
-    "latoken", "hotbit", "coinex", "bigone", "digifinex",
-    "xt", "deepcoin", "toobit", "bingx", "bitvenus",
 ]
+
+# CoinGecko legacy-slug remap. The four ids on the left are the canonical
+# slugs in our `stablecoins.coingecko_id`-style registry, but
+# /exchanges/<id> on CG still requires the legacy form on the right.
+# Ported verbatim from worker.py's pre-v9.12 inline (`_EX_FIX`).
+_EX_FIX = {
+    "coinbase-exchange": "gdax",
+    "okx": "okex",
+    "htx": "huobi",
+    "mexc": "mxc",
+}
 
 
 def _headers() -> dict:
@@ -59,7 +66,8 @@ async def _fetch_exchange_data(
 
     await rate_limiter.acquire("coingecko")
 
-    url = f"{CG_BASE}/exchanges/{exchange_id}"
+    cg_slug = _EX_FIX.get(exchange_id, exchange_id)
+    url = f"{CG_BASE}/exchanges/{cg_slug}"
     start = time.time()
     try:
         resp = await client.get(url, headers=_headers(), timeout=15)
@@ -91,7 +99,8 @@ async def _fetch_exchange_volume_history(
 
     await rate_limiter.acquire("coingecko")
 
-    url = f"{CG_BASE}/exchanges/{exchange_id}/volume_chart/{days}"
+    cg_slug = _EX_FIX.get(exchange_id, exchange_id)
+    url = f"{CG_BASE}/exchanges/{cg_slug}/volume_chart/{days}"
     start = time.time()
     try:
         resp = await client.get(url, headers=_headers(), timeout=15)
@@ -297,3 +306,75 @@ async def run_exchange_collection() -> dict:
         "exchanges_processed": total_snapshots,
         "stablecoin_pairs": total_stablecoin_pairs,
     }
+
+
+_EXCHANGE_FRESHNESS_MINUTES = 50
+
+
+async def run_exchange_collection_scheduled() -> dict:
+    """Module-canonical scheduler entry per v9.12 (#179 / #193 pattern).
+
+    Returns a status dict regardless of branch:
+      - {"status": "skipped_fresh", "table_age_minutes": X}
+      - {"status": "ran", ...run_exchange_collection() result}
+      - {"status": "error", "error": str}
+
+    The state_attestations row for data_layer:exchange_snapshots fires
+    inside this function on the skipped_fresh / error branches; the work
+    branch lets run_exchange_collection do its own attest. Schedulers
+    (worker.py, main.py) MUST NOT re-attest.
+    """
+    from app.database import fetch_one
+    from app.data_layer.provenance_scaling import attest_data_batch
+
+    table_age_minutes: float = float(_EXCHANGE_FRESHNESS_MINUTES)
+    try:
+        latest = await asyncio.to_thread(
+            fetch_one, "SELECT MAX(snapshot_at) AS t FROM exchange_snapshots"
+        )
+        if latest and latest.get("t"):
+            _t = latest["t"]
+            if hasattr(_t, "tzinfo") and _t.tzinfo is None:
+                _t = _t.replace(tzinfo=timezone.utc)
+            if hasattr(_t, "timestamp"):
+                table_age_minutes = (
+                    datetime.now(timezone.utc) - _t
+                ).total_seconds() / 60
+    except Exception as e:
+        logger.warning(f"[exchange_collector] freshness check failed: {e}")
+        table_age_minutes = float(_EXCHANGE_FRESHNESS_MINUTES)
+
+    if table_age_minutes < _EXCHANGE_FRESHNESS_MINUTES:
+        skipped_payload = {
+            "status": "skipped_fresh",
+            "table_age_minutes": round(table_age_minutes, 2),
+        }
+        try:
+            await asyncio.to_thread(
+                attest_data_batch, "exchange_snapshots", [skipped_payload]
+            )
+        except Exception as e:
+            logger.warning(f"[exchange_collector] skipped-fresh attest failed: {e}")
+        return skipped_payload
+
+    try:
+        result = await run_exchange_collection()
+        return {
+            "status": "ran",
+            "table_age_minutes": round(table_age_minutes, 2),
+            **result,
+        }
+    except Exception as e:
+        logger.warning(f"[exchange_collector] scheduled run failed: {e}")
+        error_payload = {
+            "status": "error",
+            "table_age_minutes": round(table_age_minutes, 2),
+            "error": str(e)[:200],
+        }
+        try:
+            await asyncio.to_thread(
+                attest_data_batch, "exchange_snapshots", [error_payload]
+            )
+        except Exception:
+            pass
+        return {"status": "error", "error": str(e)[:500]}

--- a/app/enrichment_worker.py
+++ b/app/enrichment_worker.py
@@ -867,20 +867,14 @@ async def run_enrichment_pipeline() -> dict:
     # ---- Tier 4: Bridge flows — DEFERRED (constitution v9.3) ----
     # DeFiLlama paywalled all bridges endpoints. Deferred to Phase 2.
 
-    # ---- Tier 5: Exchange data ----
-
-    async def _run_exchange_collection():
-        from app.data_layer.exchange_collector import run_exchange_collection
-        return await run_exchange_collection()
-
-    pipeline.add(EnrichmentTask(
-        name="exchange_data", func=_run_exchange_collection,
-        timeout_seconds=600, group="data_layer", priority=3,
-        gate_check=_db_gate(
-            "SELECT MAX(snapshot_at) AS latest FROM exchange_snapshots",
-            min_hours=1,
-        ),
-    ))
+    # ---- Tier 5: Exchange data (v9.12 module-canonical — no enrichment task) ----
+    # The scheduled wrapper `run_exchange_collection_scheduled` owns the
+    # freshness gate (50min) inside the module; worker.py invokes it
+    # every fast cycle. No separate enrichment task needed — the wrapper
+    # is the single entry point. The previous `exchange_data` task here
+    # (min_hours=1 db_gate) was kept closed by worker.py's inline writes
+    # and never ran in steady state (lesson 6 family); removing it now
+    # that the inline is gone.
 
     # ---- Tier 6: Correlation matrices (computed, no API calls) ----
 

--- a/app/worker.py
+++ b/app/worker.py
@@ -1183,67 +1183,25 @@ async def run_fast_cycle():
         logger.error(f"=== ENTITIES: {_es_ok} ok, {_es_err} err, total={_es_total} ===")
     except Exception as _e1: logger.error(f"=== ENTITIES FAILED: {_e1} ===")
 
-    # ==== 2. EXCHANGE SNAPSHOTS ====
-    _ex_ok, _ex_err = 0, 0
-    _ex_block_error: str | None = None
+    # ==== 2. EXCHANGE SNAPSHOTS (v9.12 module-canonical) ====
+    # Inline implementation removed — exchange_collector.run_exchange_collection_scheduled
+    # is the canonical writer for exchange_snapshots. Freshness gate +
+    # attestation (skipped_fresh / ran / error branches) all live inside
+    # the module. Worker is scheduler-only.
+    # The 15-id list and _EX_FIX legacy-slug remap moved with the inline
+    # into the module (per v9.12 P0 sweep + #195 Blocker 2 findings).
     try:
-        _EX = ["binance","coinbase-exchange","okx","bybit_spot","kraken","kucoin","gate",
-               "bitget","htx","crypto_com","mexc","bitfinex","bitstamp","gemini","lbank"]
-        # CoinGecko exchange ID corrections (IDs that 404)
-        _EX_FIX = {
-            "coinbase-exchange": "gdax",   # CoinGecko still uses legacy 'gdax' for Coinbase
-            "okx": "okex",                 # OKX listed as 'okex' on CoinGecko
-            "htx": "huobi",                # HTX rebranded from Huobi, CG still uses 'huobi'
-            "mexc": "mxc",                 # CoinGecko slug is 'mxc'
-        }
-        async with httpx.AsyncClient(timeout=30) as _xc:
-            for _xid in _EX:
-                _cg_xid = _EX_FIX.get(_xid, _xid)
-                try:
-                    _r = await _xc.get(f"{CG_BASE}/exchanges/{_cg_xid}", headers=CG_HDR)
-                    if _r.status_code != 200: continue
-                    _d = _r.json()
-                    await execute_async("""INSERT INTO exchange_snapshots
-                            (exchange_id,name,trust_score,trust_score_rank,trade_volume_24h_btc,
-                             year_established,country,trading_pairs,snapshot_at)
-                            VALUES(%s,%s,%s,%s,%s,%s,%s,%s,NOW())""",
-                            (_xid,_d.get("name"),_d.get("trust_score"),_d.get("trust_score_rank"),
-                             _sn(_d.get("trade_volume_24h_btc")),_d.get("year_established"),
-                             _d.get("country"),len(_d.get("tickers",[])) if _d.get("tickers") else None))
-                    _ex_ok += 1
-                except Exception as _e:
-                    _ex_err += 1
-                    if _ex_err <= 3: logger.error(f"exchange fail {_xid}: {_e}")
-                await asyncio.sleep(0.15)
-        _ex_total = await fetch_one_async("SELECT COUNT(*) as c FROM exchange_snapshots")
-        logger.error(f"=== EXCHANGES: {_ex_ok} ok, {_ex_err} err, total={_ex_total} ===")
+        _ex_start = time.time()
+        from app.data_layer.exchange_collector import run_exchange_collection_scheduled
+        _ex_summary = await run_exchange_collection_scheduled()
+        logger.error(
+            f"=== EXCHANGE_COLLECTOR: status={_ex_summary.get('status')}, "
+            f"exchanges_processed={_ex_summary.get('exchanges_processed', 0)}, "
+            f"stablecoin_pairs={_ex_summary.get('stablecoin_pairs', 0)}, "
+            f"elapsed={time.time()-_ex_start:.1f}s ==="
+        )
     except Exception as _e2:
-        _ex_block_error = f"{type(_e2).__name__}: {_e2}"[:200]
-        logger.error(f"=== EXCHANGES FAILED: {_e2} ===")
-
-    # Attest from the live worker.py path. Lives OUTSIDE the outer try
-    # because the Wave 3 #153 placement inside the try meant any failure
-    # of fetch_one_async/COUNT(*) or other inner step swallowed the attest
-    # too. Wave 5a moves it out so freshness signal advances independently
-    # of the block's success/failure. Status carries the block outcome.
-    try:
-        from app.data_layer.provenance_scaling import attest_data_batch
-        if _ex_block_error:
-            _ex_status = "block_failed"
-        elif _ex_ok:
-            _ex_status = "ok"
-        else:
-            _ex_status = "ran_no_inserts"
-        _ex_payload: dict = {
-            "status": _ex_status,
-            "exchanges_ok": _ex_ok,
-            "exchanges_err": _ex_err,
-        }
-        if _ex_block_error:
-            _ex_payload["error"] = _ex_block_error
-        await asyncio.to_thread(attest_data_batch, "exchange_snapshots", [_ex_payload])
-    except Exception as _e_attest:
-        logger.warning(f"exchange_snapshots worker attest failed: {_e_attest}")
+        logger.error(f"=== EXCHANGE_COLLECTOR SCHEDULED FAILED: {_e2} ===")
 
     # ==== 3. YIELD SNAPSHOTS (DeFiLlama) ====
     try:

--- a/docs/audits/2026-05-11-module-canonical-migration-plan.md
+++ b/docs/audits/2026-05-11-module-canonical-migration-plan.md
@@ -30,7 +30,7 @@ schedule the module from worker.py.
 |---|---|---|---|---|
 | `psi_discoveries` | `worker.py:2548`, `main.py:262` | (none — enrichment task wraps `app/discovery.py`) | **P0** | 3-PR history (#137, #150, #157). Highest-friction case. |
 | ~~`data_layer:peg_snapshots_5m` (+ `market_chart_history` + `volatility_surfaces`)~~ ✅ | ~~worker.py:1310-1373 inline~~ removed | `app/data_layer/peg_monitor.py::run_peg_monitoring_scheduled` | **P0 → DONE** | First v9.13 coupled-write refactor. #188 made the module canonical writer for all 3 domains; this PR adds the scheduled wrapper (freshness gate + 3-domain skip/error attest) and routes worker, enrichment_worker, and main.py through it. Dispatcher heartbeat at worker.py:2787 left in place until Phase 2.3. |
-| `data_layer:exchange_snapshots` | `worker.py:1261` | `app/data_layer/exchange_collector.py:274` | **P0** | Wave 5a hoist. |
+| ~~`data_layer:exchange_snapshots`~~ ✅ | ~~worker.py:1186-1246 inline~~ removed | `app/data_layer/exchange_collector.py::run_exchange_collection_scheduled` | **P0 → DONE** | Q1 answered by #197 (migration 109 — schema replay). Q2 answered: 15 exchanges (worker._EX list), `_EX_FIX` legacy-slug remap ported into module. 35 additional exchanges deferred to Q2-extension (see below). enrichment_worker.py task entry removed (was kept closed by inline; lesson 6 family). main.py daily lambda switched. Dispatcher heartbeat at worker.py:2787 left in place until Phase 2.3. |
 | ~~`data_layer:dex_pool_ohlcv`~~ ✅ | ~~worker.py inline~~ removed | `app/data_layer/ohlcv_collector.py::run_ohlcv_collection_scheduled` | **P0 → DONE** | Pilot landed this session; module-canonical via `run_ohlcv_collection_scheduled()`. Dispatcher heartbeat at worker.py:2778 left in place until Phase 2.3. |
 | `wallets` | `worker.py:2082`, also `worker.py:2787` (heartbeat) | — (driven by `app/indexer/pipeline.py`) | **P1** | Wave 1 + Wave 3 + Wave 5b. |
 | `web_research` | `worker.py:1960`, also 2787 | `app/collectors/web_research.py:563` | **P1** | Wave 1 + Wave 3 + Wave 5b. |
@@ -278,3 +278,52 @@ Phase 2.3 dispatcher collapse remains the last item in the queue;
 it is blocked on every P0+P1 domain reaching SINGLE_WRITER state.
 The shape of "what does SINGLE_WRITER mean for peg+mchart coupled-write?"
 is the unresolved design question gating the whole sweep.
+
+---
+
+## Blocker 2 / Q2-extension — additional 35 exchanges (deferred)
+
+The v9.12 exchange_snapshots refactor (#197 + the second-PR refactor)
+adopts the **15-exchange list** that matches worker.py's pre-v9.12
+`_EX` (binance, coinbase-exchange, okx, bybit_spot, kraken, kucoin,
+gate, bitget, htx, crypto_com, mexc, bitfinex, bitstamp, gemini,
+lbank). The module's original `TOP_EXCHANGES` had **50 ids** — the
+35 not in worker._EX are deferred from the live writer until an
+operator decision on coverage expansion.
+
+Deferred ids (35), grouped by region/tier as they appeared in the
+pre-refactor `TOP_EXCHANGES`:
+
+```
+# Tier-2 global volume (5):
+upbit, bithumb, whitebit, bitrue, poloniex
+
+# Specialty / derivatives (5):
+hashkey-exchange, bitmart, phemex, deribit, bitflyer
+
+# Regional KR/JP (5):
+indodax, korbit, exmo, btcturk, tidex
+
+# Regional KR/JP (5):
+coinone, probit-exchange, bitbank, zaif, coincheck
+
+# Tier-3 / legacy (5):
+okcoin, gopax, liquid, btcbox, bkex
+
+# Tier-3 / smaller (5):
+latoken, hotbit, coinex, bigone, digifinex
+
+# Newer / aggregators (5):
+xt, deepcoin, toobit, bingx, bitvenus
+```
+
+Re-enabling: add the ids back to `TOP_EXCHANGES` in
+`app/data_layer/exchange_collector.py`. No schema change needed —
+the schema (post-migration 109) already supports the richer
+column shape. If any of the deferred ids has a CG-legacy slug,
+add it to `_EX_FIX` at the same time.
+
+Cost: +35 `/exchanges/{id}` + `/exchanges/{id}/volume_chart/30`
+calls per fast cycle (~80 calls / cycle / hour). CG pro tier
+(500/min, 500k credits/month) has ample headroom. Worth a brief
+budget check against the daily usage tracker before flipping.

--- a/main.py
+++ b/main.py
@@ -332,7 +332,7 @@ def run_worker_loop():
             # --- Every-cycle collectors (hourly) ---
             for name, coro_fn in [
                 ("liquidity_depth", lambda: __import__('app.data_layer.liquidity_collector', fromlist=['run_liquidity_collection']).run_liquidity_collection()),
-                ("exchange_snapshots", lambda: __import__('app.data_layer.exchange_collector', fromlist=['run_exchange_collection']).run_exchange_collection()),
+                ("exchange_snapshots", lambda: __import__('app.data_layer.exchange_collector', fromlist=['run_exchange_collection_scheduled']).run_exchange_collection_scheduled()),
                 ("entity_snapshots", lambda: __import__('app.data_layer.entity_snapshots', fromlist=['run_entity_snapshots']).run_entity_snapshots()),
             ]:
                 try:


### PR DESCRIPTION
Second of the two-PR plan from #195's Blocker 2 findings. Migration 109 (#197) shipped the schema replay (**Q1** answer); this PR is the module-canonical refactor (**Q2** answer).

Per Q2 design call: **15 exchanges** (matching worker.py's pre-v9.12 `_EX`, NOT module's prior `TOP_EXCHANGES`-of-50). `_EX_FIX` legacy-slug remap ported into the module. The 35 deferred ids are catalogued in the migration plan's new "Q2-extension" section for future expansion.

Mirrors #193's peg_monitor scheduled-wrapper shape, which mirrors #179's dex_pool_ohlcv pilot.

Pre-flight verified
-------------------

```sql
SELECT column_name FROM information_schema.columns
WHERE table_name='exchange_snapshots'
  AND column_name IN ('trade_volume_24h_usd','has_trading_incentive',
                       'stablecoin_pairs','raw_data');
```
→ all 4 columns present on prod. #197 deployed at 2026-05-12 09:41 UTC. Module's 12-column INSERT no longer references nonexistent columns.

Changes
-------

`+ app/data_layer/exchange_collector.py`
- `TOP_EXCHANGES` trimmed from 50 → 15 (matches worker._EX exactly, order preserved).
- Add `_EX_FIX` dict — port verbatim from worker.py: `coinbase-exchange→gdax`, `okx→okex`, `htx→huobi`, `mexc→mxc`. Applied inside `_fetch_exchange_data` AND `_fetch_exchange_volume_history` so the CG legacy slugs are used for both `/exchanges/{id}` and `/exchanges/{id}/volume_chart/{days}` calls.
- Add `run_exchange_collection_scheduled()`. 50-min freshness gate on `MAX(snapshot_at)`. `skipped_fresh` / `error` branches attest `data_layer:exchange_snapshots` independently; `ran` branch lets `run_exchange_collection` do its own attest.

`- app/worker.py`
- Delete the 60-line inline block at 1186-1246 (the `_EX` list, `_EX_FIX`, /exchanges loop, INSERT, attest).
- Replace with a 9-line call to `run_exchange_collection_scheduled()`.

`= app/enrichment_worker.py`
- Remove the enrichment task entry at 872-883. The task's `min_hours=1` db_gate was kept closed by worker.py inline writes in steady state (lesson 6 family); the scheduled wrapper is now the single entry point.

`= main.py`
- Switch the daily lambda at line 335 from `run_exchange_collection` → `run_exchange_collection_scheduled`. Also closes the silent try/except surface — the wrapper's error branch records to `state_attestations` with `status='error'`, so failures from this caller stop being invisible (one of the issues surfaced in #195).

`= docs/audits/2026-05-11-module-canonical-migration-plan.md`
- Flip the exchange_snapshots row from DUAL_WRITER (P0) to DONE.
- Append "Blocker 2 / Q2-extension" section listing the 35 deferred ids in tier groupings, with cost/recipe for re-enabling.

Out of scope
------------

- The 35 deferred exchanges — Q2-extension, future PR.
- `main.py:342-344` outer try/except — left defensive. Wrapper's error branch is primary failure surface now; outer is a safety net.
- `psi_discoveries` (other P0) — separate refactor.
- Dispatcher heartbeat at `worker.py:2787` still attests `data_layer:exchange_snapshots` — comes out in Phase 2.3 collapse.

## Substrate verification

### Pre-deploy

Baseline at 2026-05-12 09:44 UTC (post-#197 deploy):

```
total_rows:                   2099
distinct_ex:                    15      ← worker._EX (matches new module list)
usd_vol_populated_pre:           0      ← worker never wrote this column
incentive_populated_pre:         0      ← ditto
stbpairs_populated_pre:          0      ← ditto
raw_populated_pre:               0      ← ditto
latest_pre:        2026-05-12 08:53:15 UTC
attest_latest_pre: 2026-05-12 08:53:16 UTC (data_layer:exchange_snapshots)
attest_total_pre:               21
```

### Post-deploy halt criteria (operator runs ~2h post-deploy)

```sql
-- (1) attestation domain advances
SELECT MAX(cycle_timestamp) AS last_attest,
       NOW() - MAX(cycle_timestamp) AS staleness,
       COUNT(*) FILTER (WHERE cycle_timestamp > '<deploy_time>') AS attests_post
FROM state_attestations
WHERE domain = 'data_layer:exchange_snapshots';
-- Expect: attests_post >= 1 (mix of skipped_fresh + ran, similar to #193)

-- (2) row count advances past baseline
SELECT COUNT(*) AS total,
       COUNT(DISTINCT exchange_id) AS distinct_ex,
       COUNT(*) FILTER (WHERE snapshot_at > '<deploy_time>') AS rows_new
FROM exchange_snapshots;
-- Expect: rows_new > 0; distinct_ex still = 15 (sanity check on list)

-- (3) usd_vol population — module writes this; worker.py inline didn't.
SELECT COUNT(*) FILTER (
   WHERE trade_volume_24h_usd IS NOT NULL AND snapshot_at > '<deploy_time>'
) AS usd_vol_post
FROM exchange_snapshots;
-- Expect: > 0. Strong signal module is the live writer.

-- (4) /api/data/exchanges list endpoint
-- curl https://basisprotocol.xyz/api/data/exchanges
-- Expect: 200, non-empty result set.

-- (5) cycle_errors visibility
SELECT COUNT(*) FROM cycle_errors
WHERE occurred_at > '<deploy_time>'
  AND (cycle_phase ILIKE '%exchange%' OR error_message ILIKE '%exchange_snapshots%');
-- Now THE signal, not background noise.
```

Revert paths (lesson 11 — rate-based, not zero-based)
-----------------------------------------------------

- `rows_new=0` AND no 4xx/5xx from CG → wrapper not on live path (lesson 6). Revert.
- `rows_new > 0` BUT `distinct_ex != 15` → wrong list. Revert.
- `rows_new > 0` BUT `usd_vol_post=0` → module INSERT still failing on a column. **Halt + diagnose**, don't revert immediately (may signal a fifth missing column from 058 drift).
- 4 CG-legacy ids still 404ing → `_EX_FIX` port broken. Revert.
- `/api/data/exchanges` 500s → #197 regression. Immediate revert.

References
----------

- #195 (investigation findings)
- #197 (migration 109 — Q1 answer)
- #193 (peg_monitor scheduled wrapper — pattern reference)
- #179 (dex_pool_ohlcv pilot — original v9.12 pattern)
- `docs/basis_protocol_v9_12_constitution_amendment.md`

https://claude.ai/code/session_01T9JSBB6E4rxjLUssCLk5X3

---
_Generated by [Claude Code](https://claude.ai/code/session_01T9JSBB6E4rxjLUssCLk5X3)_