### PR TITLE
refactor(v9.12): psi_discoveries module-canonical (Q1=C, depth ii)

### DIFF
--- a/app/data_layer/psi_discovery_monitor.py
+++ b/app/data_layer/psi_discovery_monitor.py
@@ -1,0 +1,109 @@
+"""
+PSI Discovery Monitor — Module-Canonical Wrapper (v9.12 #198 / v9.13 #193)
+==========================================================================
+Single owner of `attest_state("psi_discoveries", ...)`.
+
+Pre-refactor, three writers diverged in payload + gating
+(worker.py path A, main.py path B, enrichment_worker.py path C). Per
+docs/audits/2026-05-12-psi-discoveries-design-questions.md and operator
+sign-off on issue #200 (Q1=C, Q2=C, Q3=A, Q5=A; Q4/Q6 deferred):
+
+- Depth (ii): expansion workload stays in worker.py:run_slow_cycle;
+  this wrapper owns only the freshness gate + attest call.
+- Payload: {status, synced, discovered, enriched, promoted}.
+  `hours_since_last_expansion` is dropped (it churned batch_hash).
+- Gate: SELECT MAX(snapshot_date) FROM protocol_collateral_exposure,
+  24h threshold. Gate-closed branch emits status="skipped_fresh"
+  (prevents the 29-day silence #157 fixed).
+- entity_id always NULL; methodology_version defaults to FORMULA_VERSION.
+
+The slow-cycle heartbeat at worker.py:2602-2652 also writes this
+domain — preserved untouched during rollout (Q4 deferred).
+"""
+
+import asyncio
+import logging
+from datetime import date, datetime
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+_PSI_DISCOVERY_GATE_HOURS = 24
+
+
+async def run_psi_discovery_monitor_scheduled(
+    cycle_ts: Optional[datetime] = None,
+    *,
+    status: str = "skipped_unknown",
+    synced: int = 0,
+    discovered: int = 0,
+    enriched: int = 0,
+    promoted: int = 0,
+) -> dict:
+    """Three terminal branches: skipped_fresh, ran, error.
+
+    Args:
+        cycle_ts: informational cycle timestamp for logging.
+        status: caller's workload status (ran | skipped_fresh | error |
+            skipped_unknown).
+        synced/discovered/enriched/promoted: workload result counts.
+
+    Returns:
+        The payload dict that was attested.
+    """
+    from app.database import fetch_one_async
+    from app.state_attestation import attest_state
+
+    # Gate query — verbatim from pre-refactor path A semantics
+    # (worker.py:2330-2339).
+    hours_since: float = float(_PSI_DISCOVERY_GATE_HOURS + 1)  # default: stale
+    try:
+        last_expansion = await fetch_one_async(
+            "SELECT MAX(snapshot_date) AS latest FROM protocol_collateral_exposure"
+        )
+        last_date = last_expansion["latest"] if last_expansion else None
+        if last_date and isinstance(last_date, date):
+            hours_since = float((date.today() - last_date).days * 24)
+    except Exception as e:
+        logger.warning(f"[psi_discovery_monitor] freshness query failed: {e}")
+
+    # Branch selection
+    if status == "error":
+        out_payload = {
+            "status": "error",
+            "synced": synced, "discovered": discovered,
+            "enriched": enriched, "promoted": promoted,
+        }
+    elif hours_since < _PSI_DISCOVERY_GATE_HOURS:
+        # Gate closed — emit skipped_fresh heartbeat (Q3=A).
+        out_payload = {
+            "status": "skipped_fresh",
+            "synced": 0, "discovered": 0, "enriched": 0, "promoted": 0,
+        }
+    else:
+        out_payload = {
+            "status": "ran" if status == "ran" else status,
+            "synced": synced, "discovered": discovered,
+            "enriched": enriched, "promoted": promoted,
+        }
+
+    try:
+        await asyncio.to_thread(attest_state, "psi_discoveries", [out_payload])
+    except Exception as ae:
+        logger.warning(f"[psi_discovery_monitor] attest failed: {ae}")
+        try:
+            from app.worker import _record_cycle_error
+            _record_cycle_error(
+                error_type="psi_discoveries_attestation_failure",
+                error_message=str(ae)[:500],
+                cycle_phase="psi_expansion",
+            )
+        except Exception:
+            pass
+
+    logger.info(
+        f"[psi_discovery_monitor] status={out_payload['status']} "
+        f"synced={synced} discovered={discovered} "
+        f"enriched={enriched} promoted={promoted}"
+    )
+    return out_payload

--- a/app/worker.py
+++ b/app/worker.py
@@ -2357,29 +2357,27 @@ async def run_slow_cycle():
         _psi_status = "error"
         logger.warning(f"PSI expansion pipeline failed: {e}")
 
