### PR TITLE
fix(audit): reclassify P2 domain priorities after diagnostic findings

### DIFF
--- a/docs/audits/2026-05-11-module-canonical-migration-plan.md
+++ b/docs/audits/2026-05-11-module-canonical-migration-plan.md
@@ -32,13 +32,13 @@ schedule the module from worker.py.
 | ~~`data_layer:peg_snapshots_5m` (+ `market_chart_history` + `volatility_surfaces`)~~ ✅ | ~~worker.py:1310-1373 inline~~ removed | `app/data_layer/peg_monitor.py::run_peg_monitoring_scheduled` | **P0 → DONE** | First v9.13 coupled-write refactor. #188 made the module canonical writer for all 3 domains; this PR adds the scheduled wrapper (freshness gate + 3-domain skip/error attest) and routes worker, enrichment_worker, and main.py through it. Dispatcher heartbeat at worker.py:2787 left in place until Phase 2.3. |
 | ~~`data_layer:exchange_snapshots`~~ ✅ | ~~worker.py:1186-1246 inline~~ removed | `app/data_layer/exchange_collector.py::run_exchange_collection_scheduled` | **P0 → DONE** | Q1 answered by #197 (migration 109 — schema replay). Q2 answered: 15 exchanges (worker._EX list), `_EX_FIX` legacy-slug remap ported into module. 35 additional exchanges deferred to Q2-extension (see below). enrichment_worker.py task entry removed (was kept closed by inline; lesson 6 family). main.py daily lambda switched. Dispatcher heartbeat at worker.py:2787 left in place until Phase 2.3. |
 | ~~`data_layer:dex_pool_ohlcv`~~ ✅ | ~~worker.py inline~~ removed | `app/data_layer/ohlcv_collector.py::run_ohlcv_collection_scheduled` | **P0 → DONE** | Pilot landed this session; module-canonical via `run_ohlcv_collection_scheduled()`. Dispatcher heartbeat at worker.py:2778 left in place until Phase 2.3. |
-| `wallets` | `worker.py:2082`, also `worker.py:2787` (heartbeat) | — (driven by `app/indexer/pipeline.py`) | **P1** | Wave 1 + Wave 3 + Wave 5b. |
+| `wallets` | `worker.py:2082`, also `worker.py:2787` (heartbeat) | — (driven by `app/indexer/pipeline.py`) | **P1** | Wave 1 + Wave 3 + Wave 5b. Consider v9.12 N/A — layered defense intentional (see #202). |
 | `web_research` | `worker.py:1960`, also 2787 | `app/collectors/web_research.py:563` | **P1** | Wave 1 + Wave 3 + Wave 5b. |
 | `psi_components` | `worker.py:1100`, `main.py:224` | (enrichment task) | **P1** | Two live paths post-Wave-1. |
-| `cda_extractions` | `main.py:167` | (enrichment task wraps `app/services/cda_collector.py`) | **P2** | Single legacy main.py site; module exists. |
+| `cda_extractions` | `main.py:167` | (enrichment task wraps `app/services/cda_collector.py`) | **P0** | Reclassified from P2 — coherence gap: 0 attestations despite vendor churn (see #207). |
 | `wallet_profiles` | `main.py:301` | (`app/wallet_profile.py`) | **P2** | |
-| `actors` | `main.py:317` | (`app/agent/`) | **P2** | |
-| `edges` | `main.py:456` | (`app/indexer/edges.py`) | **P2** | |
+| `actors` | `main.py:317` | (`app/agent/`) | **P1** | Reclassified from P2 — multi-writer triangle: main.py + actor_classification.py write same domain with semantically different payloads (see #208). |
+| `edges` | `main.py:456` | (`app/indexer/edges.py`) | **P0** | Reclassified from P2 — coherence gap: 0 attestations despite 348k edge updates in 7d (see #209). |
 
 ¹ Priority key:
 - **P0** — most-fraught, multiple PRs in flight on 2026-05-11; should


### PR DESCRIPTION
## Summary

Updates the priority column in `docs/audits/2026-05-11-module-canonical-migration-plan.md` to reflect findings from this session's diagnostic-first v9.12 investigations. Keeps the audit truthful for the next reader.

## Reclassifications

| domain | old | new | source | rationale |
|---|---|---|---|---|
| `cda_extractions` | P2 | **P0** | #207 | 0 attestations despite vendor churn (82 vendor extractions in 7d); broken-by-window in `cda_collector.py:1289-1309` |
| `edges` | P2 | **P0** | #209 | 0 attestations despite 348,852 wallet_edges updated in 7d; broken-by-gate in `edges.py:447-464` |
| `actors` | P2 | **P1** | #208 | Multi-writer triangle: `main.py:317` and `actor_classification.py:391` write same domain with semantically different payloads |
| `wallets` | P1 (unchanged) | P1 + annotation | #202 | 4 writers each cover a distinct failure mode (PRs #142, #155, #163); module-only-writer invariant cannot be met without losing coverage. Annotation: "Consider v9.12 N/A — layered defense intentional." |

## Source

Annotations triggered by Agent G's P2 quadruplet diagnostic (issues #207, #208, #209) and Agent D's wallets diagnostic (issue #202). Both halted refactor-PR paths after substrate showed the mechanical v9.12 hoist would either bury coherence-sweep alarms (cda/edges) or remove intentional layered defense (wallets).

## Scope

Priority column + notes column for the 4 affected rows only. Line numbers, file references, and other table content are intentionally untouched — those will be corrected in their respective per-domain refactor PRs (where the actual file:line refs can be re-verified at hoist time). `wallet_profiles` row (now hoisted in #206) is unchanged here.

## Substrate verification

### N/A

Docs-only audit reclassification. No code change, no live attestation surface affected. The substrate evidence for each priority change lives in the linked issues (#207, #208, #209, #202).

https://claude.ai/code/session_017QJC4gmqRh6kdkNk3onqkB

---
_Generated by [Claude Code](https://claude.ai/code/session_017QJC4gmqRh6kdkNk3onqkB)_