### PR TITLE
fix(main): surface silent errors at 342-344 (#195 followup)

### DIFF
--- a/main.py
+++ b/main.py
@@ -339,9 +339,35 @@ def run_worker_loop():
                     r = await coro_fn()
                     results[name] = r
                     logger.error(f"=== {name} COMPLETE: {r} ===")
+                except asyncio.CancelledError:
+                    raise
                 except Exception as e:
-                    logger.error(f"=== {name} FAILED: {type(e).__name__}: {e} ===")
+                    # #195 followup: surface failures into cycle_errors +
+                    # state_attestations. Inner wrappers attest only the
+                    # paths they cover (provenance, lookups); a top-level
+                    # raise from coro_fn (e.g. schema-drift INSERT, import
+                    # failure) used to be log-only here, never landing in
+                    # cycle_errors. The catch stays broad-but-loud so the
+                    # other every-cycle collectors in this loop still run.
+                    logger.exception(f"=== {name} FAILED: {type(e).__name__}: {e} ===")
                     results[name] = {"error": str(e)}
+                    try:
+                        from app.worker import _record_cycle_error
+                        _record_cycle_error(
+                            error_type=f"data_layer_{name}_every_cycle_failure",
+                            error_message=f"{type(e).__name__}: {e}"[:500],
+                            cycle_phase=f"data_layer:{name}",
+                        )
+                    except Exception:  # silenced-by-design: cycle_errors insert must not abort the loop
+                        pass
+                    try:
+                        from app.state_attestation import attest_state
+                        attest_state(
+                            f"data_layer:{name}",
+                            [{"status": "error", "error_type": type(e).__name__, "error": str(e)[:200]}],
+                        )
+                    except Exception:  # silenced-by-design: attest must not abort the loop
+                        pass
 
             # --- Daily-gated collectors ---
             from app.database import fetch_one as _dl_fetch


### PR DESCRIPTION
## Summary

#195 flagged `main.py:342-344` as the silent-swallow path that let
`exchange_collector.py`'s 4-column schema-drift INSERT fail for 14 days
with no entry in `cycle_errors`. This PR makes the catch loud — keeping
the broad `except Exception` (the loop intentionally tolerates one
collector failing so the other two still run) but adding
`_record_cycle_error` + `attest_state(domain, [{status: "error", ...}])`
and re-raising `asyncio.CancelledError`.

Decision: **Case B** — distinct failure surface exists (top-level raises
that bypass each wrapper's nested try/excepts), so the outer block is
not dead-weight. Narrowed observability, not exception class.

Split out from PR #199 (which also carried an unrelated investigation
doc — now PR #204).

References #195

## Substrate verification

### Pre-deploy

#### 1. Issue #195 names this exact line as the swallow path

From the issue body (https://github.com/basis-protocol/basis-hub/pull/195):

> Failures don't surface in `cycle_errors` because `main.py:335` wraps
> in try/except without `_record_cycle_error`, and
> `app/enrichment_worker.py:880`'s gate (`min_hours=1`) is always closed
> by `app/worker.py:1186-1222` inline keeping the table fresh hourly.

(The issue cites :335 — the line of the `exchange_snapshots` lambda;
the actual swallow is the surrounding try/except at :342-344.)

#### 2. Each inner wrapper attests only a partial surface

`app/data_layer/exchange_collector.py:314-380` — `run_exchange_collection_scheduled`
catches its own `run_exchange_collection()` raise and attests
`state_attestations` with an error payload, but does NOT call
`_record_cycle_error`:

```python
# app/data_layer/exchange_collector.py:367-380
    except Exception as e:
        logger.warning(f"[exchange_collector] scheduled run failed: {e}")
        error_payload = {
            "status": "error",
            "table_age_minutes": round(table_age_minutes, 2),
            "error": str(e)[:200],
        }
        try:
            await asyncio.to_thread(
                attest_data_batch, "exchange_snapshots", [error_payload]
            )
        except Exception:
            pass
        return {"status": "error", "error": str(e)[:500]}
```

`app/data_layer/liquidity_collector.py:319-409` — `run_liquidity_collection`
has **no top-level try/except**. It catches per-asset CEX/DEX fetch
errors (lines 352, 372) and provenance errors (lines 385-395), but a
raise from `_store_liquidity_records` or anywhere outside those
nested blocks propagates up to main.py. The provenance branch is the
only one that records to `cycle_errors`:

```python
# app/data_layer/liquidity_collector.py:385-395
    except Exception as e:
        logger.warning(f"Liquidity provenance failed: {e}")
        try:
            from app.worker import _record_cycle_error
            _record_cycle_error(
                error_type="data_layer_run_liquidity_collection_provenance_failure",
                error_message=str(e)[:500],
                cycle_phase="liquidity_collector",
            )
        except Exception:
            pass
```

`app/data_layer/entity_snapshots.py:150-348` — `run_entity_snapshots`
likewise has no top-level try/except. It records `_record_cycle_error`
for *psi_lookup_failure*, *circle7_mapping_failure*, and
*provenance_failure* (lines 203-213, 246-256, 330-340), but a raise
from `_store_snapshots` (line 317), `_fetch_coin_data` outside the
per-entity catch, or any pre-loop code lands in main.py's outer block
with no recorder call.

#### 3. The audit-silent-failures CI flags this exact line

```text
$ python3 scripts/audit_silent_failures.py 2>&1 | grep "main.py:342"
/home/user/basis-hub/main.py:342: [SILENT-EXCEPT] broad except missing
  attest_state/attest_data_batch (or `# rethrown` / `# expected` /
  `# silenced-by-design` marker)
```

After this PR, the audit no longer flags `main.py:342`.

### Post-deploy halt criteria

On the next worker cycle after deploy, confirm any data-layer
collector raise lands in `cycle_errors` with `cycle_phase = data_layer:`
and in `state_attestations` under domain `data_layer:`:

```sql
-- (1) cycle_errors rows for data_layer phases since deploy
SELECT cycle_phase, error_type, COUNT(*) AS n,
       MAX(occurred_at) AS last_seen
FROM cycle_errors
WHERE cycle_phase LIKE 'data_layer:%'
  AND occurred_at > ''  -- deploy timestamp
GROUP BY cycle_phase, error_type
ORDER BY n DESC;
-- Expect: zero rows if all three collectors succeed (steady state);
-- otherwise rows with error_type = data_layer_{name}_every_cycle_failure
-- and cycle_phase = data_layer:{liquidity_depth|exchange_snapshots|entity_snapshots}.

-- (2) state_attestations rows for the three data_layer domains since deploy
SELECT domain, COUNT(*) AS n,
       MIN(cycle_timestamp) AS first_seen,
       MAX(cycle_timestamp) AS last_seen
FROM state_attestations
WHERE domain IN ('data_layer:liquidity_depth',
                 'data_layer:exchange_snapshots',
                 'data_layer:entity_snapshots')
  AND cycle_timestamp > ''  -- deploy timestamp
GROUP BY domain;
-- Expect: an "error"-payload row for any collector that raised; absence
-- of rows means no failure path fired (success case).

-- (3) cross-check: audit-silent-failures CI no longer flags main.py:342
-- $ python3 scripts/audit_silent_failures.py | grep "main.py:342"
-- Expect: no output (the line now carries both _record_cycle_error and
-- attest_state inside the catch block).
```

Halt criteria:
- A collector raises but neither table records it → revert (the recorder
  / attester import path is broken in production).
- `cycle_errors` row appears but no matching `state_attestations` row
  for the same `data_layer:{name}` domain → diagnose (the attester
  branch's silenced-by-design `except` is hiding a real failure).
- `state_attestations` row appears but no matching `cycle_errors` row
  → diagnose (`_record_cycle_error` import-time failure).

## What changed and why

```python
# main.py:338-370 (after)
                try:
                    r = await coro_fn()
                    results[name] = r
                    logger.error(f"=== {name} COMPLETE: {r} ===")
                except asyncio.CancelledError:
                    raise
                except Exception as e:
                    # #195 followup: surface failures into cycle_errors +
                    # state_attestations. Inner wrappers attest only the
                    # paths they cover (provenance, lookups); a top-level
                    # raise from coro_fn (e.g. schema-drift INSERT, import
                    # failure) used to be log-only here, never landing in
                    # cycle_errors. The catch stays broad-but-loud so the
                    # other every-cycle collectors in this loop still run.
                    logger.exception(f"=== {name} FAILED: {type(e).__name__}: {e} ===")
                    results[name] = {"error": str(e)}
                    try:
                        from app.worker import _record_cycle_error
                        _record_cycle_error(
                            error_type=f"data_layer_{name}_every_cycle_failure",
                            error_message=f"{type(e).__name__}: {e}"[:500],
                            cycle_phase=f"data_layer:{name}",
                        )
                    except Exception:  # silenced-by-design: cycle_errors insert must not abort the loop
                        pass
                    try:
                        from app.state_attestation import attest_state
                        attest_state(
                            f"data_layer:{name}",
                            [{"status": "error", "error_type": type(e).__name__, "error": str(e)[:200]}],
                        )
                    except Exception:  # silenced-by-design: attest must not abort the loop
                        pass
```

Three behavior changes:
1. `asyncio.CancelledError` is re-raised (shutdown semantics preserved).
2. `logger.error` → `logger.exception` (full traceback in stdout, not
   just `type(e).__name__: e`).
3. Adds `_record_cycle_error` with `cycle_phase=data_layer:{name}` and
   `attest_state(data_layer:{name}, [{status: "error", ...}])`. The next
   coherence sweep / freshness check now sees the failure within one
   cycle rather than waiting for staleness to accumulate.

Inner safety nets around the recorder and attester are marked
`silenced-by-design` per the audit script convention — they must not
abort the cycle loop itself.

The catch remains broad-but-loud because the three coroutines have
heterogeneous failure modes (httpx, asyncpg, schema drift, import
errors from the `__import__(...)` lambdas) and the loop must keep
running the other collectors. Narrowing to a single class would either
miss real failures or fragment the catch into N near-duplicate blocks.

## CI requirement

- [x] `audit-silent-failures` passes on the modified lines (verified
      against `scripts/audit_silent_failures.py` on the prior PR #199)
- [ ] Lands without affecting `audit-async` or `audit-sync-db-advisory`


---
_Generated by [Claude Code](https://claude.ai/code/session_017QJC4gmqRh6kdkNk3onqkB)_