-    # Attest psi_discoveries from the live worker path. PR #137 patched
-    # the enrichment_worker task and PR #150 patched main.py:244, but
-    # this block at worker.py:2468 is the actual code that fires on
-    # every fast cycle. It runs `collect_collateral_exposure()` itself,
-    # which keeps protocol_collateral_exposure fresh, which closes the
-    # 24h db_gate on BOTH the enrichment task AND main.py's path —
-    # rendering both prior fixes dead code in practice.
-    #
-    # Heartbeat from here so freshness tracks the worker cycle, not the
-    # rare day when this block's own 24h gate happens to open.
+    # psi_discoveries attestation is owned by the module-canonical wrapper
+    # at app/data_layer/psi_discovery_monitor.py (v9.12 #198 / v9.13 #193
+    # pattern). The expansion workload above (depth ii) stays in this
+    # function; the wrapper consolidates the write path so paths B
+    # (main.py) and C (enrichment_worker.py) can be deleted without
+    # going silent. See docs/audits/2026-05-12-psi-discoveries-design-questions.md
+    # — operator sign-off issue #200, Q1=C / Q2=C / Q3=A / Q5=A.
     try:
-        from app.state_attestation import attest_state
-        await asyncio.to_thread(attest_state, "psi_discoveries", [{
-            "status": _psi_status,
-            "hours_since_last_expansion": round(_psi_hours_since, 2)
-                if isinstance(_psi_hours_since, (int, float)) else None,
-            "synced": _psi_synced,
-            "discovered": _psi_discovered,
-            "enriched": _psi_enriched,
-            "promoted": _psi_promoted,
-        }])
+        from app.data_layer.psi_discovery_monitor import (
+            run_psi_discovery_monitor_scheduled,
+        )
+        await run_psi_discovery_monitor_scheduled(
+            cycle_ts=datetime.now(timezone.utc),
+            status=_psi_status,
+            synced=_psi_synced,
+            discovered=_psi_discovered,
+            enriched=_psi_enriched,
+            promoted=_psi_promoted,
+        )
     except Exception as _e_attest:
-        logger.warning(f"psi_discoveries worker attest failed: {_e_attest}")
+        logger.warning(f"psi_discoveries wrapper call failed: {_e_attest}")
 
     # -------------------------------------------------------------------------
     # Pool wallet discovery — daily gate via DB timestamp


### PR DESCRIPTION
## Summary

- Establish `app/data_layer/psi_discovery_monitor.py` as the single owner of `attest_state("psi_discoveries", ...)` per operator sign-off on issue #200 design questions doc (Q1=C, Q2=C, Q3=A, Q5=A).
- Depth (ii) scope: the PSI expansion workload stays in `worker.py:run_slow_cycle`; only the write-path (gate + attest) consolidates into the new module. Wrapper signature mirrors #198 / #193 with three terminal branches: `skipped_fresh`, `ran`, `error`.
- Payload (Q2=C): `{status, synced, discovered, enriched, promoted}`. Dropped `hours_since_last_expansion` — substrate showed it churning `batch_hash` cycle-to-cycle, defeating the steady-state-stable-hash intent of #137.

## Operator-signed constraints honored

- Q1=C: new module file (`app/data_layer/psi_discovery_monitor.py`), scheduled-wrapper shape mirroring #198 / #193.
- Q2=C: payload is `{status, synced, discovered, enriched, promoted}`. `hours_since_last_expansion` dropped.
- Q3=A: gate-closed branch emits `status="skipped_fresh"` (not silent skip) — preserves the heartbeat #157 added that fixed the 29-day silence.
- Q5=A: `entity_id` stays NULL — `psi_discoveries` is registry-level. All 14 existing substrate rows have `entity_id IS NULL`, so we are consistent.
- Q4 deferred: `worker.py:2602-2652` slow-cycle heartbeat is **untouched** — stays live during rollout.
- Q6 deferred: `methodology_version` defaults to `FORMULA_VERSION` (= `v1.0.0`); no bump.

## Scope reduction — Path B / Path C deletions deferred

Per the spec's halt rule ("Diff exceeds 180 lines → halt, propose split"), the original plan's full scope (worker + main + enrichment_worker, ~313 lines of diff including deletions) exceeded the threshold. This PR ships **only**:

- New module: `app/data_layer/psi_discovery_monitor.py` (109 lines).
- worker.py wiring: in-place replacement of the inline attest with `await run_psi_discovery_monitor_scheduled(...)`.

Total diff: **151 lines (129 insertions / 22 deletions)** — under the 180-line cap.

**Follow-up PR will:**
- Delete Path B (`main.py:226-266` + `last_expansion_at` at line 137).
- Delete Path C (`_run_psi_expansion` body in `app/enrichment_worker.py:263-306` + its registration at 770-784).

Both paths are already dead in steady state — Path A (the slow-cycle writer this PR replaces with the wrapper) keeps `protocol_collateral_exposure` fresh on every slow cycle, closing both B's `last_expansion_at >= 24h` timer and C's `_db_gate("MAX(snapshot_date) ... min_hours=24")`. So leaving them in for one PR cycle is safe — they cannot fire without first racing past Path A.

## Lesson-10 full-repo consumer check

Grepped the full repo for the string `'psi_discoveries'`. Live consumers (excluding worktrees / docs):

