### PR TITLE
refactor(v9.12): web_research module-canonical attestation (#198 pattern)

### DIFF
--- a/app/collectors/web_research.py
+++ b/app/collectors/web_research.py
@@ -576,3 +576,87 @@ async def run_web_research_collection() -> list[dict]:
             pass
 
     return results
+
+
+# =============================================================================
+# Module-canonical scheduled entry per v9.12 (#179 / #193 / #198 pattern)
+# =============================================================================
+
+_WEB_RESEARCH_FRESHNESS_HOURS = 24
+
+
+async def run_web_research_scheduled() -> dict:
+    """Module-canonical scheduler entry per v9.12.
+
+    Replaces the inline gate-plus-attest block previously at
+    worker.py:1816-1863. The scheduler (worker.py) calls this on its
+    cadence; the module decides whether to fire actual work and attests
+    its decision in either branch.
+
+    Returns a status dict regardless of branch:
+      - {"status": "skipped_fresh", "gate_age_hours": X}
+      - {"status": "ran", ...run_web_research_collection() result summary}
+      - {"status": "error", "error": str}
+
+    The state_attestations row for `web_research` fires inside this
+    function (skipped_fresh / error branches) or inside
+    run_web_research_collection() (ran branch, existing attest at the
+    bottom of that function). Schedulers MUST NOT re-attest.
+
+    The 24h gate reads MAX(computed_at) across ALL web_research_*
+    index_ids (see #156 / Wave-5b notes in punchlist); the gate
+    semantics are preserved exactly from the prior worker.py inline.
+    """
+    from app.database import fetch_one_async
+    from app.state_attestation import attest_state
+
+    gate_age_hours: float = float(_WEB_RESEARCH_FRESHNESS_HOURS) + 1
+    try:
+        latest = await fetch_one_async(
+            "SELECT MAX(computed_at) AS latest FROM generic_index_scores "
+            "WHERE index_id LIKE 'web_research_%'"
+        )
+        if latest and latest.get("latest"):
+            _t = latest["latest"]
+            if hasattr(_t, "tzinfo") and _t.tzinfo is None:
+                _t = _t.replace(tzinfo=timezone.utc)
+            if hasattr(_t, "timestamp"):
+                gate_age_hours = (
+                    datetime.now(timezone.utc) - _t
+                ).total_seconds() / 3600
+    except Exception as e:
+        logger.warning(f"[web_research] freshness check failed: {e}")
+        gate_age_hours = float(_WEB_RESEARCH_FRESHNESS_HOURS) + 1
+
+    if gate_age_hours < _WEB_RESEARCH_FRESHNESS_HOURS:
+        skipped_payload = {
+            "status": "skipped_fresh",
+            "gate_age_hours": round(gate_age_hours, 2),
+        }
+        try:
+            await asyncio.to_thread(attest_state, "web_research", [skipped_payload])
+        except Exception as e:
+            logger.warning(f"[web_research] skipped-fresh attest failed: {e}")
+        return skipped_payload
+
+    try:
+        results = await run_web_research_collection()
+        scored = sum(1 for r in results if "score" in r)
+        return {
+            "status": "ran",
+            "gate_age_hours": round(gate_age_hours, 2),
+            "scored": scored,
+            "results_count": len(results),
+        }
+    except Exception as e:
+        logger.warning(f"[web_research] scheduled run failed: {e}")
+        error_payload = {
+            "status": "error",
+            "gate_age_hours": round(gate_age_hours, 2),
+            "error": str(e)[:200],
+        }
+        try:
+            await asyncio.to_thread(attest_state, "web_research", [error_payload])
+        except Exception:
+            pass
+        return {"status": "error", "error": str(e)[:500]}

--- a/app/enrichment_worker.py
+++ b/app/enrichment_worker.py
@@ -517,19 +517,22 @@ async def run_enrichment_pipeline() -> dict:
         timeout_seconds=600, group="data_collection", priority=3,
     ))
 
-    # ---- Web research ----
+    # ---- Web research (v9.12 module-canonical) ----
+    # The scheduled wrapper `run_web_research_scheduled` owns the 24h
+    # freshness gate (MAX(computed_at) across web_research_* index_ids)
+    # inside the module. Worker.py invokes it every slow cycle. The
+    # enrichment task here also routes through the wrapper — the
+    # external _db_gate is removed because the wrapper's internal gate
+    # is authoritative; an external gate would suppress the wrapper's
+    # skipped_fresh attest entirely.
 
     async def _run_web_research():
