### PR TITLE
refactor(v9.12): P2 main.py-legacy — wallet_profiles single mechanical hoist

### DIFF
--- a/docs/audits/2026-05-12-actors-design-questions.md
+++ b/docs/audits/2026-05-12-actors-design-questions.md
@@ -1,0 +1,127 @@
+# `actors` — design questions (2026-05-12)
+
+Holdout from the v9.12 P2 main.py-legacy bundle. The standard hoist
+fails because **two different writers stamp the same domain key
+`actors` with semantically different payloads**.
+
+See `docs/audits/2026-05-12-p2-main-py-legacy-investigation.md` for
+the bundle-scope investigation.
+
+## Substrate
+
+```sql
+SELECT COUNT(*), MAX(cycle_timestamp) FROM state_attestations WHERE domain = 'actors';
+-- 114 rows, last 2026-05-12T10:19:17.679Z
+```
+
+Healthy cadence — but the 114 rows are a **mixed signal** from two
+different writers tracking two different underlying tables.
+
+## The multi-writer triangle
+
+Five entry points touch the `actors` domain across the codebase:
+
+| Caller | Function | Attests `actors`? | Payload shape |
+|---|---|---|---|
+| `main.py:307-321` | `run_agent_cycle()` -> attest | YES, caller-side | `{"assessments": N, "severities": {silent/notable/alert/critical: M}}` |
+| `app/worker.py:1446-1447` | `run_agent_cycle()` (no attest) | NO | — |
+| `app/worker.py:2299-2300` | `classify_all_active()` | YES, inside module | `{"classified": N, "reclassified": M, "by_type": {...}}` |
+| `app/worker.py:2703-2707` | `classify_all_active()` | YES, inside module | same |
+| `app/enrichment_worker.py:603-605` | `classify_all_active(limit=300)` | YES, inside module | same |
+
+`run_agent_cycle()` (`app/agent/watcher.py`) writes the
+`assessment_events` table (severity classification, broadcast
+decisions, daily-cycle assessment). It is **not** about actor type.
+
+`classify_all_active()` (`app/actor_classification.py`) writes
+`wallet_graph.actor_classifications` with `actor_type` (autonomous_agent,
+human, contract_vault). It is **the canonical "actors" writer**.
+
+Both share domain key `actors` in `state_attestations`. Consumers
+treat that key as a single freshness signal.
+
+## Where consumers expect what
+
+`app/coherence.py:34,73` lists `actors` with 24h cadence in
+`ALL_DOMAINS` / `DOMAIN_FREQUENCIES`. The check is freshness-only
+(`MAX(cycle_timestamp)`); it doesn't care which writer produced the
+row.
+
+`app/pulse_generator.py:250` lists `actors` in the daily-pulse state
+root domain list.
+
+`app/integrity.py:420` — `freshness_query` for actor classification
+runs on `wallet_graph.actor_classifications.classified_at`, not on
+`state_attestations`. So the integrity check side-steps the
+multi-writer entirely; the consumer that does suffer is coherence.
+
+## Why hoisting doesn't help
+
+A clean `main.py:317` deletion would remove the `assessments` shape
+from the domain. Coherence would then see only the `classify_all_active`
+attests, which is what it actually wants. But:
+
+1. There's no canonical wrapper home for `run_agent_cycle` that
+   matches the #198 shape (the agent watcher is event-triggered, not
+   freshness-gated).
+2. The `assessments` data is still meaningful as a freshness signal
+   for **assessment_events**, just not under domain `actors`.
+
+## Design questions
+
+**Q1.** Should `run_agent_cycle()` attest a **separate domain**
+(`assessments` or `assessment_events`)? Migration impact: would need
+to add the new domain to `coherence.ALL_DOMAINS` + `pulse_generator`
+domain list + any report consumers. Maybe 5-10 lines.
+
+**Q2.** Or should `main.py:317` simply delete — since
+`worker.py:1446-1447` already calls `run_agent_cycle` (no attest) AND
+the consumers' real signal for "actors are being classified" already
+comes from the `classify_all_active` writers? The cost: agent-cycle
+freshness becomes invisible.
+
+**Q3.** Is there value in **collapsing** the four `classify_all_active`
+call sites (worker.py:2299, worker.py:2703, enrichment_worker.py:603,
+plus implicit from agent) down to a single scheduled entry? They're
+called from different cadences (every cycle vs slow cycle vs
+enrichment task vs background) — but all do the same work and all
+attest the same way.
+
+**Q4.** What's the relationship between agent-cycle assessments
+(`assessment_events`) and actor classifications
+(`wallet_graph.actor_classifications`)? Should they share a domain
+key intentionally (as a unified "behavioral signals" surface) or
+intentionally split?
+
+## Recommendation
+
+Q1 is the cleanest fix: introduce domain `assessments`, repoint
+`main.py:317` (or the wrapper that replaces it) to write to that
+domain instead of `actors`. Then `actors` becomes the
+classification-only signal it was meant to be.
+
+The Q3 collapse (consolidating four `classify_all_active` callers) is
+a separate cleanup — worth surfacing as its own draft issue, not
+gating this one.
+
+## Halt condition for the eventual refactor PR
+
+After deploy, the post-substrate should show:
+- `domain = 'actors'` rows from `classify_all_active` only (payload
+  has `classified` / `by_type` keys, never `assessments` / `severities`).
+- New `domain = 'assessments'` rows from agent cycles, with
+  `assessments` / `severities` payload.
+
+If `actors` is still receiving `severities` payloads, the agent-cycle
+caller wasn't updated. If `assessments` rows don't appear, the new
+domain isn't on the live path.
+
+## References
+
+- `app/agent/watcher.py::run_agent_cycle` (assessment writer)
+- `app/actor_classification.py:387-401` (classification writer)
+- `app/worker.py:1446-1447,2299-2300,2703-2707` (worker callers)
+- `app/enrichment_worker.py:603-605` (enrichment caller)
+- `app/coherence.py:34,73` (consumer — freshness only)
+- `app/pulse_generator.py:250` (consumer — state-root list)
+- `docs/audits/2026-05-12-p2-main-py-legacy-investigation.md` (parent)