- `app/coherence.py:35,74` — freshness SLA only (24h). Doesn't read payload. **Safe.**
- `app/pulse_generator.py:251` — reads `batch_hash`, `record_count`, `cycle_timestamp` only. **Safe.**
- `app/report.py:245` — calls `_get_state_hashes(["psi_components", "psi_discoveries"], entity_id=slug)`. Pre-existing bug: passes `slug` as `entity_id` but all `psi_discoveries` rows have `entity_id IS NULL`, so this lookup has been returning empty hashes regardless. Q5=A preserves that pre-existing state (entity_id stays NULL). **Not regressed by this PR.**
- `app/worker.py:2609` slow-cycle heartbeat — preserved verbatim (Q4 deferred).
- `app/enrichment_worker.py:288-305` and `main.py:260-268` — the Path B / Path C writers themselves. Untouched in this PR; deletion deferred to follow-up.

Repo-wide grep for `hours_since_last_expansion` (the Q2=C dropped field) found **one** match — the writer site in `worker.py` we are removing. **No external consumer.** No volatility_surfaces-style surprises.

Repo-wide grep for `methodology_version` filters: no consumer pins `'v1.0.0'` against `state_attestations`. Q6 deferral is safe.

## Substrate verification

### Pre-deploy

```sql
SELECT COUNT(*) AS rows_24h, MIN(cycle_timestamp), MAX(cycle_timestamp)
FROM state_attestations
WHERE domain = 'psi_discoveries' AND cycle_timestamp > NOW() - INTERVAL '24 hours';
```

```
rows_24h | min                          | max
---------+------------------------------+------------------------------
       9 | 2026-05-11T17:39:55.671Z     | 2026-05-12T13:41:35.181Z
```

```sql
SELECT batch_hash, COUNT(*) FROM state_attestations
WHERE domain = 'psi_discoveries' AND cycle_timestamp > NOW() - INTERVAL '7 days'
GROUP BY batch_hash;
```

```
batch_hash                                                       | count
-----------------------------------------------------------------+-------
2f52550d114e0aee6a6bc3d299179c71c51845f2b9b3944f21c5e6cbf4813504 | 1
4167597418093d6f39a45d25777a5ffd9386bbc98cea87eb6f0db5ee324858ab | 1
b4ed02612febe5661386875bdfcae74bcf2fcad9c095c9a3c57124ef89c3dfcf | 1
cc9ae5fcf8d43597ec76be33fa0acd94ed94de52e56f80a8550843c6c7084837 | 1
49e1bed1fe40427e5f43ec7d8accb0404644385b3ad5c843c963191c7ed3d544 | 2
42e668324e8a77d9db0c3f7fad4895a608f0d84b0dd27613d46ecd101aeaf12d | 1
63d4d62d4b4391501ebbf9a7e42237c729ed46b4a41bf14b536d3609eb0ebaee | 1
b9080fff4d75b6d877b5326d6038084b65b8bc589aea38c361f743a9f5565eea | 1
```

Eight distinct hashes across nine rows in seven days — exactly the churn pattern the design doc surfaced (3.4). Q2=C should compress this materially.

```sql
SELECT methodology_version, COUNT(*) FROM state_attestations
WHERE domain = 'psi_discoveries' GROUP BY 1;
```

```
methodology_version | count
--------------------+-------
v1.0.0              | 14
```

Single methodology_version across all rows. Repo grep confirmed no consumer filters on a pinned version string against `state_attestations`. Q6 deferral safe.

### Post-deploy halt criteria

- **Cadence:** at least 1 attest row appearing every ~2h slow cycle within 4h of deploy. If `rows_post < 1` after 4h, revert this PR.
- **batch_hash distribution:** fewer distinct hashes than the pre-refactor sample of 8 / 9 rows (Q2=C working). Expected steady-state: 1–2 distinct hashes (matching `status` cardinality of `skipped_fresh` vs `ran`).
- **No new errors:** `cycle_errors WHERE error_type = 'psi_discoveries_attestation_failure'` should stay flat. The wrapper preserves `cycle_phase="psi_expansion"` exactly so existing alerting keeps firing.

## Test plan

- [ ] Substrate post-deploy: rerun the three SQL queries above 4h after merge; confirm ≥ 1 row at 2h cadence, and that distinct batch_hash count drops vs the pre-deploy sample.
- [ ] Verify `worker.py:run_slow_cycle` log line `[psi_discovery_monitor] status=...` appears once per slow cycle.
- [ ] Confirm `worker.py:2602-2652` heartbeat still writes its expected payload (Q4 deferred — should be unaffected).
- [ ] Follow-up PR deletes Path B + Path C and confirms cadence remains 1 row / slow cycle.

## References

- Closes #200 (partial — module + worker.py consumer landed; B/C deletions tracked as follow-up).
- Pattern precedent: #198 (`exchange_collector` v9.12 module-canonical), #193 (`peg_monitor` v9.13 coupled-write).
- Design doc: `docs/audits/2026-05-12-psi-discoveries-design-questions.md`.

https://claude.ai/code/session_017QJC4gmqRh6kdkNk3onqkB

---
_Generated by [Claude Code](https://claude.ai/code/session_017QJC4gmqRh6kdkNk3onqkB)_