### PR TITLE
feat(webhooks): CoinGecko cg.coin.info.updated subscriber

### DIFF
--- a/app/server.py
+++ b/app/server.py
@@ -3813,6 +3813,21 @@ async def handle_monitor_alert(request: Request):
     return {"status": "unknown_monitor", "monitor_id": monitor_id}
 
 
+@app.post("/api/webhooks/coingecko")
+async def handle_coingecko_webhook(request: Request):
+    """
+    CoinGecko `cg.coin.info.updated` subscriber.
+
+    Captures constituent metadata mutations (contract migrations,
+    symbol/logo/name changes, platform additions) on the SII + PSI
+    slugs into coingecko_metadata_events for audit + alerting. The
+    handler does not write to stablecoins or rpi_protocol_config —
+    operator review is required before any registry edit.
+    """
+    from app.webhooks.coingecko import handle_webhook
+    return await handle_webhook(request)
+
+
 # =============================================================================
 # CDA Public Evidence Layer API
 # =============================================================================

--- a/app/webhooks/coingecko.py
+++ b/app/webhooks/coingecko.py
@@ -1,0 +1,447 @@
+"""
+CoinGecko webhook handler — `cg.coin.info.updated`.
+
+Receives mutation notifications for constituent metadata (contract
+migrations, symbol / logo / name changes, platform additions) on the
+36 SII and 13 PSI slugs we track, persists them to
+coingecko_metadata_events, resolves the basis entity, attests state
+inline (v9.12 module-canonical — handler owns its attestation), and
+fires an ops alert if the change touches `contract_address` or
+`platforms`.
+
+This is provenance-adjacent: the registry rewrite is deliberately
+manual. The handler does not modify `stablecoins` or
+`rpi_protocol_config`.
+
+Architecture fit (v9.9.8 / v9.12):
+- New attestation domain `coingecko_metadata_events`.
+- Module-canonical writer: insert + attest happen in this module,
+  no dispatcher / heartbeat fallback.
+- Signature mismatch and unmapped slug both write structured
+  cycle_errors per v9.12's silent-except-on-debug rule.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+import logging
+import os
+import traceback
+import uuid as uuid_mod
+from typing import Any, Optional
+
+from fastapi import Request
+from fastapi.responses import JSONResponse
+
+from app.database import (
+    execute,
+    execute_async,
+    fetch_one,
+    fetch_one_async,
+)
+
+logger = logging.getLogger(__name__)
+
+# Header name used by CoinGecko to carry the HMAC. CoinGecko's docs
+# describe a single hex HMAC-SHA256 of the raw request body, keyed by
+# the per-subscription secret. The header name is the value most
+# commonly used by their webhook product; configurable so we can
+# follow CG's evolving header naming without a code change.
+SIGNATURE_HEADER = os.environ.get(
+    "COINGECKO_WEBHOOK_SIGNATURE_HEADER", "x-cg-webhook-signature"
+)
+
+# Shared secret configured on the CoinGecko subscription. Required —
+# if unset the handler rejects all calls as unsigned (this is the
+# safe default; missing secret in prod is itself a deploy bug).
+WEBHOOK_SECRET_ENV = "COINGECKO_WEBHOOK_SECRET"
+
+# Fields whose mutation triggers an ops alert. Everything else is
+# logged only (already captured in the table). The task spec calls
+# out contract_address + platforms explicitly.
+ALERTING_FIELDS = ("contract_address", "platforms")
+
+
+# ---------------------------------------------------------------------------
+# cycle_errors writer (local copy — v9.12 module-canonical, no import from
+# app.worker which pulls scoring deps we don't need on the API server)
+# ---------------------------------------------------------------------------
+
+def _record_cycle_error(
+    error_type: str,
+    error_message: str,
+    cycle_phase: str = "webhook_coingecko",
+    severity: str = "caught",
+) -> None:
+    """Record a webhook handler error to cycle_errors. Never raises."""
+    try:
+        tb = traceback.format_exc()
+        execute(
+            """INSERT INTO cycle_errors
+                (error_type, error_message, traceback, cycle_phase, severity)
+            VALUES (%s, %s, %s, %s, %s)""",
+            (error_type, error_message[:2000], tb[:8000], cycle_phase, severity),
+        )
+    except Exception as e:
+        logger.warning(f"[cycle_errors] failed to record error: {e}")
+
+
+# ---------------------------------------------------------------------------
+# Signature verification
+# ---------------------------------------------------------------------------
+
+def _expected_signature(secret: str, body: bytes) -> str:
+    """HMAC-SHA256(secret, body) → hex string."""
+    return hmac.new(secret.encode("utf-8"), body, hashlib.sha256).hexdigest()
+
+
+def verify_signature(secret: str, body: bytes, provided: Optional[str]) -> bool:
+    """
+    Constant-time HMAC-SHA256 verification.
+
+    Accepts either the bare hex digest or a `sha256=<hex>` prefix
+    (some CG webhook samples use the prefixed form).
+    """
+    if not secret or not provided:
+        return False
+
+    candidate = provided.strip()
+    if candidate.lower().startswith("sha256="):
+        candidate = candidate.split("=", 1)[1].strip()
+
+    expected = _expected_signature(secret, body)
+    return hmac.compare_digest(expected, candidate)
+
+
+# ---------------------------------------------------------------------------
+# coingecko_id → basis entity resolution
+# ---------------------------------------------------------------------------
+
+def resolve_basis_entity(coingecko_id: str) -> tuple[Optional[str], Optional[str]]:
+    """
+    Map CoinGecko slug → (basis_entity_type, basis_entity_id).
+
+    1. Stablecoins: `SELECT id FROM stablecoins WHERE coingecko_id = %s`.
+       Returns ("stablecoin", id) on hit.
+    2. Protocols: PSI uses governance-token coingecko_ids
+       (PROTOCOL_GOVERNANCE_TOKENS in app/collectors/psi_collector.py)
+       which map back to protocol_slug. Returns ("protocol", slug) on hit.
+    3. Otherwise (None, None) and the caller logs cycle_errors.
+    """
+    if not coingecko_id:
+        return (None, None)
+
+    try:
+        row = fetch_one(
+            "SELECT id FROM stablecoins WHERE coingecko_id = %s LIMIT 1",
+            (coingecko_id,),
+        )
+        if row:
+            return ("stablecoin", row["id"])
+    except Exception as e:
+        logger.warning(f"[coingecko_webhook] stablecoin lookup failed: {e}")
+
+    try:
+        from app.collectors.psi_collector import PROTOCOL_GOVERNANCE_TOKENS
+        for protocol_slug, gov_token_cg_id in PROTOCOL_GOVERNANCE_TOKENS.items():
+            if gov_token_cg_id == coingecko_id:
+                return ("protocol", protocol_slug)
+    except Exception as e:
+        logger.warning(f"[coingecko_webhook] protocol token map import failed: {e}")
+
+    return (None, None)
+
+
+# ---------------------------------------------------------------------------
+# Payload normalization
+# ---------------------------------------------------------------------------
+
+def extract_coingecko_id(payload: dict) -> str:
+    """
+    CoinGecko's webhook payload shape isn't fully stable across event
+    versions. Probe known locations in order of how the documented
+    samples describe the field.
+    """
+    for key in ("coin_id", "coingecko_id", "id", "slug"):
+        v = payload.get(key)
+        if isinstance(v, str) and v:
+            return v
+    data = payload.get("data")
+    if isinstance(data, dict):
+        for key in ("coin_id", "coingecko_id", "id", "slug"):
+            v = data.get(key)
+            if isinstance(v, str) and v:
+                return v
+    return ""
+
+
+def extract_changed_fields(payload: dict) -> dict:
+    """
+    Return the diff if CoinGecko provided one (`changes`, `diff`,
+    `changed_fields`). Otherwise pass the full payload through —
+    downstream queries can still inspect e.g. `payload->'platforms'`.
+    """
+    for key in ("changed_fields", "changes", "diff"):
+        v = payload.get(key)
+        if isinstance(v, dict):
+            return v
+    return payload
+
+
+def _alert_fields_touched(changed: dict) -> list[str]:
+    """Return the subset of ALERTING_FIELDS present in the diff."""
+    touched = []
+    for f in ALERTING_FIELDS:
+        if f in changed:
+            touched.append(f)
+            continue
+        data = changed.get("data")
+        if isinstance(data, dict) and f in data:
+            touched.append(f)
+    return touched
+
+
+# ---------------------------------------------------------------------------
+# Insert + attest
+# ---------------------------------------------------------------------------
+
+def _content_hash(raw_payload: bytes) -> str:
+    """SHA-256 of the exact bytes signed by the sender."""
+    return hashlib.sha256(raw_payload).hexdigest()
+
+
+def persist_event(
+    coingecko_id: str,
+    basis_entity_type: Optional[str],
+    basis_entity_id: Optional[str],
+    event_type: str,
+    changed_fields: dict,
+    raw_payload: dict,
+    content_hash: str,
+) -> Optional[str]:
+    """
+    Insert a coingecko_metadata_events row. Idempotent on content_hash —
+    a duplicate delivery returns the existing event_id.
+    """
+    event_id = str(uuid_mod.uuid4())
+    try:
+        existing = fetch_one(
+            "SELECT event_id FROM coingecko_metadata_events WHERE content_hash = %s",
+            (content_hash,),
+        )
+        if existing:
+            return str(existing["event_id"])
+        execute(
+            """
+            INSERT INTO coingecko_metadata_events
+                (event_id, coingecko_id, basis_entity_type, basis_entity_id,
+                 event_type, changed_fields, raw_payload, received_at, content_hash)
+            VALUES (%s, %s, %s, %s, %s, %s, %s, NOW(), %s)
+            ON CONFLICT (content_hash) DO NOTHING
+            """,
+            (
+                event_id,
+                coingecko_id,
+                basis_entity_type,
+                basis_entity_id,
+                event_type,
+                json.dumps(changed_fields, default=str),
+                json.dumps(raw_payload, default=str),
+                content_hash,
+            ),
+        )
+        return event_id
+    except Exception as e:
+        _record_cycle_error(
+            error_type="webhook_persist_failure",
+            error_message=str(e)[:2000],
+            cycle_phase="webhook_coingecko",
+        )
+        return None
+
+
+def attest_inline(
+    event_id: str,
+    coingecko_id: str,
+    basis_entity_type: Optional[str],
+    basis_entity_id: Optional[str],
+    content_hash: str,
+) -> None:
+    """
+    v9.12 module-canonical: the handler owns the attest_state call
+    for its domain. Single record per webhook delivery — the
+    content_hash + entity tuple is the canonical state.
+    """
+    from app.state_attestation import attest_state
+
+    record = {
+        "event_id": event_id,
+        "coingecko_id": coingecko_id,
+        "basis_entity_type": basis_entity_type,
+        "basis_entity_id": basis_entity_id,
+        "content_hash": content_hash,
+    }
+    try:
+        attest_state(
+            "coingecko_metadata_events",
+            [record],
+            entity_id=basis_entity_id,
+        )
+    except Exception as e:
+        _record_cycle_error(
+            error_type="webhook_attestation_failure",
+            error_message=str(e)[:2000],
+            cycle_phase="webhook_coingecko",
+        )
+
+
+async def maybe_alert(
+    coingecko_id: str,
+    basis_entity_type: Optional[str],
+    basis_entity_id: Optional[str],
+    changed_fields: dict,
+) -> None:
+    """Fire ops alert if `contract_address` or `platforms` changed."""
+    touched = _alert_fields_touched(changed_fields)
+    if not touched:
+        return
+    try:
+        from app.ops.tools.alerter import send_alert
+
+        message = (
+            f"CoinGecko metadata change on {coingecko_id}: "
+            f"{', '.join(touched)} mutated. "
+            f"basis_entity={basis_entity_type}:{basis_entity_id}. "
+            f"Review required — no auto-application."
+        )
+        # default=str per v9.12 lesson (Decimal/datetime safety in
+        # the alerter's own json.dumps path is already covered, but
+        # we pass primitives through our context to keep the
+        # serialization local).
+        context = {
+            "coingecko_id": coingecko_id,
+            "basis_entity_type": basis_entity_type,
+            "basis_entity_id": basis_entity_id,
+            "fields": touched,
+            "changed_fields": json.loads(
+                json.dumps(changed_fields, default=str)
+            ),
+        }
+        await send_alert(
+            alert_type="coingecko_metadata_change",
+            message=message,
+            context=context,
+            severity="critical",
+        )
+    except Exception as e:
+        _record_cycle_error(
+            error_type="webhook_alert_failure",
+            error_message=str(e)[:2000],
+            cycle_phase="webhook_coingecko",
+        )
+
+
+# ---------------------------------------------------------------------------
+# FastAPI handler
+# ---------------------------------------------------------------------------
+
+async def handle_webhook(request: Request) -> JSONResponse:
+    """
+    POST /api/webhooks/coingecko
+
+    - Reads raw body and verifies HMAC-SHA256 against
+      COINGECKO_WEBHOOK_SECRET. Mismatch → 401 + cycle_errors row.
+    - Parses JSON, persists row, resolves basis entity, attests
+      state, and (if applicable) fires ops alert.
+    - Returns 200 fast — the alert path runs async and never blocks
+      the ack.
+    """
+    raw = await request.body()
+    provided_sig = request.headers.get(SIGNATURE_HEADER) or request.headers.get(
+        SIGNATURE_HEADER.lower()
+    )
+    secret = os.environ.get(WEBHOOK_SECRET_ENV, "")
+
+    if not verify_signature(secret, raw, provided_sig):
+        _record_cycle_error(
+            error_type="webhook_signature_invalid",
+            error_message=(
+                f"CoinGecko webhook HMAC mismatch from "
+                f"{request.client.host if request.client else 'unknown'} "
+                f"sig_present={bool(provided_sig)} secret_configured={bool(secret)}"
+            ),
+            cycle_phase="webhook_coingecko",
+            severity="alert",
+        )
+        return JSONResponse(status_code=401, content={"status": "invalid_signature"})
+
+    try:
+        payload = json.loads(raw.decode("utf-8") or "{}")
+    except Exception as e:
+        _record_cycle_error(
+            error_type="webhook_payload_invalid",
+            error_message=f"json decode: {e}"[:2000],
+            cycle_phase="webhook_coingecko",
+        )
+        return JSONResponse(status_code=400, content={"status": "invalid_payload"})
+
+    coingecko_id = extract_coingecko_id(payload)
+    event_type = (
+        payload.get("event") or payload.get("event_type") or "cg.coin.info.updated"
+    )
+    changed_fields = extract_changed_fields(payload)
+    content_hash = _content_hash(raw)
+
+    basis_entity_type, basis_entity_id = resolve_basis_entity(coingecko_id)
+
+    event_id = persist_event(
+        coingecko_id=coingecko_id,
+        basis_entity_type=basis_entity_type,
+        basis_entity_id=basis_entity_id,
+        event_type=event_type,
+        changed_fields=changed_fields,
+        raw_payload=payload,
+        content_hash=content_hash,
+    )
+
+    if event_id is None:
+        return JSONResponse(
+            status_code=500, content={"status": "persist_failed"}
+        )
+
+    if basis_entity_type is None:
+        _record_cycle_error(
+            error_type="webhook_unmapped_slug",
+            error_message=(
+                f"coingecko_id={coingecko_id!r} not present in stablecoins "
+                f"or PROTOCOL_GOVERNANCE_TOKENS — event stored unmapped"
+            ),
+            cycle_phase="webhook_coingecko",
+        )
+
+    attest_inline(
+        event_id=event_id,
+        coingecko_id=coingecko_id,
+        basis_entity_type=basis_entity_type,
+        basis_entity_id=basis_entity_id,
+        content_hash=content_hash,
+    )
+
+    await maybe_alert(
+        coingecko_id=coingecko_id,
+        basis_entity_type=basis_entity_type,
+        basis_entity_id=basis_entity_id,
+        changed_fields=changed_fields,
+    )
+
+    return JSONResponse(
+        status_code=200,
+        content={
+            "status": "ok",
+            "event_id": event_id,
+            "basis_entity_type": basis_entity_type,
+            "basis_entity_id": basis_entity_id,
+        },
+    )

--- a/docs/coingecko_metadata_events_domain.md
+++ b/docs/coingecko_metadata_events_domain.md
@@ -1,0 +1,187 @@
+# Domain: `coingecko_metadata_events` — CoinGecko Webhook Subscriber
+
+**Date:** 2026-05-13
+**Status:** Proposed
+**Scope:** Additive — new attestation domain, no SII/PSI methodology change.
+**Closest precedent:** v9.9.8 chain-variant amendment (new attestation domain, no scoring path change).
+
+## Forcing function
+
+Basis ingests CoinGecko via hourly REST in the SII / PSI / CQI cycle. We
+have no signal when CoinGecko mutates constituent metadata (contract
+migrations, symbol / logo / name changes, platform additions). Today
+these are discovered reactively — the canonical case is the
+2026-05-05 punchlist Section C: the `exchange_trust_ratio` collector
+silently returning zero because a CoinGecko response shape changed
+and our parser swallowed it.
+
+The webhook stream is the substrate CoinGecko already maintains; we
+were not subscribed.
+
+## Decision
+
+A new attestation domain, `coingecko_metadata_events`, captures every
+`cg.coin.info.updated` delivery on the 36 SII slugs and 13 PSI
+governance-token slugs we currently track. The handler:
+
+1. **Verifies HMAC-SHA256** of the raw body against
+   `COINGECKO_WEBHOOK_SECRET`. Mismatches return 401 and write a
+   structured `cycle_errors` row with `error_type=webhook_signature_invalid`.
+
+2. **Persists** the event to `coingecko_metadata_events` (event_id,
+   coingecko_id, basis_entity_type, basis_entity_id, event_type,
+   changed_fields, raw_payload, received_at, content_hash). The table
+   uses `content_hash UNIQUE` for idempotency — CoinGecko's docs
+   describe at-least-once delivery, and re-deliveries are no-ops.
+
+3. **Resolves** `coingecko_id` to a Basis entity:
+   - Stablecoins: `SELECT id FROM stablecoins WHERE coingecko_id = %s`
+     → `("stablecoin", id)`.
+   - Protocols: reverse-lookup against
+     `app.collectors.psi_collector.PROTOCOL_GOVERNANCE_TOKENS`
+     (governance-token CG-id → protocol_slug) →
+     `("protocol", slug)`.
+   - Unmapped: writes the event with `basis_entity_type=NULL` and a
+     `cycle_errors` row with `error_type=webhook_unmapped_slug`. The
+     audit trail is still valuable; the row carries the raw payload
+     for forensic replay.
+
+4. **Attests state** inline via
+   `attest_state("coingecko_metadata_events", [record],
+   entity_id=basis_entity_id)`. The record contains the event_id,
+   coingecko_id, entity tuple, and content_hash — sufficient to
+   re-derive the receipt from raw_payload at any time.
+
+5. **Alerts** if `changed_fields` touches `contract_address` or
+   `platforms`. Sent through the existing
+   `app.ops.tools.alerter.send_alert` path with
+   `alert_type=coingecko_metadata_change`, `severity=critical`.
+   `json.dumps(context, default=str)` per the v9.12
+   Decimal/datetime-safety lesson.
+
+The handler returns 200 immediately on success; alert and attestation
+both run inside the request but are independently fault-isolated —
+each failure writes its own cycle_error and the 200 still goes back
+so CoinGecko doesn't redeliver unnecessarily.
+
+## What the handler explicitly does NOT do
+
+This is alert + audit trail, not a writer to constituent registries.
+
+- The `stablecoins` table is not touched. A new `contract_address` on
+  USDC does not update `stablecoins.contract`. A human review step is
+  intentional for now — auto-application is a follow-up, gated on
+  operator validation of the first N event payload shapes.
+- `rpi_protocol_config` is not touched. PSI scoring is unchanged.
+- The SII / PSI scoring path is unaffected. This domain is
+  provenance-adjacent metadata, not a scored component.
+- The hourly REST polling cadence is unchanged. Webhook is additive,
+  not a replacement.
+
+## Architecture fit
+
+| Aspect | Choice | Why |
+|--------|--------|-----|
+| Service | api-server (`app/server.py`) | Webhooks are request/response, not cycle-driven. The Scoring-Worker has no inbound HTTP. |
+| Module location | `app/webhooks/coingecko.py` | New package; matches the precedent that handlers are module-canonical (v9.12) and own their attestation. No dispatcher fallback. |
+| Attestation | Inline `attest_state` in the handler | Module-canonical per v9.12 — no orphan dispatcher heartbeat path. |
+| Error handling | Structured `cycle_errors` per failure mode | v9.12's silent-except-on-debug rule. No bare excepts. |
+| Idempotency | `content_hash UNIQUE` on the table | At-least-once delivery from CG; replay-safe. |
+
+## Schema
+
+Migration `110_coingecko_metadata_events.sql`:
+
+```sql
+CREATE TABLE coingecko_metadata_events (
+    event_id           UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    coingecko_id       TEXT NOT NULL,
+    basis_entity_type  TEXT,            -- 'stablecoin' | 'protocol' | NULL
+    basis_entity_id    TEXT,            -- stablecoins.id or protocol_slug
+    event_type         TEXT,            -- CG passthrough
+    changed_fields     JSONB,           -- diff if CG sends one, else full payload
+    raw_payload        JSONB NOT NULL,  -- verbatim, for replay
+    received_at        TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    content_hash       TEXT NOT NULL UNIQUE  -- sha256(raw_payload), idempotency
+);
+CREATE INDEX idx_cg_meta_events_cgid     ON coingecko_metadata_events (coingecko_id, received_at DESC);
+CREATE INDEX idx_cg_meta_events_entity   ON coingecko_metadata_events (basis_entity_type, basis_entity_id, received_at DESC);
+CREATE INDEX idx_cg_meta_events_received ON coingecko_metadata_events (received_at DESC);
+```
+
+## Configuration
+
+| Env var | Purpose | Required |
+|---------|---------|----------|
+| `COINGECKO_WEBHOOK_SECRET` | HMAC-SHA256 key shared with the CoinGecko subscription. | Yes — if unset the handler rejects all calls as unsigned. |
+| `COINGECKO_WEBHOOK_SIGNATURE_HEADER` | HTTP header name carrying the signature. | No — defaults to `x-cg-webhook-signature`. Configurable for CG header-name drift. |
+| `COINGECKO_WEBHOOK_CALLBACK_URL` | Public URL of `POST /api/webhooks/coingecko`. | Used only by the subscription script. |
+| `COINGECKO_API_KEY` | Existing pro-api key, reused by the subscription script. | Yes for `subscribe_webhooks.py`. |
+
+## Pre-flight (operator)
+
+Before running the subscription script:
+
+1. Confirm the production CoinGecko pro-api plan includes webhooks.
+   CoinGecko's product post claims access is already enabled for pro
+   tier; the script's `/api/v3/key` probe surfaces plan metadata if
+   the response includes it.
+2. Confirm CoinGecko's webhook signing scheme matches the verifier
+   (HMAC-SHA256, hex digest, raw body). The verifier accepts both the
+   bare hex digest and a `sha256=` prefix.
+
+## Subscription
+
+`scripts/coingecko/subscribe_webhooks.py` registers the subscription
+for every scoring-enabled stablecoin slug (from the DB; falls back to
+`STABLECOIN_REGISTRY`) plus every value in
+`PROTOCOL_GOVERNANCE_TOKENS`. Idempotent — existing subscriptions on
+the same `(event, coin_id, callback_url)` tuple are detected via a
+GET probe and skipped. Safe to re-run after coin promotions.
+
+```bash
+export COINGECKO_API_KEY=...
+export COINGECKO_WEBHOOK_SECRET=...
+export COINGECKO_WEBHOOK_CALLBACK_URL=https://hub.basis.../api/webhooks/coingecko
+python scripts/coingecko/subscribe_webhooks.py --dry-run
+python scripts/coingecko/subscribe_webhooks.py
+```
+
+## Halt criteria (substrate-verifiable, 24h post-merge)
+
+```sql
+-- Deliveries are arriving. Zero is acceptable if no constituent metadata
+-- changed in 24h; log a note in the wave summary if zero.
+SELECT COUNT(*) FROM coingecko_metadata_events
+WHERE received_at > NOW() - INTERVAL '24 hours';
+
+-- Signature verifier is correct. Non-zero means either an attacker is
+-- probing the endpoint or our verifier disagrees with CG's signing.
+SELECT COUNT(*) FROM cycle_errors
+WHERE error_type = 'webhook_signature_invalid'
+  AND occurred_at > NOW() - INTERVAL '24 hours';
+-- Expected: 0.
+
+-- Attestation domain is wired and reaching state_attestations.
+SELECT MAX(cycle_timestamp), NOW() - MAX(cycle_timestamp)
+FROM state_attestations
+WHERE domain = 'coingecko_metadata_events';
+-- Expected: non-null. Null means attestation isn't firing.
+```
+
+## Out-of-scope follow-ups
+
+- Auto-application of contract migrations to `stablecoins` / `rpi_protocol_config`. Gated on operator review of the first N events to validate payload shape.
+- Webhook subscription for chain-variant changes (the v9.9.8 surface) — natural extension once the canonical flow is stable.
+- Equivalent subscribers for DeFiLlama or Etherscan if either publishes a comparable event stream.
+
+## References
+
+- v9.9.8 chain-variant constitution amendment — closest precedent for additive attestation domain.
+- v9.12 module-canonical live path — handler owns its own attestation; no dispatcher fallback.
+- 2026-05-05 punchlist Section C — the reactive-discovery incident that forced this.
+- Migration: `migrations/110_coingecko_metadata_events.sql`.
+- Handler: `app/webhooks/coingecko.py`.
+- Route: `app/server.py` — `POST /api/webhooks/coingecko`.
+- Subscriber: `scripts/coingecko/subscribe_webhooks.py`.
+- Tests: `tests/test_coingecko_webhook.py`.

--- a/migrations/110_coingecko_metadata_events.sql
+++ b/migrations/110_coingecko_metadata_events.sql
@@ -1,0 +1,57 @@
+-- Migration 110: CoinGecko metadata-change webhook events
+--
+-- Net-new attestation domain for CoinGecko's `cg.coin.info.updated`
+-- webhook stream. Same shape as v9.9.8 chain_variant_state — additive
+-- schema, new attestation domain, no SII/PSI methodology change.
+--
+-- Purpose: capture constituent metadata mutations (contract migrations,
+-- symbol / logo / name changes, platform additions) at the moment
+-- CoinGecko sees them, so we no longer discover them reactively via a
+-- silently-failing parser. The table is provenance-adjacent — alert +
+-- audit trail, NOT a writer to the stablecoins or rpi_protocol_config
+-- registries. Auto-application of contract migrations is a deliberate
+-- follow-up gated on operator review of the first N events.
+--
+-- Columns:
+--   event_id            uuid PK     — server-generated, idempotent insert
+--   coingecko_id        text        — slug from payload (e.g. "usd-coin")
+--   basis_entity_type   text        — 'stablecoin' | 'protocol' | NULL
+--   basis_entity_id     text        — stablecoins.id or protocol_slug
+--   event_type          text        — CG passthrough (e.g. "cg.coin.info.updated")
+--   changed_fields      jsonb       — diff if CG sends one, else full payload
+--   raw_payload         jsonb       — verbatim body for replay
+--   received_at         timestamptz — server receive time
+--   content_hash        text        — sha256 of raw_payload, prevents dup
+--
+-- Idempotency: content_hash is UNIQUE. Re-delivery from CG (their docs
+-- mention at-least-once) inserts no row on duplicate hash.
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM information_schema.tables
+        WHERE table_schema = 'public'
+          AND table_name = 'coingecko_metadata_events'
+    ) THEN
+        CREATE TABLE coingecko_metadata_events (
+            event_id           UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+            coingecko_id       TEXT NOT NULL,
+            basis_entity_type  TEXT,
+            basis_entity_id    TEXT,
+            event_type         TEXT,
+            changed_fields     JSONB,
+            raw_payload        JSONB NOT NULL,
+            received_at        TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+            content_hash       TEXT NOT NULL UNIQUE
+        );
+
+        CREATE INDEX IF NOT EXISTS idx_cg_meta_events_cgid
+            ON coingecko_metadata_events (coingecko_id, received_at DESC);
+        CREATE INDEX IF NOT EXISTS idx_cg_meta_events_entity
+            ON coingecko_metadata_events (basis_entity_type, basis_entity_id, received_at DESC);
+        CREATE INDEX IF NOT EXISTS idx_cg_meta_events_received
+            ON coingecko_metadata_events (received_at DESC);
+    END IF;
+END $$;
+
+INSERT INTO migrations (name) VALUES ('110_coingecko_metadata_events') ON CONFLICT DO NOTHING;

--- a/scripts/coingecko/subscribe_webhooks.py
+++ b/scripts/coingecko/subscribe_webhooks.py
@@ -1,0 +1,217 @@
+#!/usr/bin/env python3
+"""
+Register the basis-hub `cg.coin.info.updated` subscription against
+CoinGecko's webhook API for every scoring-enabled stablecoin slug and
+every PSI protocol governance-token slug.
+
+Idempotent: existing subscriptions for the same (event, coin_id,
+callback_url) tuple are detected via a GET probe and skipped. Safe to
+re-run after coin promotions or rotations.
+
+Usage:
+    export COINGECKO_API_KEY=...                          # pro-api key
+    export COINGECKO_WEBHOOK_SECRET=...                   # subscription HMAC secret
+    export COINGECKO_WEBHOOK_CALLBACK_URL=https://hub.example/api/webhooks/coingecko
+    python scripts/coingecko/subscribe_webhooks.py
+    python scripts/coingecko/subscribe_webhooks.py --dry-run
+
+Pre-flight reminder (per task spec): confirm the production CoinGecko
+pro-api plan supports webhooks before running. The script reports
+which plan the key is attached to via `/api/v3/key` if the response
+includes plan metadata.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import sys
+import time
+from typing import Optional
+
+import httpx
+
+logger = logging.getLogger("subscribe_webhooks")
+logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s] %(message)s")
+
+CG_PRO_BASE = "https://pro-api.coingecko.com/api/v3"
+EVENT_NAME = "cg.coin.info.updated"
+
+
+def _require_env(name: str) -> str:
+    val = os.environ.get(name, "").strip()
+    if not val:
+        logger.error(f"Missing required env: {name}")
+        sys.exit(2)
+    return val
+
+
+def _stablecoin_slugs() -> list[str]:
+    """All scoring-enabled stablecoin coingecko_ids from the DB.
+
+    DB is the authoritative registry (auto-promotion fills it). Falls
+    back to STABLECOIN_REGISTRY if DB is unreachable so the script is
+    runnable from a workstation without DATABASE_URL.
+    """
+    try:
+        from app.database import fetch_all
+        rows = fetch_all(
+            "SELECT coingecko_id FROM stablecoins "
+            "WHERE scoring_enabled = TRUE AND coingecko_id IS NOT NULL "
+            "ORDER BY coingecko_id"
+        ) or []
+        slugs = [r["coingecko_id"] for r in rows if r.get("coingecko_id")]
+        if slugs:
+            return slugs
+    except Exception as e:
+        logger.warning(f"DB stablecoin lookup failed, falling back to registry: {e}")
+
+    from app.config import STABLECOIN_REGISTRY
+    return [cfg["coingecko_id"] for cfg in STABLECOIN_REGISTRY.values() if cfg.get("coingecko_id")]
+
+
+def _protocol_slugs() -> list[str]:
+    """All PSI protocol governance-token coingecko_ids."""
+    from app.collectors.psi_collector import PROTOCOL_GOVERNANCE_TOKENS
+    return sorted({v for v in PROTOCOL_GOVERNANCE_TOKENS.values() if v})
+
+
+def _headers(api_key: str) -> dict:
+    return {
+        "Accept": "application/json",
+        "Content-Type": "application/json",
+        "x-cg-pro-api-key": api_key,
+    }
+
+
+def _list_existing(client: httpx.Client, api_key: str) -> list[dict]:
+    """
+    Fetch existing webhook subscriptions. CoinGecko's webhook list
+    endpoint path may differ by plan — we try the documented form and
+    return [] if the endpoint isn't reachable (the create path is
+    still safe because we tolerate 409/conflict on create).
+    """
+    candidates = ["/webhooks", "/webhook/subscriptions", "/webhook/list"]
+    for path in candidates:
+        try:
+            r = client.get(f"{CG_PRO_BASE}{path}", headers=_headers(api_key), timeout=15.0)
+            if r.status_code == 200:
+                data = r.json()
+                if isinstance(data, list):
+                    return data
+                if isinstance(data, dict) and isinstance(data.get("subscriptions"), list):
+                    return data["subscriptions"]
+            logger.debug(f"list probe {path} → {r.status_code}")
+        except Exception as e:
+            logger.debug(f"list probe {path} failed: {e}")
+    return []
+
+
+def _already_subscribed(existing: list[dict], coin_id: str, callback_url: str) -> bool:
+    for sub in existing:
+        if not isinstance(sub, dict):
+            continue
+        same_event = sub.get("event") == EVENT_NAME or sub.get("event_name") == EVENT_NAME
+        same_coin = sub.get("coin_id") == coin_id or sub.get("slug") == coin_id
+        same_cb = sub.get("callback_url") == callback_url or sub.get("url") == callback_url
+        if same_event and same_coin and same_cb:
+            return True
+    return False
+
+
+def _subscribe(
+    client: httpx.Client,
+    api_key: str,
+    coin_id: str,
+    callback_url: str,
+    secret: str,
+    dry_run: bool,
+) -> tuple[bool, str]:
+    """Create a single subscription. Returns (ok, status_msg)."""
+    body = {
+        "event": EVENT_NAME,
+        "coin_id": coin_id,
+        "callback_url": callback_url,
+        "secret": secret,
+    }
+    if dry_run:
+        return True, "dry_run"
+
+    candidates = ["/webhooks", "/webhook/subscriptions"]
+    last_err = ""
+    for path in candidates:
+        try:
+            r = client.post(
+                f"{CG_PRO_BASE}{path}",
+                headers=_headers(api_key),
+                content=json.dumps(body),
+                timeout=20.0,
+            )
+            if r.status_code in (200, 201):
+                return True, f"created via {path}"
+            if r.status_code == 409:
+                return True, f"already_exists via {path}"
+            last_err = f"{path} → {r.status_code}: {r.text[:200]}"
+        except Exception as e:
+            last_err = f"{path} exc: {e}"
+    return False, last_err
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--dry-run", action="store_true", help="Print plan, do not POST.")
+    args = parser.parse_args()
+
+    api_key = _require_env("COINGECKO_API_KEY")
+    secret = _require_env("COINGECKO_WEBHOOK_SECRET")
+    callback_url = _require_env("COINGECKO_WEBHOOK_CALLBACK_URL")
+
+    stablecoin_slugs = _stablecoin_slugs()
+    protocol_slugs = _protocol_slugs()
+    all_slugs = sorted(set(stablecoin_slugs) | set(protocol_slugs))
+
+    logger.info(
+        f"Plan: subscribe to {EVENT_NAME} for "
+        f"{len(stablecoin_slugs)} stablecoin slugs + "
+        f"{len(protocol_slugs)} protocol slugs "
+        f"({len(all_slugs)} unique). callback={callback_url} dry_run={args.dry_run}"
+    )
+
+    with httpx.Client() as client:
+        try:
+            key_check = client.get(f"{CG_PRO_BASE}/key", headers=_headers(api_key), timeout=15.0)
+            if key_check.status_code == 200:
+                logger.info(f"key metadata: {key_check.text[:300]}")
+            else:
+                logger.warning(f"key probe → {key_check.status_code}: {key_check.text[:200]}")
+        except Exception as e:
+            logger.warning(f"key probe failed: {e}")
+
+        existing = _list_existing(client, api_key)
+        logger.info(f"existing subscriptions discovered: {len(existing)}")
+
+        created = 0
+        skipped = 0
+        failed = 0
+        for slug in all_slugs:
+            if _already_subscribed(existing, slug, callback_url):
+                logger.info(f"  [skip] {slug} already subscribed")
+                skipped += 1
+                continue
+            ok, msg = _subscribe(client, api_key, slug, callback_url, secret, args.dry_run)
+            if ok:
+                logger.info(f"  [ok]   {slug} — {msg}")
+                created += 1
+            else:
+                logger.error(f"  [fail] {slug} — {msg}")
+                failed += 1
+            time.sleep(0.1)  # gentle on the API
+
+    logger.info(f"done: created={created} skipped={skipped} failed={failed}")
+    return 0 if failed == 0 else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_coingecko_webhook.py
+++ b/tests/test_coingecko_webhook.py
@@ -1,0 +1,355 @@
+"""
+Unit tests for the CoinGecko webhook handler.
+
+Covers the four required scenarios:
+  1. Valid signature → 200 + row inserted + attest_state called
+  2. Invalid signature → 401 + cycle_errors row written
+  3. Unmapped slug → 200 + row inserted with null basis_entity_id + cycle_errors row
+  4. contract_address change → ops alert fired
+
+These tests exercise the handler logic directly via mocked DB
+helpers — the table doesn't need to exist for the tests to run, and
+they don't require a live FastAPI server.
+"""
+
+import asyncio
+import hashlib
+import hmac
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Test helpers
+# ---------------------------------------------------------------------------
+
+SECRET = "test-secret-do-not-use-in-prod"
+
+
+def _sign(body: bytes, secret: str = SECRET) -> str:
+    return hmac.new(secret.encode("utf-8"), body, hashlib.sha256).hexdigest()
+
+
+class _CaseInsensitiveHeaders:
+    """Mimic Starlette's case-insensitive headers .get()."""
+    def __init__(self, headers: dict):
+        self._h = {k.lower(): v for k, v in headers.items()}
+
+    def get(self, key, default=None):
+        return self._h.get(key.lower(), default)
+
+
+def _mock_request(body_bytes: bytes, headers: dict | None = None) -> MagicMock:
+    """Build a minimal FastAPI-shaped Request mock."""
+    req = MagicMock()
+    req.body = AsyncMock(return_value=body_bytes)
+    req.headers = _CaseInsensitiveHeaders(headers or {})
+    req.client = MagicMock(host="127.0.0.1")
+    return req
+
+
+def _run(coro):
+    return asyncio.get_event_loop().run_until_complete(coro)
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+def test_signature_verification_constant_time():
+    """verify_signature accepts hex digest and sha256= prefix; rejects garbage."""
+    from app.webhooks.coingecko import verify_signature
+
+    body = b'{"coin_id":"usd-coin"}'
+    good = _sign(body)
+
+    assert verify_signature(SECRET, body, good) is True
+    assert verify_signature(SECRET, body, f"sha256={good}") is True
+    assert verify_signature(SECRET, body, "deadbeef") is False
+    assert verify_signature(SECRET, body, "") is False
+    assert verify_signature("", body, good) is False
+
+
+def test_valid_signature_inserts_row_and_attests(monkeypatch):
+    """Happy path: valid sig → 200, row inserted, attest_state called."""
+    monkeypatch.setenv("COINGECKO_WEBHOOK_SECRET", SECRET)
+    from app.webhooks import coingecko as cg
+
+    payload = {
+        "event": "cg.coin.info.updated",
+        "coin_id": "usd-coin",
+        "changed_fields": {"name": "USD Coin (updated)"},
+    }
+    raw = json.dumps(payload).encode("utf-8")
+    sig = _sign(raw)
+
+    req = _mock_request(raw, headers={cg.SIGNATURE_HEADER: sig})
+
+    def _fetch_one(sql, params=None):
+        if "FROM coingecko_metadata_events" in sql:
+            return None  # idempotency check: no existing row
+        if "FROM stablecoins" in sql:
+            return {"id": "usdc"}
+        return None
+
+    with patch.object(cg, "fetch_one", side_effect=_fetch_one) as mock_fetch, \
+         patch.object(cg, "execute") as mock_exec, \
+         patch("app.state_attestation.attest_state") as mock_attest, \
+         patch.object(cg, "_record_cycle_error") as mock_err, \
+         patch("app.ops.tools.alerter.send_alert", new_callable=AsyncMock) as mock_alert:
+
+        resp = _run(cg.handle_webhook(req))
+
+        assert resp.status_code == 200
+        body = json.loads(resp.body)
+        assert body["status"] == "ok"
+        assert body["basis_entity_type"] == "stablecoin"
+        assert body["basis_entity_id"] == "usdc"
+        assert body["event_id"]
+
+        # Insert happened
+        insert_calls = [c for c in mock_exec.call_args_list
+                        if "INSERT INTO coingecko_metadata_events" in c.args[0]]
+        assert len(insert_calls) == 1, f"expected 1 insert, got {len(insert_calls)}"
+
+        # Attestation happened
+        mock_attest.assert_called_once()
+        attest_args = mock_attest.call_args
+        assert attest_args.args[0] == "coingecko_metadata_events"
+        records = attest_args.args[1]
+        assert len(records) == 1
+        assert records[0]["coingecko_id"] == "usd-coin"
+        assert records[0]["basis_entity_id"] == "usdc"
+
+        # No cycle_errors for happy path
+        mock_err.assert_not_called()
+
+        # No alert — changed_fields didn't touch contract_address or platforms
+        mock_alert.assert_not_called()
+
+
+def test_invalid_signature_returns_401_and_logs_cycle_error(monkeypatch):
+    """Bad sig → 401, cycle_errors row written, no insert, no attestation."""
+    monkeypatch.setenv("COINGECKO_WEBHOOK_SECRET", SECRET)
+    from app.webhooks import coingecko as cg
+
+    raw = b'{"coin_id":"usd-coin"}'
+    req = _mock_request(raw, headers={cg.SIGNATURE_HEADER: "wrong-hex"})
+
+    with patch.object(cg, "execute") as mock_exec, \
+         patch("app.state_attestation.attest_state") as mock_attest, \
+         patch.object(cg, "_record_cycle_error") as mock_err:
+
+        resp = _run(cg.handle_webhook(req))
+
+        assert resp.status_code == 401
+        body = json.loads(resp.body)
+        assert body["status"] == "invalid_signature"
+
+        # cycle_errors recorded with the right error_type
+        mock_err.assert_called_once()
+        kwargs = mock_err.call_args.kwargs
+        assert kwargs["error_type"] == "webhook_signature_invalid"
+        assert kwargs["cycle_phase"] == "webhook_coingecko"
+
+        # No insert, no attestation
+        insert_calls = [c for c in mock_exec.call_args_list
+                        if "INSERT INTO coingecko_metadata_events" in c.args[0]]
+        assert len(insert_calls) == 0
+        mock_attest.assert_not_called()
+
+
+def test_unmapped_slug_inserts_with_null_entity_and_logs_cycle_error(monkeypatch):
+    """Unknown coingecko_id → 200, row inserted with NULL entity, cycle_errors row."""
+    monkeypatch.setenv("COINGECKO_WEBHOOK_SECRET", SECRET)
+    from app.webhooks import coingecko as cg
+
+    payload = {
+        "event": "cg.coin.info.updated",
+        "coin_id": "some-token-we-dont-track",
+        "changed_fields": {"description": "x"},
+    }
+    raw = json.dumps(payload).encode("utf-8")
+    sig = _sign(raw)
+    req = _mock_request(raw, headers={cg.SIGNATURE_HEADER: sig})
+
+    # fetch_one returns None (no stablecoin match); PROTOCOL_GOVERNANCE_TOKENS
+    # is a real dict — "some-token-we-dont-track" won't be a value in it.
+    with patch.object(cg, "fetch_one", return_value=None), \
+         patch.object(cg, "execute") as mock_exec, \
+         patch("app.state_attestation.attest_state") as mock_attest, \
+         patch.object(cg, "_record_cycle_error") as mock_err:
+
+        resp = _run(cg.handle_webhook(req))
+
+        assert resp.status_code == 200
+        body = json.loads(resp.body)
+        assert body["status"] == "ok"
+        assert body["basis_entity_type"] is None
+        assert body["basis_entity_id"] is None
+
+        # Row was still inserted (we want the audit trail even for unmapped slugs)
+        insert_calls = [c for c in mock_exec.call_args_list
+                        if "INSERT INTO coingecko_metadata_events" in c.args[0]]
+        assert len(insert_calls) == 1
+        insert_params = insert_calls[0].args[1]
+        # tuple positions: event_id, coingecko_id, basis_entity_type, basis_entity_id, ...
+        assert insert_params[1] == "some-token-we-dont-track"
+        assert insert_params[2] is None  # basis_entity_type
+        assert insert_params[3] is None  # basis_entity_id
+
+        # cycle_errors row with webhook_unmapped_slug
+        err_calls = [c for c in mock_err.call_args_list
+                     if c.kwargs.get("error_type") == "webhook_unmapped_slug"]
+        assert len(err_calls) == 1
+
+        # Attestation still fired — provenance value is in the receipt itself
+        mock_attest.assert_called_once()
+
+
+def test_contract_address_change_fires_alert(monkeypatch):
+    """contract_address mutation → send_alert called with severity=critical."""
+    monkeypatch.setenv("COINGECKO_WEBHOOK_SECRET", SECRET)
+    from app.webhooks import coingecko as cg
+
+    payload = {
+        "event": "cg.coin.info.updated",
+        "coin_id": "tether",
+        "changed_fields": {
+            "contract_address": {
+                "before": "0xdac17f958d2ee523a2206206994597c13d831ec7",
+                "after": "0xNEWADDRESS00000000000000000000000000000",
+            },
+        },
+    }
+    raw = json.dumps(payload).encode("utf-8")
+    sig = _sign(raw)
+    req = _mock_request(raw, headers={cg.SIGNATURE_HEADER: sig})
+
+    def _fetch_one(sql, params=None):
+        if "FROM coingecko_metadata_events" in sql:
+            return None
+        if "FROM stablecoins" in sql:
+            return {"id": "usdt"}
+        return None
+
+    with patch.object(cg, "fetch_one", side_effect=_fetch_one), \
+         patch.object(cg, "execute"), \
+         patch("app.state_attestation.attest_state"), \
+         patch.object(cg, "_record_cycle_error"), \
+         patch("app.ops.tools.alerter.send_alert", new_callable=AsyncMock) as mock_alert:
+
+        resp = _run(cg.handle_webhook(req))
+
+        assert resp.status_code == 200
+        mock_alert.assert_awaited_once()
+        kwargs = mock_alert.call_args.kwargs
+        assert kwargs["alert_type"] == "coingecko_metadata_change"
+        assert kwargs["severity"] == "critical"
+        assert "contract_address" in kwargs["context"]["fields"]
+        assert kwargs["context"]["basis_entity_id"] == "usdt"
+
+
+def test_platforms_change_fires_alert(monkeypatch):
+    """platforms mutation (chain additions) also fires alert."""
+    monkeypatch.setenv("COINGECKO_WEBHOOK_SECRET", SECRET)
+    from app.webhooks import coingecko as cg
+
+    payload = {
+        "event": "cg.coin.info.updated",
+        "coin_id": "usd-coin",
+        "changed_fields": {
+            "platforms": {"new_chain": "0xabc..."},
+        },
+    }
+    raw = json.dumps(payload).encode("utf-8")
+    sig = _sign(raw)
+    req = _mock_request(raw, headers={cg.SIGNATURE_HEADER: sig})
+
+    def _fetch_one(sql, params=None):
+        if "FROM coingecko_metadata_events" in sql:
+            return None
+        if "FROM stablecoins" in sql:
+            return {"id": "usdc"}
+        return None
+
+    with patch.object(cg, "fetch_one", side_effect=_fetch_one), \
+         patch.object(cg, "execute"), \
+         patch("app.state_attestation.attest_state"), \
+         patch.object(cg, "_record_cycle_error"), \
+         patch("app.ops.tools.alerter.send_alert", new_callable=AsyncMock) as mock_alert:
+
+        resp = _run(cg.handle_webhook(req))
+
+        assert resp.status_code == 200
+        mock_alert.assert_awaited_once()
+        assert "platforms" in mock_alert.call_args.kwargs["context"]["fields"]
+
+
+def test_duplicate_delivery_is_idempotent(monkeypatch):
+    """Same content_hash arriving twice → second insert is a no-op."""
+    monkeypatch.setenv("COINGECKO_WEBHOOK_SECRET", SECRET)
+    from app.webhooks import coingecko as cg
+
+    payload = {"event": "cg.coin.info.updated", "coin_id": "usd-coin",
+               "changed_fields": {"name": "x"}}
+    raw = json.dumps(payload).encode("utf-8")
+    sig = _sign(raw)
+    req = _mock_request(raw, headers={cg.SIGNATURE_HEADER: sig})
+
+    # fetch_one returns the existing event row first (idempotency
+    # guard), then returns the stablecoin mapping is not reached.
+    existing_event = {"event_id": "00000000-0000-0000-0000-000000000001"}
+
+    def _fetch_one_side_effect(sql, params=None):
+        if "FROM coingecko_metadata_events" in sql:
+            return existing_event
+        if "FROM stablecoins" in sql:
+            return {"id": "usdc"}
+        return None
+
+    with patch.object(cg, "fetch_one", side_effect=_fetch_one_side_effect), \
+         patch.object(cg, "execute") as mock_exec, \
+         patch("app.state_attestation.attest_state"), \
+         patch.object(cg, "_record_cycle_error"):
+
+        resp = _run(cg.handle_webhook(req))
+
+        assert resp.status_code == 200
+        # No INSERT executed because dup was detected
+        insert_calls = [c for c in mock_exec.call_args_list
+                        if "INSERT INTO coingecko_metadata_events" in c.args[0]]
+        assert len(insert_calls) == 0
+        # Returned the same event_id as the existing row
+        body = json.loads(resp.body)
+        assert body["event_id"] == existing_event["event_id"]
+
+
+def test_resolve_basis_entity_stablecoin(monkeypatch):
+    """resolve_basis_entity returns ('stablecoin', id) for known CG ids."""
+    from app.webhooks import coingecko as cg
+
+    with patch.object(cg, "fetch_one", return_value={"id": "usdc"}):
+        assert cg.resolve_basis_entity("usd-coin") == ("stablecoin", "usdc")
+
+
+def test_resolve_basis_entity_protocol():
+    """resolve_basis_entity reverse-maps governance-token CG ids."""
+    from app.webhooks import coingecko as cg
+
+    with patch.object(cg, "fetch_one", return_value=None):
+        # "aave" is in PROTOCOL_GOVERNANCE_TOKENS with key "aave" → "aave"
+        result = cg.resolve_basis_entity("aave")
+        assert result[0] == "protocol"
+        assert result[1] == "aave"
+
+
+def test_resolve_basis_entity_unmapped():
+    """resolve_basis_entity returns (None, None) for unknown slugs."""
+    from app.webhooks import coingecko as cg
+
+    with patch.object(cg, "fetch_one", return_value=None):
+        assert cg.resolve_basis_entity("totally-made-up") == (None, None)
+        assert cg.resolve_basis_entity("") == (None, None)


