### PR TITLE
docs(phase-b): holdout-scenarios isolation + closure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,9 @@ node_modules/
 env.dev
 # Phase A — compose command detection cache (written by dev-bootstrap.sh)
 .compose-cmd
+
+# Phase B — holdout eval scenarios. basis-protocol/scenarios MUST NOT
+# be cloned into any basis-hub working tree. See
+# docs/development/phase-b-isolation.md.
+scenarios/
+basis-protocol-scenarios/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -291,4 +291,11 @@ Spokes never import from `app/`. They never touch the database directly.
 - Install heavy dependencies without asking first
 - Use `sudo` for anything
 - Hardcode stablecoin lists — the registry is dynamic
+- Access, read, clone, or fetch `basis-protocol/scenarios` from any
+  basis-hub session. That repo is the holdout eval test set for CC
+  itself; touching it from a basis-hub session burns scenarios.
+  Do not extend MCP allowlists to include it. Do not link to
+  scenario folders from basis-hub issues, PRs, or docs. Do not paste
+  scenario content into any basis-hub-facing surface. See
+  `docs/development/phase-b-isolation.md` for full rationale.
 - Create arrays/lists like `['usdc', 'usdt', 'dai', ...]` — always query

--- a/docs/audits/2026-05-12-phase-b-closure.md
+++ b/docs/audits/2026-05-12-phase-b-closure.md
@@ -1,0 +1,170 @@
+# Phase B Closure — Dark Factory Holdout Bank
+
+**Date:** 2026-05-12
+**Outcome:** Phase B shipped with five of six seed scenarios in
+`basis-protocol/scenarios`; safeguards landed in basis-hub via
+this PR.
+
+## Locked design decisions
+
+Four decisions were settled before scenario authoring began and
+remain in force for Phase C onwards:
+
+1. **Grader: two-stage per scenario.** Stage 1 is a SQL check
+   against substrate state (fail-fast filter). Stage 2 is an LLM
+   judge over the PR diff against an enumerated wrong-answer
+   list.
+2. **Code state: current-main only.** Scenarios target today's
+   basis-hub `main`. The source PR / issue in each
+   `meta.yaml::source` is provenance, not test substrate. A
+   `harness.setup_revert` field optionally instructs the harness
+   to `git revert --no-edit <SHA>` against `main` before handing
+   the tree to CC.
+3. **Categories:** `timing/coupling`, `argument-shape`,
+   `silent-path`, `hidden-dependency`. A free-text `subcategory`
+   field captures finer cuts.
+4. **Difficulty levels:** 1 = single-file mechanical fix;
+   2 = multi-file or one explicit design choice;
+   3 = CC must first decide *what kind of fix* applies.
+
+## Folder layout per scenario
+
+Every scenario folder in `basis-protocol/scenarios` contains
+seven files:
+
+```
+NNN-slug/
+  meta.yaml              # scenario metadata (validates against schema)
+  prompt.md              # hint-free problem statement for CC
+  setup_code.md          # how to recreate the broken code state
+  setup_substrate.sql    # idempotent DB substrate setup
+  expected_substrate.sql # stage-1 grader query with pass/fail comments
+  wrong_answers.md       # enumerated shallow fixes, anti-examples for judge
+  notes.md               # reviewer-only context — NEVER FOR CC CONTEXT
+```
+
+`meta.yaml` validates against `schema/meta.schema.yaml` in the
+scenarios repo. The required fields are `slug`, `title`,
+`category`, `subcategory`, `difficulty`, `source`, `grader`,
+`harness`, `tags`. `harness.entry_point` is the Python expression
+the harness invokes after substrate setup and CC's submitted fix
+are applied; `harness.setup_revert` is the optional commit SHA
+the harness reverts before handing the tree to CC.
+
+## Six-seed bank
+
+The Phase B brief specified six seed scenarios across the four
+categories above. Five shipped; the sixth was deferred (see
+below).
+
+| Status | Category | Difficulty |
+|--------|----------|------------|
+| Shipped | timing/coupling | 2 |
+| Shipped | timing/coupling | 2 |
+| Shipped | argument-shape | 1 |
+| Shipped | argument-shape | 3 |
+| Shipped | silent-path | 2 |
+| Deferred | hidden-dependency | 3 |
+
+Slugs and provenance for the shipped scenarios live in the
+scenarios repo, not here, by isolation discipline (see
+"Isolation" below). The shipped bank covers three of the four
+seed categories; `hidden-dependency` will be filled by the
+Phase B+ follow-up below.
+
+## Sixth scenario deferred to Phase B+ follow-up
+
+The original Phase B brief listed six seed scenarios across four
+categories (timing/coupling, argument-shape, silent-path,
+hidden-dependency). Five landed; the sixth (hidden-dependency)
+halted at the verification step the brief itself prescribed
+(lesson 10: "read directories not single files — grep basis-hub
+main for consumers, don't trust this prompt's file:line hint").
+Slugs and provenance for the shipped scenarios live in the
+scenarios repo, not here, by isolation discipline.
+
+**Premise decay.** The module the brief named —
+`app/data_layer/volatility_surfaces.py` — does not exist in
+current `main`. `volatility_surfaces` is alive as a Postgres
+table with many active consumers (`app/server.py:7916`,
+`app/data_layer/peg_monitor.py` as the producer at lines
+258/281/454, plus catalog, schema-validator, state-growth, and
+component-replay references). There is no apparent orphan to
+investigate. Reshaping the scenario to target a real
+apparent-orphan module is in scope for Phase B+ but requires
+picking a candidate and verifying its consumer graph matches
+the lesson-10 pattern before writing the prompt. Candidate
+selection is itself out of scope for this closure doc to avoid
+burning the future scenario.
+
+**Schema gap surfaced by the attempt.** The current
+`schema/meta.schema.yaml` requires `source.pr_fix: integer` and
+`harness: object`. Proposal-style scenarios — where pass/fail is
+on CC's investigation answer, not substrate state — fit neither:
+no single fix PR exists, and no runtime invocation advances
+state. The Phase B+ follow-up will land three coordinated
+changes:
+(a) `source.pr_fix` → nullable, with `null` reserved for
+non-fix scenarios;
+(b) `harness` → optional, omitted for proposal scenarios;
+(c) `grader.stage_1` → accept a `noop` sentinel for scenarios
+whose pass/fail is judged entirely by stage 2 over CC's answer.
+None of these affect the five shipped scenarios; they extend the
+schema, they don't break it.
+
+Phase B ships with the five scenarios above. The follow-up to
+land the sixth and the schema patches is tracked separately; it
+does not gate any downstream phase (C runs scenarios, D builds
+the judge harness, E automates), since all three downstream
+phases can proceed against the five-scenario seed bank.
+
+## Isolation discipline
+
+> THIS CC session writes the scenarios — it has already seen the
+> underlying bugs (they were fixed minutes ago in basis-hub).
+> What matters is FUTURE CC sessions never having scenarios in
+> context. No links from basis-hub issues to scenario folders.
+> No clones of basis-protocol/scenarios in any basis-hub working
+> dir. No paste of scenario content into future prompts.
+
+The discipline is encoded in three surfaces in this repo:
+
+1. `.gitignore` — blocks `scenarios/` and
+   `basis-protocol-scenarios/` as tripwires.
+2. `CLAUDE.md` — `## Do NOT` section names the isolation rule
+   so every CC session that reads project context sees it.
+3. `docs/development/phase-b-isolation.md` — full rationale,
+   leak-response procedure, scope boundary between basis-hub
+   docs and the scenarios repo.
+
+The scenarios repo itself enforces the same boundary from its
+side: a prominent isolation policy in `README.md`, a discipline
+checklist in `CONTRIBUTING.md`, and a defensive `.gitignore`
+blocking `basis-hub/` patterns.
+
+## Phase C / D / E forward pointers
+
+This closure doc records what Phase B landed. The subsequent
+phases are out of execution scope here:
+
+- **Phase C — Running scenarios.** Spawn fresh CC sessions in
+  ephemeral environments against each scenario; collect diffs
+  and substrate-post-states for grading. Inherits no context
+  from any basis-hub working session.
+- **Phase D — LLM judge harness.** Wire stage 2: judge LLM
+  scores CC's diff against `wrong_answers.md` per scenario;
+  surface the diff-shape patterns CC actually proposes so the
+  wrong-answer lists can grow from observation rather than
+  guess. Likely lifts stage-1 SQL assertions out of inline
+  comments into structured `meta.yaml::grader.stage_1.assertions`
+  triples; also lands the `source.pr_fix`/`harness` schema
+  patches above.
+- **Phase E — Automation.** Cron the loop. Define stop
+  conditions for retiring burned scenarios and authoring
+  replacements.
+
+Each phase MUST preserve the isolation discipline from Phase B.
+Specifically: no Phase C / D / E artifact may import scenario
+content into a basis-hub-facing surface, and no eval harness may
+share a context window between a basis-hub working session and
+a scenario-running session.

--- a/docs/development/phase-b-isolation.md
+++ b/docs/development/phase-b-isolation.md
@@ -1,0 +1,85 @@
+# Phase B Isolation — basis-protocol/scenarios
+
+**TL;DR:** `basis-protocol/scenarios` is a holdout eval test set for
+Claude Code working on this repo. Future CC sessions on basis-hub
+must never see its contents. This doc explains why, what that
+means concretely, and how the discipline is enforced.
+
+## Why a holdout exists
+
+Phase B established a separate private repository,
+`basis-protocol/scenarios`, populated with concrete failure-mode
+scenarios derived from recent basis-hub work. Each scenario
+encodes a real bug pattern, the substrate that triggers it, an
+enumerated wrong-answer list, and a reviewer-only rationale.
+Scenarios are run by an out-of-band harness against fresh CC
+sessions — none of which has ever seen the scenarios.
+
+The holdout's value depends entirely on CC never having seen the
+scenarios. The moment a scenario leaks into a basis-hub CC
+session — via a clone in a working tree, a paste in an issue, a
+link in a PR, a quote in a comment, or an MCP allowlist extension
+— that scenario is burned. It tests memorization, not
+generalization, from that point on. Burned scenarios must be
+retired and replaced.
+
+## What "isolation" means concretely
+
+These are non-negotiable:
+
+1. **No clones.** Do not `git clone`, `git fetch`, or `gh repo
+   clone` `basis-protocol/scenarios` into any basis-hub working
+   tree or sibling directory CC sessions can read.
+2. **No MCP allowlist extensions.** A basis-hub CC session's MCP
+   tools are scoped to `basis-protocol/basis-hub`. Do not add
+   `basis-protocol/scenarios` to that allowlist. The MCP
+   boundary is the enforcement surface.
+3. **One-way provenance.** Scenarios reference basis-hub PRs in
+   their `meta.yaml::source`. basis-hub PRs, issues, comments,
+   and docs do **not** reference scenario folders. Provenance
+   flows scenarios → basis-hub, never the reverse.
+4. **No paste-in.** Do not paste scenario text into basis-hub
+   issues, PRs, code comments, Slack channels CC watches,
+   shared docs CC has been told to read, or any other
+   CC-readable surface.
+5. **No simultaneous read access.** A human contributor working
+   on both repos should not run a single CC session that has
+   read access to both. One or the other — never both.
+
+## How the discipline is enforced
+
+- `.gitignore` at this repo's root blocks `scenarios/` and
+  `basis-protocol-scenarios/` directory names as tripwires.
+- `CLAUDE.md`'s `## Do NOT` section lists the isolation rule so
+  every CC session that reads the project context sees it.
+- The scenarios repo itself has a complementary `.gitignore`
+  blocking `basis-hub/` patterns, a prominent isolation policy
+  in `README.md`, and a discipline checklist in
+  `CONTRIBUTING.md`.
+- Phase D's eval harness runs against fresh CC sessions in
+  ephemeral environments; it does not inherit context from any
+  basis-hub working session.
+
+## What to do if a leak happens
+
+1. Identify which scenario(s) leaked, where, and into what
+   surface (chat log, PR, doc, etc.).
+2. Retire the affected scenario: move its folder under
+   `retired/NNN-slug/` in the scenarios repo with a `RETIRED.md`
+   explaining the leak. Do not delete; the audit trail matters.
+3. Author a replacement scenario covering the same category and
+   difficulty before the next eval cycle, derived from a basis-hub
+   PR the new scenario's target CC sessions have not yet seen.
+
+## What is in scope here vs. there
+
+| Surface | Lives in |
+|---------|----------|
+| Isolation rationale | basis-hub `docs/development/phase-b-isolation.md` (this doc) |
+| Closure record of Phase B | basis-hub `docs/audits/2026-05-12-phase-b-closure.md` |
+| Scenario folders, prompts, substrate | `basis-protocol/scenarios` repo only |
+| Eval harness (Phases C–E) | TBD; not yet committed |
+
+Phase C onwards is implementation: running scenarios, building
+the judge, automating the loop. The isolation discipline above
+applies forward through all of those phases.


### PR DESCRIPTION
## Summary

Phase B established `basis-protocol/scenarios` as a private holdout
eval test set for Claude Code working on this repo. The holdout's
value depends on future basis-hub CC sessions never seeing scenario
content. This PR lands the basis-hub-side safeguards plus the
closure audit doc.

- `.gitignore` — tripwire entries blocking `scenarios/` and
  `basis-protocol-scenarios/` paths at repo root.
- `CLAUDE.md` — extend `## Do NOT` with the isolation rule so every
  CC session that reads project context sees it (no access, no
  clone, no MCP allowlist extension, no paste-in, no link).
- `docs/development/phase-b-isolation.md` (new) — full discipline
  rationale, leak-response procedure, scope boundary between
  basis-hub docs and the scenarios repo.
- `docs/audits/2026-05-12-phase-b-closure.md` (new) — closure
  record with the four locked design decisions, seed-bank shape at
  category level (slugs withheld per isolation discipline), 006
  deferral with schema-gap note, and Phase C/D/E forward pointers
  (no execution scope).

Phase B ships with five scenarios; the sixth and the schema
patches its attempt surfaced are tracked as a Phase B+ follow-up
and do not gate downstream phases.

## Test plan

- [ ] CI green on this branch (no runtime code touched; expecting
  lint / formatting passes only)
- [ ] `CLAUDE.md`'s `## Do NOT` section renders with the new
  isolation bullet
- [ ] `.gitignore` correctly excludes a hypothetical `scenarios/`
  directory at repo root (no tracked file matches the new patterns)
- [ ] Closure doc and isolation doc render correctly in the
  rendered Markdown preview

## Substrate verification

### N/A

Docs + gitignore only, no runtime impact, no scoring path or DB
writer touched. No state attestation domain changed.

## Out of scope

- Creating or pushing to `basis-protocol/scenarios` itself (landed
  out-of-band by the operator to preserve the MCP isolation barrier
  for this session).
- Phase B+ follow-up: sixth scenario reshape + the three schema
  patches noted in the closure doc (`source.pr_fix` → nullable,
  `harness` → optional, `grader.stage_1` → accept `noop` sentinel).
- Phase C / D / E execution. Forward pointers only in the closure
  doc.