-        from app.collectors.web_research import run_web_research_collection
-        return await run_web_research_collection()
+        from app.collectors.web_research import run_web_research_scheduled
+        return await run_web_research_scheduled()
 
     pipeline.add(EnrichmentTask(
         name="web_research", func=_run_web_research,
         timeout_seconds=600, group="data_collection", priority=4,
-        gate_check=_db_gate(
-            "SELECT MAX(computed_at) AS latest FROM generic_index_scores WHERE index_id LIKE 'web_research_%'",
-            min_hours=24,
-        ),
     ))
 
     # ---- Governance events ----

--- a/app/worker.py
+++ b/app/worker.py
@@ -1814,53 +1814,18 @@ async def run_slow_cycle():
         logger.warning(f"DEX pool data collection failed: {e}")
 
     # -------------------------------------------------------------------------
-    # Web research collection — daily gate (expensive Parallel API calls)
+    # Web research collection — module-canonical per v9.12.
+    # The 24h freshness gate, work, and attestation all live inside
+    # app/collectors/web_research.py::run_web_research_scheduled().
+    # Worker.py is the scheduler; the module is the only writer.
+    # Dispatcher heartbeat at worker.py:2644 left in place until Phase 2.3.
     # -------------------------------------------------------------------------
-    _wr_status = "skipped_unknown"
-    _wr_scored = 0
     try:
-        last_research = await fetch_one_async(
-            "SELECT MAX(computed_at) AS latest FROM generic_index_scores WHERE index_id LIKE 'web_research_%'"
-        )
-        research_age_hours = 25
-        if last_research and last_research.get("latest"):
-            latest = last_research["latest"]
-            if latest.tzinfo is None:
-                latest = latest.replace(tzinfo=timezone.utc)
-            research_age_hours = (datetime.now(timezone.utc) - latest).total_seconds() / 3600
-
-        if research_age_hours >= 24:
-            from app.collectors.web_research import run_web_research_collection
-            logger.info("Running web research collection...")
-            research_results = await run_web_research_collection()
-            _wr_scored = sum(1 for r in research_results if "score" in r)
-            _wr_status = "ran"
-            logger.info(f"Web research complete: {_wr_scored} components collected")
-        else:
-            _wr_status = "skipped_fresh"
-            logger.info(f"Web research skipped — last ran {research_age_hours:.1f}h ago")
+        from app.collectors.web_research import run_web_research_scheduled
+        _wr_outcome = await run_web_research_scheduled()
+        logger.info(f"Web research: {_wr_outcome}")
     except Exception as e:
-        _wr_status = "error"
-        logger.warning(f"Web research collection failed: {e}")
-
-    # Attest web_research from the worker side regardless of whether the
-    # 24h gate opened. The gate reads MAX(computed_at) across ALL
-    # web_research_* index_ids; if any single id (e.g. web_research_bridge)
-    # is fresher than 24h, the entire collector is skipped — even though
-    # web_research_protocol and web_research_exchange may be days stale.
-    # PR #143's attest inside run_web_research_collection() never fires
-    # when the gate skips. Heartbeat from the worker side decouples
-    # freshness from the gate.
-    try:
-        from app.state_attestation import attest_state
-        await asyncio.to_thread(attest_state, "web_research", [{
-            "status": _wr_status,
-            "gate_age_hours": round(research_age_hours, 2)
-                if isinstance(research_age_hours, (int, float)) else None,
-            "scored": _wr_scored,
-        }])
-    except Exception as _e_attest:
-        logger.warning(f"web_research worker attest failed: {_e_attest}")
+        logger.warning(f"Web research scheduler call failed: {e}")
 
     # -------------------------------------------------------------------------
     # Daily-gated: governance event collection (Snapshot/Tally)


### PR DESCRIPTION
## Summary

- Hoists `worker.py:1816-1863`'s 24h-gate + inline `state_attestations` write into a new module-canonical scheduled wrapper `run_web_research_scheduled()` in `app/collectors/web_research.py`. Wrapper owns the freshness gate (`MAX(computed_at)` across `web_research_*` index_ids, `min_hours=24` — semantics preserved verbatim) and emits attestations on three terminal branches: `skipped_fresh`, `ran`, `error`. The `ran` branch defers to the existing in-module attest at `web_research.py:563`. Schedulers no longer re-attest.
- `worker.py` is now scheduler-only (awaits wrapper, logs status). `enrichment_worker.py`'s `web_research` task is also re-routed through the wrapper; its external `_db_gate` is removed because the wrapper's internal gate is authoritative — an external gate would suppress the wrapper's `skipped_fresh` attest entirely (matches #198's enrichment-task posture).
- Wrapper shape mirrors **#198** (exchange_snapshots), **#193** (peg_monitor), **#179** (dex_pool_ohlcv pilot). Only material difference: web_research uses `attest_state` (top-level domain) rather than `attest_data_batch` (data_layer: prefix). Dispatcher heartbeat at `worker.py:2609` (the `wallets/web_research/psi_discoveries/rpi_components` for-loop) is **untouched** — Phase 2.3, separate.