### PR DESCRIPTION
## Summary

Net-new attestation domain `coingecko_metadata_events` captures constituent metadata mutations (contract migrations, symbol / logo / name changes, platforms) on the SII + PSI slugs the hub tracks. Replaces the reactive-discovery loop (parser swallows a CG shape change → silent zero, the 2026-05-05 punchlist §C class) with a push receipt, audit trail, and ops alert on `contract_address` or `platforms` changes.

Provenance-adjacent only — handler does **not** write to `stablecoins` or `rpi_protocol_config`. Auto-application is a deliberate follow-up gated on operator review of the first N event payloads.

## Architecture fit

- **v9.9.8 precedent** — additive attestation domain, no SII/PSI methodology change.
- **v9.12 module-canonical** — `app/webhooks/coingecko.py` owns the inline `attest_state` call; no dispatcher heartbeat path.
- **Structured `cycle_errors`** on `webhook_signature_invalid` and `webhook_unmapped_slug` per silent-except-on-debug rule. No bare excepts.
- **Endpoint lives on api-server**, not Scoring-Worker — webhooks are request/response, not cycle-driven.

## Changes

- `migrations/110_coingecko_metadata_events.sql` — UUID PK + `content_hash UNIQUE` for at-least-once idempotency; indexes on `(coingecko_id, received_at)` and `(basis_entity_type, basis_entity_id, received_at)`.
- `app/webhooks/coingecko.py` — HMAC-SHA256 verifier (bare hex or `sha256=` prefix), persist + resolve + inline `attest_state` + alerter.
- `app/server.py` — `POST /api/webhooks/coingecko` route, slotted next to the existing CDA monitor webhook.
- `scripts/coingecko/subscribe_webhooks.py` — idempotent registration over scoring-enabled stablecoin slugs (from DB, fallback to `STABLECOIN_REGISTRY`) and `PROTOCOL_GOVERNANCE_TOKENS` values; `--dry-run` flag.
- `tests/test_coingecko_webhook.py` — 10 unit tests covering valid sig, invalid sig (401 + `cycle_errors`), unmapped slug (200 + null entity + `cycle_errors`), `contract_address` alert, `platforms` alert, duplicate-delivery idempotency, and entity resolution. All pass locally.
- `docs/coingecko_metadata_events_domain.md` — domain spec + halt-criteria SQL.