--- a/docs/audits/2026-05-12-cda-extractions-design-questions.md
+++ b/docs/audits/2026-05-12-cda-extractions-design-questions.md
@@ -1,0 +1,134 @@
+# `cda_extractions` — design questions (2026-05-12)
+
+Holdout from the v9.12 P2 main.py-legacy bundle. The standard hoist
+(delete `main.py:167`, route through module-canonical wrapper) does
+**not** fix the substrate problem this audit surfaces.
+
+See `docs/audits/2026-05-12-p2-main-py-legacy-investigation.md` for
+the bundle-scope investigation.
+
+## Substrate
+
+```sql
+SELECT COUNT(*) FROM state_attestations WHERE domain = 'cda_extractions';
+-- 0
+```
+
+Paired underlying table:
+
+```sql
+SELECT COUNT(*) AS total,
+       COUNT(*) FILTER (WHERE extracted_at > NOW() - INTERVAL '7 days') AS in_7d,
+       MAX(extracted_at) AS last
+FROM cda_vendor_extractions;
+-- total=267, in_7d=82, last=2026-05-11T17:07:17.405Z
+```
+
+So extractions are landing in the underlying table (82 in 7d), but
+**not a single `state_attestations` row has ever been written for
+domain `cda_extractions`**.
+
+## The dual-writer pair (both broken in the same way)
+
+`main.py:161-169`:
+
+```python
+from app.state_attestation import attest_state
+from app.database import fetch_all as _fa
+cda_rows = _fa("SELECT asset_symbol, field_name, extracted_value, source_url "
+               "FROM cda_vendor_extractions "
+               "WHERE extracted_at > NOW() - INTERVAL '2 hours'")
+if cda_rows:
+    attest_state("cda_extractions", [dict(r) for r in cda_rows])
+```
+
+`app/services/cda_collector.py:1289-1296`:
+
+```python
+from app.state_attestation import attest_state
+recent = await asyncio.to_thread(fetch_all,
+    "SELECT asset_symbol, field_name, extracted_value, source_url "
+    "FROM cda_vendor_extractions "
+    "WHERE extracted_at > NOW() - INTERVAL '2 hours'"
+)
+if recent:
+    await asyncio.to_thread(attest_state, "cda_extractions",
+                             [dict(r) for r in recent])
+```
+
+Identical SELECT, identical 2-hour window, identical attest pattern.
+
+## Why both writers miss
+
+`run_collection()` walks the entire issuer registry sequentially with
+inter-issuer sleeps (`cda_collector.py:1281-1282` — `await asyncio.sleep(2)`)
+plus per-step delays. On prod with the current registry size (≈ a dozen
+active issuers) the full cycle exceeds 2 hours wall-clock when even one
+issuer hits the Reducto PDF parsing path or the Parallel Task deep
+research path.
+
+By the time the closing SELECT fires, the earliest extractions inserted
+in this cycle have already aged past the 2h window. Both ends of the
+DUAL_WRITER see `recent = []`, both no-op, and `attest_state(domain,
+[])` short-circuits to `return ""` (`app/state_attestation.py:63-64`).
+The cycle finishes; nothing lands in `state_attestations`.
+
+## Why hoisting doesn't help
+
+A standard #179/#193/#198-shape hoist would:
+- Delete `main.py:161-169`
+- Wrap `cda_collector.run_collection` in a `run_collection_scheduled()`
+  that adds freshness gate + `skipped_fresh / ran / error` attest
+
+The problem: the **inside** of `run_collection` is broken too. The
+existing `cda_collector.py:1289-1309` attest block has the same window
+bug. Hoisting moves where the bug lives but doesn't fix it.
+
+## Design questions
+
+**Q1.** Should `run_collection` attest **all extractions inserted in
+this run**, regardless of wall-clock window? Implementation: collect
+inserted IDs into a list during the per-issuer loop, then run
+`SELECT ... WHERE id = ANY(%s)` at the end. Pro: deterministic. Con:
+buffers in memory.
+
+**Q2.** Or should `run_collection` attest a **summary payload** (count
+of extractions + cycle outcome + per-issuer success counts) regardless
+of any SELECT? Matches #198 `skipped_fresh / ran / error` shape. Pro:
+no window race. Con: loses per-extraction hash detail.
+
+**Q3.** Or should the window expand to match expected cycle length
+(say `INTERVAL '6 hours'` to cover worst-case)? Pro: smallest diff.
+Con: still racy; coupled to cycle length tuning.
+
+**Q4.** Coherence cadence says 24h (`coherence.py:69`). If we attest
+per-cycle (~1/h) is that overweight signal? Or right (since each
+cycle's freshness is meaningful)?
+
+## Recommendation
+
+Q2 + Q3 combined: build the `run_collection_scheduled` wrapper that
+attests `skipped_fresh / ran / error` always (Q2), and inside `ran`
+also keep an aggregated extraction-count attest (no SELECT — count
+the inserts as they happen inside `_store_extraction`).
+
+Estimated diff: ~80-120 lines (wrapper + inserted-count threading).
+Substrate gate verification: post-deploy
+`SELECT COUNT(*) FROM state_attestations WHERE domain = 'cda_extractions'
+AND cycle_timestamp > NOW() - INTERVAL '2 hours'`
+should return > 0 within 2 hours of next CDA cycle.
+
+## Halt condition for the eventual refactor PR
+
+After deploy, if the substrate query above still returns 0 after 4
+hours, halt — `run_collection_scheduled` is not on the live path
+(lesson 6 family).
+
+## References
+
+- #198 (exchange_snapshots scheduled-wrapper shape — same pattern)
+- `app/coherence.py:30,69` (consumer)
+- `app/pulse_generator.py:212,226,249` (consumer)
+- `app/ops/entity_views.py:219` (consumer)
+- `app/state_attestation.py:63-64` (the empty-records short-circuit)
+- `docs/audits/2026-05-12-p2-main-py-legacy-investigation.md` (parent)

--- a/docs/audits/2026-05-12-edges-design-questions.md
+++ b/docs/audits/2026-05-12-edges-design-questions.md
@@ -1,0 +1,185 @@
+# `edges` — design questions (2026-05-12)
+
+Holdout from the v9.12 P2 main.py-legacy bundle. The standard hoist
+doesn't fix the substrate problem this audit surfaces.
+
+See `docs/audits/2026-05-12-p2-main-py-legacy-investigation.md` for
+the bundle-scope investigation.
+
+## Substrate
+
+```sql
+SELECT COUNT(*) FROM state_attestations WHERE domain = 'edges';
+-- 0
+```
+
+Paired underlying table:
+
+```sql
+SELECT COUNT(*) AS total,
+       COUNT(*) FILTER (WHERE updated_at > NOW() - INTERVAL '7 days') AS updated_7d,
+       MAX(updated_at) AS last_updated
+FROM wallet_graph.wallet_edges;
+-- total=1,011,156, updated_7d=348,852, last_updated=2026-05-12T09:23:25.863Z
+```
+
+1M+ edges total, 350K updated in the last 7 days — but **zero
+`state_attestations` rows for domain `edges` ever**.
+
+## The dual-writer pair (both broken in the same way)
+
+`main.py:476-486`:
+
+```python
+edge_result = asyncio.run(run_edge_builder(...))
+# Attest edges for this chain
+try:
+    from app.state_attestation import attest_state
+    if edge_result.get('total_edges_created', 0) > 0:
+        attest_state("edges", [{"chain": edge_chain,
+                                "wallets": ..., "edges": ...}])
+except Exception as ae:
+    logger.debug(f"Edge attestation skipped for {edge_chain}: {ae}")
+```
+
+`app/indexer/edges.py:447-464`:
+
+```python
+try:
+    from app.state_attestation import attest_state
+    if total_edges > 0:
+        await asyncio.to_thread(attest_state, "edges",
+            [{"chain": chain, "wallets": wallets_processed, "edges": total_edges}],
+            chain)
+except asyncio.CancelledError:
+    raise
+except Exception as ae:
+    logger.warning(f"Edge attestation skipped for {chain}: {ae}")
+    ...
+```
+
+Identical gate (`> 0`), identical domain key, identical payload shape.
+
+## Why both writers miss
+
+`total_edges` accumulates `result["edges_upserted"]` per wallet
+(`edges.py:419`). The "upserted" count includes both inserts and
+updates — there's no separate `inserted` counter. In steady state
+with 1M edges already present, almost every per-wallet upsert hits the
+`ON CONFLICT DO UPDATE` branch at `edges.py:291-298`.
+
+Specifically:
+
+```sql
+INSERT INTO wallet_graph.wallet_edges (...)
+VALUES (...)
+ON CONFLICT (from_address, to_address, chain, edge_type) DO UPDATE SET
+    transfer_count = wallet_graph.wallet_edges.transfer_count + EXCLUDED.transfer_count,
+    ...
+```
+
+Every conflict counts as `+1` on `edges_upserted` but the row already
+existed. So `total_edges_created` is misleading; nothing was actually
+*created*. The `> 0` gate therefore opens only when at least one wallet
+in the batch has a transfer to a counterparty never seen before in the
+edge graph — which is rare given coverage saturation.
+
+## Secondary issue: entity_id leak
+
+`edges.py:451` calls `attest_state("edges", [...], chain)` — the third
+positional arg is `entity_id` (`app/state_attestation.py:61`).
+
+When `entity_id` is set, the consumer query at `state_attestation.py:84`
+filters `WHERE domain = %s AND entity_id IS NULL` — meaning chain-scoped
+attests don't show up in the default `get_latest_attestation` lookup.
+This compounds the gate problem: even if the gate did open, the
+attest row would be stamped with `entity_id = 'ethereum'` (or `'base'`
+etc.) and consumers calling `get_latest_attestation('edges')` would
+miss it.
+
+`main.py:482` does NOT pass `chain` as `entity_id`, so the caller-side
+attest writes `entity_id = NULL` — but the caller-side gate is the
+same `> 0` so it never fires either.
+
+## Why hoisting doesn't help
+
+Removing `main.py:482` deletes one of two DUAL_WRITERs, but the
+remaining `edges.py:451` writer:
+1. Has the same `> 0` gate that doesn't open in steady state.
+2. Writes with `entity_id = chain`, which fails the consumer's
+   `entity_id IS NULL` lookup.
+
+Coherence sweep with 12h cadence (`coherence.py:72`) will continue to
+show `edges` as stale or missing.
+
+## Design questions
+
+**Q1.** Should `run_edge_builder` attest **always at end-of-run**,
+regardless of edges-created count? Payload like:
+
+```python
+{
+    "chain": chain,
+    "wallets_processed": N,
+    "edges_upserted": E,  # current "total_edges"
+    "transfers_processed": T,
+    "status": "ran" | "skipped_fresh" | "error",
+}
+```
+
+Matches #198 / #193 wrapper shape. Pro: substrate cadence becomes
+measurable. Con: floods `state_attestations` with no-op rows (~6
+chains x ~hourly).
+
+**Q2.** Or should the gate switch from `total_edges > 0` to
+`wallets_processed > 0`? That captures "we tried" rather than
+"something new emerged". Pro: smallest diff. Con: still misses
+the genuinely-skipped case.
+
+**Q3.** Should the `entity_id = chain` parameter at `edges.py:451`
+move into the payload instead, so the row stays `entity_id = NULL`
+and consumers can find it? Or should consumers be updated to also
+look up by `entity_id = chain`?
+
+**Q4.** The coherence cadence (12h) is tighter than the main.py gate
+(10h between `run_edge_builder` invocations). Should these be
+coupled? Currently they're independent.
+
+**Q5.** Should we add an actual `inserted` count by checking pg's
+`xact_commit_lsn` or by doing `INSERT ... RETURNING (xmax = 0)` to
+distinguish new vs updated edges? That would let the `> 0` gate
+have its original intended meaning.
+
+## Recommendation
+
+Q1 + Q3: build `run_edge_builder_scheduled(chain)` wrapper that
+attests always with status payload, AND fix the `entity_id` plumbing
+so consumers can find the rows. Q5 is nice-to-have but expensive;
+the always-attest pattern from Q1 makes Q5 optional.
+
+Estimated diff: ~50-80 lines (wrapper + entity_id refactor). Substrate
+gate verification: post-deploy, the consumer query
+
+```sql
+SELECT COUNT(*) FROM state_attestations
+WHERE domain = 'edges' AND cycle_timestamp > NOW() - INTERVAL '12 hours';
+```
+
+should return > 0 within 12 hours of next edge build cycle.
+
+## Halt condition for the eventual refactor PR
+
+If `edges` rows still don't appear within 24h of deploy, halt — the
+wrapper is not on the live path (lesson 6 family) or the `entity_id`
+shape is still mismatched.
+
+## References
+
+- `app/coherence.py:33,72` (consumer)
+- `app/report.py:327` (consumer — wallet-report state hashes)
+- `app/pulse_generator.py:250` (consumer — state-root list)
+- `app/integrity.py:409` (consumer — edges integrity check)
+- `app/state_attestation.py:61,84` (the `entity_id` plumbing)
+- `app/indexer/edges.py:291-298` (the ON CONFLICT path that masks
+  insert vs update)
+- `docs/audits/2026-05-12-p2-main-py-legacy-investigation.md` (parent)

--- a/docs/audits/2026-05-12-p2-main-py-legacy-investigation.md
+++ b/docs/audits/2026-05-12-p2-main-py-legacy-investigation.md
@@ -1,0 +1,233 @@
+# v9.12 P2 main.py-legacy investigation — 2026-05-12
+
+Scope: four `attest_state(...)` call sites in `main.py::run_worker_loop`
+(lines 167, 301, 317, 482 on origin/main `1667d0e`) flagged as DUAL_WRITER
+candidates for the standard v9.12 hoist (delete caller-side inline, route
+through module-canonical wrapper per the #179 / #193 / #198 pattern).
+
+Verdict: **3 of 4 surface design questions; only 1 is mechanical.**
+
+This doc is the gate report. The single mechanical hoist landed in the
+PR titled `refactor(v9.12): P2 main.py-legacy — wallet_profiles single
+mechanical hoist`. The three holdouts get their own design-q docs and
+draft issues.
+
+## Substrate (raw rows, verbatim)
+
+```
+projectId: small-scene-57890564  (BasisProtocol Neon)
+ran_at:    2026-05-12T10:19Z
+```
+
+```sql
+SELECT domain, COUNT(*) AS rows, MAX(cycle_timestamp) AS last_at,
+       MIN(cycle_timestamp) AS first_at
+FROM state_attestations
+WHERE domain IN ('cda_extractions','wallet_profiles','actors','edges')
+   OR (domain LIKE 'data_layer:%'
+       AND domain ~ 'cda|wallet_profile|actor|edge')
+GROUP BY 1 ORDER BY 1;
+```
+
+```
+domain            | rows | last_at                  | first_at
+actors            |  114 | 2026-05-12T10:19:17.679Z | 2026-04-10T05:16:26.409Z
+wallet_profiles   |   51 | 2026-05-12T08:15:34.319Z | 2026-04-12T10:02:59.330Z
+(cda_extractions and edges return zero rows)
+```
+
+Underlying-table fresh-record counts (paired):
+
+```
+cda_vendor_extractions:        267 total, 82 in 7d, last 2026-05-11T17:07
+wallet_graph.wallet_edges:  1,011,156 total, 348,852 updated in 7d, last 2026-05-12T09:23
+assessment_events:                       769 in 7d, last 2026-05-12T10:13
+wallet_graph.wallet_profiles:         93,061 updated in 7d, last 2026-05-12T09:26
+```
+
+So `cda_extractions` and `edges` have **healthy underlying-table churn
+but zero `state_attestations` rows ever**. That's a coherence-sweep
+red flag — `app/coherence.py:30,33` lists both domains in `ALL_DOMAINS`
+with expected cadences (24h for cda, 12h for edges).
+
+## Per-domain diagnostic table
+
+Schema-compatibility column refers to whether the existing module-side
+attest payload would slot into the same `state_attestations` row shape
+the consumers expect (`app/coherence.py`, `app/report.py::_get_state_hashes`,
+`app/pulse_generator.py`).
+
+| domain | main.py call | module-canonical writer | module attests already? | same domain key? | wrapper exists? | substrate rows | verdict |
+|---|---|---|---|---|---|---|---|
+| `cda_extractions` | `main.py:167` | `app/services/cda_collector.py::run_collection` | YES (`cda_collector.py:1289-1309`) — same `INTERVAL '2 hours'` window, same domain key | YES | NO `run_*_scheduled` wrapper | **0** | **design-q** |
+| `wallet_profiles` | `main.py:301` | `app/indexer/profiles.py::rebuild_all_profiles` | YES (`profiles.py:191-210`) — covers `built > 0` -> records and `built == 0` -> `ran_no_results` | YES | NO wrapper (`rebuild_all_profiles` IS the entry) | **51** | **mechanical** |
+| `actors` | `main.py:317` | conflated — see below | NO inside `app/agent/watcher.py`; YES inside `app/actor_classification.py::classify_all_active:387-401` (different writer, same domain) | YES domain key, but **semantically different payload** | NO wrapper | **114** | **design-q** |
+| `edges` | `main.py:482` | `app/indexer/edges.py::run_edge_builder` | YES (`edges.py:447-464`) — gated `if total_edges > 0` (NEW edges only) | YES | NO wrapper | **0** | **design-q** |
+
+## Why each design-q is a design-q (not just a hoist)
+
+### cda_extractions — symmetric empty-window gate
+
+Both writers use:
+
+```python
+"SELECT ... FROM cda_vendor_extractions WHERE extracted_at > NOW() - INTERVAL '2 hours'"
+```
+
+and `attest_state(...)` short-circuits to `return ""` if records is
+empty (`app/state_attestation.py:63-64`). The daily CDA cycle takes
+materially more than 2h on prod; by the time `run_collection()`
+returns and the SELECT fires, the in-cycle inserts have already aged
+past the 2h window in many cases. Result: both DUAL_WRITER ends see
+zero records, both no-op, `state_attestations` stays empty.
+
+A pure hoist (delete `main.py:167`) doesn't change this — the
+identical bug exists at `cda_collector.py:1296`. The design question
+is "how should `cda_extractions` attestation actually work":
+
+1. Drop the 2h window, attest **all extractions from this run** by
+   tracking inserted IDs in `run_collection()` (refactor scope).
+2. Or attest a **summary payload** (count + cycle outcome) at the
+   end of `run_collection()` regardless of window (matches the
+   #198 / #193 `skipped_fresh / ran / error` shape).
+3. Or change the window to match expected cycle length (~6h).
+
+Holdout doc: `docs/audits/2026-05-12-cda-extractions-design-questions.md`.
+
+### actors — multi-writer triangle with semantic conflation
+
+`main.py:317` writes `{"assessments": N, "severities": {...}}` to
+domain `actors` after `app/agent/watcher.py::run_agent_cycle()`, which
+produces **assessment events** (table `assessment_events`).
+
+`app/actor_classification.py:387-401` writes
+`{"classified": N, "reclassified": M, "by_type": {...}}` to domain
+`actors` from a **different writer** (`classify_all_active`) which
+populates `wallet_graph.actor_classifications`.
+
+Both are stamped under domain `actors`. Consumers
+(`app/coherence.py:73`, `app/pulse_generator.py`, `app/report.py:327`)
+treat the domain as a single freshness signal — they don't know they're
+reading from two different writers with different payload shapes.
+
+Three more writers compound it: `app/worker.py:1446-1447` calls
+`run_agent_cycle()` (no attest), `worker.py:2299-2300` calls
+`classify_all_active()` (attests internally), `worker.py:2703-2707`
+calls `classify_all_active()` again (attests internally),
+`enrichment_worker.py:603-605` calls `classify_all_active()`
+(attests internally).
+
+So actors substrate (`114 rows, last 2026-05-12T10:19`) is composed of
+agent-cycle assessments **and** actor-classification batches mixed.
+A naive hoist removes one without addressing the conflation.
+
+Design questions:
+1. Should `run_agent_cycle()` attest a separate domain (`assessments`
+   or `assessment_events`)? Migration impact: coherence.py + report.py
+   + pulse_generator.py both reference `actors`.
+2. Or should `main.py:317` simply delete (since worker.py:1446 already
+   calls `run_agent_cycle` and consumers see actor_classification
+   attests already)?
+3. What's the canonical wrapper home for the four agent/classify call
+   sites — single entry, or two?
+
+Holdout doc: `docs/audits/2026-05-12-actors-design-questions.md`.
+
+### edges — gate skips the steady state
+
+`main.py:482`: `if edge_result.get('total_edges_created', 0) > 0`
+`edges.py:450`: `if total_edges > 0` (same gate, same semantics)
+
+`total_edges` is computed from `result["edges_upserted"]` at
+`edges.py:419` — that's the **upsert count returned per wallet**, not
+inserted-only. In steady state with 1M+ existing edges, almost every
+edge for a known wallet is an update of an existing row. New edges
+are rare; the `> 0` gate rarely opens.
+
+Substrate confirms: 348,852 edges updated in 7d, but `state_attestations`
+has zero `edges` rows ever. Both writers gate identically; neither fires
+in steady state. A pure hoist doesn't fix it.
+
+Design questions:
+1. Should the attest fire **always at end-of-run**, with payload like
+   `{"chain": ..., "wallets_processed": ..., "edges_upserted": ...,
+   "new_edges_inserted": ...}`? (Matches #193 `skipped_fresh / ran /
+   error` shape.)
+2. Or split `edges_upserted` into `inserted` vs `updated` and only
+   attest on inserts? (Original intent, but the field doesn't exist
+   on the explorer response.)
+3. Coherence cadence says 12h — but main.py gate is 10h between
+   `run_edge_builder` invocations. Should these be coupled?
+
+Plus a related substrate finding: the attest call at `edges.py:451`
+passes `chain` as the **third positional arg** to `attest_state`,
+which is the `entity_id` parameter. That's actually correct (chains
+are entities), but it means each chain produces a separate-entity
+attestation row, and the consumer queries that ask for `domain='edges'
+AND entity_id IS NULL` would never match. This is a small design Q on
+its own. (`app/state_attestation.py:88` — `entity_id IS NULL` branch.)
+
+Holdout doc: `docs/audits/2026-05-12-edges-design-questions.md`.
+
+### wallet_profiles — the only mechanical case
+
+`main.py:301`: gated `if profile_result.get('built', 0) > 0` -> attest
+`profiles.py:194`: same gate -> attest with `{"built", "total"}`
+`profiles.py:196-197`: ALSO has `else` branch -> attest with
+`{"status": "ran_no_results"}`
+
+So the module covers both gates; the caller-side is a pure duplicate.
+Removing `main.py:298-303` removes one of the two writes per cycle
+without changing the substrate cadence.
+
+Substrate confirms: `wallet_profiles` shows 51 rows since 2026-04-12,
+last 2026-05-12T08:15 — fresh and within the 24h cadence in
+`coherence.py:71`.
+
+This is the single mechanical hoist that landed in the PR.
+
+## Out-of-worker consumers (Lesson 10)
+
+Full-repo grep for the four domain strings turned up these consumers
+that a single-file grep would miss:
+
+```
+app/coherence.py:30,33    -> ALL_DOMAINS list (freshness sweep)
+app/coherence.py:69,72    -> DOMAIN_FREQUENCIES (24h / 12h cadence)
+app/report.py:112,327     -> _get_state_hashes(...) for SII + wallet reports
+app/pulse_generator.py:249-250 -> daily-pulse state-root domain list
+app/integrity.py:409      -> "edges" integrity check definition
+app/ops/entity_views.py:219 -> entity-view CDA extraction surface
+app/ops/entity_routes.py:313 -> entity routes consume CDA list
+```
+
+All of these read from `state_attestations`. The 0-row substrate for
+`cda_extractions` and `edges` means these consumers are silently
+serving stale/missing freshness data. That makes the design-q decisions
+above urgent rather than cosmetic.
+
+## What landed in the PR
+
+Just `main.py:297-303` deletion (the wallet_profiles inline). All
+other changes are the comment block referencing this audit doc.
+
+```
+ main.py | 18 ++++++++++++------
+ docs/audits/2026-05-12-p2-main-py-legacy-investigation.md | (this file)
+ docs/audits/2026-05-12-cda-extractions-design-questions.md | (new)
+ docs/audits/2026-05-12-actors-design-questions.md | (new)
+ docs/audits/2026-05-12-edges-design-questions.md | (new)
+```
+
+Total diff: well under 500 lines (the bundle target). The original
+"4 mechanical -> bundle PR" path is **not viable** because three of
+the four are not mechanical.
+
+## References
+
+- #179 (dex_pool_ohlcv pilot — original v9.12 pattern)
+- #193 (peg_monitor scheduled wrapper — 3-domain coupled write)
+- #198 (exchange_snapshots — most recent #179 application)
+- #199 (main.py:342-344 silent-swallow fix — adjacent, different lines)
+- `app/state_attestation.py` (attest API surface)
+- `app/coherence.py` (consumer of all four domains)

--- a/main.py
+++ b/main.py
@@ -294,13 +294,18 @@ def run_worker_loop():
                     f"Profile rebuild complete: {profile_result.get('built', 0)} built, "
                     f"{profile_result.get('errors', 0)} errors out of {profile_result.get('total', 0)} addresses"
                 )
-                # Attest profiles
-                try:
-                    from app.state_attestation import attest_state
-                    if profile_result.get('built', 0) > 0:
-                        attest_state("wallet_profiles", [{"built": profile_result.get('built', 0), "total": profile_result.get('total', 0)}])
-                except Exception as ae:
-                    logger.debug(f"Profile attestation skipped: {ae}")
+                # v9.12 P2 hoist: wallet_profiles attestation moved into
+                # app/indexer/profiles.py::rebuild_all_profiles (terminal
+                # branches: built > 0 -> records, built == 0 ->
+                # ran_no_results, exception -> _record_cycle_error). The
+                # caller-side block previously here (`if built > 0 ->
+                # attest_state("wallet_profiles", ...)`) duplicated the
+                # module's attest. Module attest covers both gates, so
+                # caller-side is removed. See #198 / #193 for wrapper-
+                # shape precedent, and docs/audits/2026-05-12-p2-main-py-
+                # legacy-investigation.md for the multi-writer audit that
+                # scoped this PR down from the 4-domain bundle to
+                # wallet_profiles only.
             except Exception as e:
                 logger.warning(f"Profile rebuild failed: {e}")
 


### PR DESCRIPTION
Diagnostic-first P2 audit (per #185 / #195 pattern) on four
main.py-legacy `state_attestations` call sites:

- `main.py:167` -> `cda_extractions`
- `main.py:301` -> `wallet_profiles`
- `main.py:317` -> `actors`
- `main.py:482` -> `edges`

**Audit verdict: 3 of 4 surface design questions. Only `wallet_profiles`
is mechanical.** This PR ships the single mechanical hoist plus four
investigation docs. Three draft issues track the holdouts.

## Substrate

`projectId: small-scene-57890564` (BasisProtocol Neon), ran 2026-05-12T10:19Z:

```sql
SELECT domain, COUNT(*) AS rows, MAX(cycle_timestamp) AS last_at
FROM state_attestations
WHERE domain IN ('cda_extractions','wallet_profiles','actors','edges')
   OR (domain LIKE 'data_layer:%' AND domain ~ 'cda|wallet_profile|actor|edge')
GROUP BY 1 ORDER BY 1;
```

```
domain            | rows | last_at
actors            |  114 | 2026-05-12T10:19:17.679Z
wallet_profiles   |   51 | 2026-05-12T08:15:34.319Z
(cda_extractions and edges return zero rows)
```

Paired underlying-table churn (so we know the writers ARE running):

```
cda_vendor_extractions:        267 total, 82 in 7d
wallet_graph.wallet_edges:  1,011,156 total, 348,852 updated in 7d
assessment_events:                       769 in 7d
wallet_graph.wallet_profiles:         93,061 updated in 7d
```

So `cda_extractions` and `edges` have **healthy underlying-table churn
but zero `state_attestations` rows ever** — and consumers
(`app/coherence.py:30,33`, `app/report.py:_get_state_hashes`,
`app/pulse_generator.py:249-250`) expect those rows. This is the
coherence-sweep red flag that pulled three of the four hoists out of
the "mechanical" bucket and into design-q.

## Per-domain diagnostic table

| domain | main.py call | module attests already? | same key as main.py? | wrapper exists? | schema compatible? | substrate | verdict |
|---|---|---|---|---|---|---|---|
| `cda_extractions` | `main.py:167` | YES (`cda_collector.py:1289-1309`) | YES — identical 2h SQL window | NO `run_*_scheduled` wrapper | OK | **0 rows** | **design-q** |
| `wallet_profiles` | `main.py:301` | YES (`profiles.py:191-210`) — covers built > 0 AND ran_no_results | YES | NO (`rebuild_all_profiles` IS the entry) | OK | **51 rows, last 2026-05-12T08:15** | **mechanical** |
| `actors` | `main.py:317` | NO inside `agent/watcher.py`; YES inside `actor_classification.py:387-401` | YES domain key, but **semantically different payload** | NO | conflated | **114 rows (mixed signal)** | **design-q** |
| `edges` | `main.py:482` | YES (`edges.py:447-464`), gated `total_edges > 0` (steady state = ~0 new) | YES | NO | OK | **0 rows** | **design-q** |

## What landed in this PR

`main.py:297-303` — the wallet_profiles inline `attest_state(...)` is
removed, replaced with a comment referencing `profiles.py` as
canonical writer and the investigation doc. Module-side
`rebuild_all_profiles` already attests on both `built > 0` and
`ran_no_results` branches. Pattern matches #198 / #193 commentary
style.

**Files:**
- `main.py` — wallet_profiles inline removed (-6 +11 lines)
- `docs/audits/2026-05-12-p2-main-py-legacy-investigation.md` (new)
- `docs/audits/2026-05-12-cda-extractions-design-questions.md` (new)
- `docs/audits/2026-05-12-actors-design-questions.md` (new)
- `docs/audits/2026-05-12-edges-design-questions.md` (new)

Total diff: well under 500 lines.

## Substrate verification

### Pre-deploy

```sql
SELECT COUNT(*) FROM state_attestations
WHERE domain = 'wallet_profiles' AND cycle_timestamp > NOW() - INTERVAL '24 hours';
-- expect: > 0 (substrate at audit time: 51 total, last 2026-05-12T08:15)
```

### Post-deploy halt criteria (operator runs ~2h post-deploy)

```sql
-- (1) wallet_profiles attestation domain still advancing
SELECT MAX(cycle_timestamp) AS last_attest,
       NOW() - MAX(cycle_timestamp) AS staleness,
       COUNT(*) FILTER (WHERE cycle_timestamp > NOW() - INTERVAL '24 hours') AS attests_post
FROM state_attestations
WHERE domain = 'wallet_profiles';
-- Expect: attests_post >= 1; module-canonical attest still firing from profiles.py:191-210

-- (2) payload shape matches profiles.py writer (not main.py's removed writer)
SELECT cycle_timestamp,
       record_count,
       methodology_version
FROM state_attestations
WHERE domain = 'wallet_profiles'
ORDER BY cycle_timestamp DESC LIMIT 5;
-- Expect: record_count = 1 (profiles.py writes single-row summary,
-- same as main.py's removed writer — no observable shape change).

-- (3) coherence sweep doesn't flag wallet_profiles as stale
-- (24h cadence per coherence.py:71)
```

### Halt condition

If `wallet_profiles` attests stop within 24h of deploy — module-side
attest is broken; revert. Substrate shows module attest has been
running for ~30 days (since 2026-04-12), so this is low risk.

## Holdouts

- `cda_extractions`: symmetric 2h SELECT window race. Both DUAL_WRITER
  ends see empty `recent` and no-op. Hoist alone doesn't fix it. Draft
  issue + design doc.
- `actors`: multi-writer triangle. `main.py:317` writes assessment-
  shape payload to domain `actors`, while `actor_classification.py:391`
  writes classification-shape payload to the same domain. Semantic
  conflation, not just duplication. Draft issue + design doc.
- `edges`: `> 0` gate on `edges_upserted` (which counts ON CONFLICT
  updates) so it never opens in steady state. Plus `edges.py:451`
  passes chain as `entity_id` which consumers' default IS NULL lookup
  misses. Two design Qs in one. Draft issue + design doc.

## References

- #179 (dex_pool_ohlcv pilot — original v9.12 pattern)
- #193 (peg_monitor scheduled wrapper)
- #198 (exchange_snapshots — most recent #179 application; the
  audit cited it as wrapper-shape precedent)
- #195 (the diagnostic-first P0 investigation this audit mirrors)
- #199 (main.py:342-344 silent-swallow fix — adjacent, different
  lines, no conflict)

https://claude.ai/code/session_017QJC4gmqRh6kdkNk3onqkB

---
_Generated by [Claude Code](https://claude.ai/code/session_017QJC4gmqRh6kdkNk3onqkB)_