## File:line refs

| Site | Before | After |
|---|---|---|
| inline gate + attest | `app/worker.py:1816-1863` (~48 lines) | removed |
| scheduler invocation | (mixed with inline above) | `app/worker.py:1816-1828` (~13 lines, scheduler-only) |
| new wrapper home | n/a | `app/collectors/web_research.py:580-664` |
| existing in-module attest | `app/collectors/web_research.py:547-576` | unchanged (called from `ran` branch) |
| enrichment task | `app/enrichment_worker.py:520-533` (gate + direct call) | `app/enrichment_worker.py:520-535` (routes through wrapper, no external gate) |
| dispatcher heartbeat | `app/worker.py:2609` | **untouched** (Phase 2.3) |

Diff: 103 inserts / 51 deletes / 3 files.

## Substrate verification

### Pre-deploy

```sql
SELECT domain, COUNT(*), MAX(cycle_timestamp), MIN(cycle_timestamp)
FROM state_attestations
WHERE domain = 'web_research'
GROUP BY 1;
```

Result (2026-05-12 ~10:21Z):

```
[
  {
    "domain": "web_research",
    "count": "12",
    "max": "2026-05-12T07:29:22.181Z",
    "min": "2026-04-13T01:05:30.021Z"
  }
]
```

Recent 24h window:

```
{rows_24h: 7, rows_1h: 0, latest: 2026-05-12T07:29:22.181Z, minutes_since_latest: 172.0}
```

Row shape bimodal — same `web_research` domain key carries two payload shapes that this refactor preserves:

- `record_count=1` rows (last 7, since 2026-05-11 17:39Z): the worker.py inline heartbeat — `[{status, gate_age_hours, scored}]`. Post-refactor: emitted by the wrapper's `skipped_fresh` / `error` branches.
- `record_count=50` / `51` rows (5 rows, 2026-04-13 → 2026-05-03): the module's own attest when the 24h gate opened — per-component scored rows. Post-refactor: emitted unchanged by the existing `web_research.py:563` attest on the `ran` branch.

### Expected post-deploy

```sql
SELECT domain, COUNT(*), MAX(cycle_timestamp),
  EXTRACT(EPOCH FROM (NOW() - MAX(cycle_timestamp)))/60.0 AS minutes_since_latest
FROM state_attestations
WHERE domain = 'web_research'
GROUP BY 1;
```

Expected after the next slow cycle elapses (~hourly cadence):

- `COUNT(*)` increments by ≥1 per slow cycle (skipped_fresh or ran).
- `minutes_since_latest` < 75 (slow cycle is ~hourly; allow margin).
- No new domain keys appear (no `web_research:*` variants — wrapper attests the same flat `web_research` key).
- When the 24h gate eventually opens (≥24h since latest `generic_index_scores.computed_at` for any `web_research_*`), the next row should have `record_count` in the 50-ish range, matching pre-refactor `ran` cycles.

No regression in row cadence is expected vs. the pre-refactor heartbeat (worker.py:1856), which fired every slow cycle.

## References

- PR #198 — wrapper-shape precedent (exchange_snapshots; same `skipped_fresh / ran / error` shape)
- PR #193 — enrichment_worker re-routing precedent (peg_monitor; remove external gate, let wrapper own)
- PR #179 — pilot (dex_pool_ohlcv)
- `docs/audits/2026-05-11-module-canonical-migration-plan.md` row 6 — this is the P1 `web_research` entry

## Test plan

- [ ] Confirm `git diff main...HEAD --stat` shows 3 files / ~150 lines.
- [ ] AST-parse all three edited files (done locally, passes).
- [ ] After deploy + 1 slow cycle elapse: run pre-deploy query, confirm `COUNT(*) >= 13` and `minutes_since_latest < 75`.
- [ ] After 24h: confirm at least one new row with `record_count >= 50` (gate-opened `ran` cycle) — proves the module's in-module attest still fires unchanged.
- [ ] Confirm `worker.py:2609` heartbeat loop still names `web_research` (greppable post-merge).

https://claude.ai/code/session_017QJC4gmqRh6kdkNk3onqkB

---
_Generated by [Claude Code](https://claude.ai/code/session_017QJC4gmqRh6kdkNk3onqkB)_