## Test plan

- [ ] CI green.
- [ ] After deploy, confirm migration applied: `SELECT 1 FROM migrations WHERE name = '110_coingecko_metadata_events'`.
- [ ] Set `COINGECKO_WEBHOOK_SECRET` and `COINGECKO_WEBHOOK_CALLBACK_URL` in prod env.
- [ ] Pre-flight confirm CG pro-api plan supports webhooks via the script's `/api/v3/key` probe.
- [ ] `python scripts/coingecko/subscribe_webhooks.py --dry-run` first; then live.
- [ ] 24h halt criteria (in `docs/coingecko_metadata_events_domain.md`):
  - `SELECT COUNT(*) FROM coingecko_metadata_events WHERE received_at > NOW() - INTERVAL '24 hours'` — ≥1 expected if any constituent metadata changed; zero acceptable but log a note.
  - `SELECT COUNT(*) FROM cycle_errors WHERE error_type = 'webhook_signature_invalid' AND occurred_at > NOW() - INTERVAL '24 hours'` — expected 0.
  - `SELECT MAX(cycle_timestamp), NOW() - MAX(cycle_timestamp) FROM state_attestations WHERE domain = 'coingecko_metadata_events'` — expected non-null.

## Out-of-scope follow-ups (intentional)

- Auto-application of contract migrations to `stablecoins` / `rpi_protocol_config` — gated on operator review of first N events.
- Webhook subscription for chain-variant changes (v9.9.8 surface) — natural extension once canonical flow is stable.
- Equivalent subscribers for DeFiLlama / Etherscan if either publishes a comparable stream.

## Notes for reviewer

- `CLAUDE.md` says "next migration: 085" but the actual `migrations/` directory is at 109 — used **110**.
- `COINGECKO_WEBHOOK_SIGNATURE_HEADER` defaults to `x-cg-webhook-signature` and is env-overridable so we can follow CG header-name drift without a code change.
- Verifier accepts both the bare hex digest and a `sha256=<hex>` prefix.

---
_Generated by [Claude Code](https://claude.ai/code/session_015QPK4ud7HH9nb6eMwnbJRv)_