### PR TITLE
fix(v9.12): hoist cda_extractions wrapper to LIVE-PATH (#220)

### DIFF
--- a/app/enrichment_worker.py
+++ b/app/enrichment_worker.py
@@ -670,8 +670,17 @@ async def run_enrichment_pipeline() -> dict:
     # ---- CDA collection ----
 
     async def _run_cda():
-        from app.services.cda_collector import run_collection
-        result = await run_collection()
+        # v9.12 module-canonical: scheduler wrapper attests
+        # skipped_fresh / ran / error inline. Hoisted here from the
+        # LEGACY-DEAD-CODE site in main.py:163 per #225 Phase 0
+        # classification — enrichment_worker is on the LIVE-PATH (run by
+        # Dockerfile.worker via app.worker). Fixes #220 regression
+        # introduced by #212. Do NOT re-attest in this task. The outer
+        # _db_gate (min_hours=24) is preserved; the wrapper's internal
+        # 23h gate is strictly tighter, so when this task fires, the
+        # wrapper enters the ran branch and emits a per-run attestation.
+        from app.services.cda_collector import run_collection_scheduled
+        result = await run_collection_scheduled()
         logger.info(f"[enrichment] cda_collection result: {result}")
         return result
 

--- a/app/worker.py
+++ b/app/worker.py
@@ -1882,9 +1882,16 @@ async def run_slow_cycle():
 
         if cda_age_hours >= cda_interval_hours:
             logger.info("Running CDA collection pipeline...")
-            from app.services.cda_collector import run_collection
-            await run_collection()
-            logger.info("CDA collection complete")
+            # v9.12 module-canonical: scheduler wrapper attests
+            # skipped_fresh / ran / error inline. Hoisted here from the
+            # LEGACY-DEAD-CODE site in main.py:163 per #225 Phase 0
+            # classification — Dockerfile.worker runs app.worker directly,
+            # so this is the LIVE-PATH scheduler. Fixes #220 regression
+            # introduced by #212 (wrapper added but never on the live
+            # writer path). Do NOT re-attest here.
+            from app.services.cda_collector import run_collection_scheduled
+            cda_result = await run_collection_scheduled()
+            logger.info(f"CDA collection complete: {cda_result.get('status')}")
         else:
             logger.info(f"CDA collection skipped — last ran {cda_age_hours:.1f}h ago")
     except Exception as e:


### PR DESCRIPTION
## Summary

PR #212 added `run_collection_scheduled()` in `app/services/cda_collector.py` — a scheduler wrapper that attests `state_attestations.domain='cda_extractions'` on every branch (`skipped_fresh` / `ran` / `error`) and threads a ContextVar push-counter through `_store_extraction`. But #212 only swapped the call site at `main.py:163`, which #225 Phase 0 reclassified as **LEGACY-DEAD-CODE**:

- `Dockerfile.api:19` sets `WORKER_ENABLED=false`
- `Dockerfile.worker:15` runs `app.worker` directly (`app/worker.py:3703`)
- `main.py:848-851` only starts `run_worker_loop` when `WORKER_ENABLED=true` — never true

So the wrapper has never fired in production. The LIVE-PATH writers were still calling bare `run_collection()`:

- `app/worker.py:1886` (slow-cycle CDA branch)
- `app/enrichment_worker.py:674` (enrichment task `_run_cda`)

This PR hoists both LIVE-PATH bare calls to `run_collection_scheduled()`. `main.py:163` is left as-is (cosmetic dead-code site).

Both call sites are already `async`/`await` contexts and the wrapper's signature is a drop-in replacement — no adapter needed.

Closes #220
Refs #212, #225

## Substrate verification

### Pre-deploy

Raw output from `mcp__neon__run_sql` against project `small-scene-57890564` (BasisProtocol):

```sql
SELECT COUNT(*) AS rows, COUNT(DISTINCT batch_hash) AS hashes,
       AVG(record_count) AS avg_rcount, MAX(cycle_timestamp) AS latest
FROM state_attestations WHERE domain = 'cda_extractions';
```

```json
[
  {
    "rows": "0",
    "hashes": "0",
    "avg_rcount": null,
    "latest": null
  }
]
```

```sql
SELECT COUNT(*) FILTER (WHERE extracted_at > NOW() - INTERVAL '7 days')
FROM cda_vendor_extractions;
```

```json
[
  {
    "cda_extractions_last_7d": "64"
  }
]
```

Baseline confirms the regression: 64 extractions inserted in the last 7 days (bare-call path firing), yet `state_attestations.domain='cda_extractions'` has 0 rows (wrapper never reached).

### Post-deploy halt criteria

(Wrapper ran-branch flavor per #225's PR template update — substrate verification MUST distinguish wrapper's `ran` branch from any fallback.)

- **Advancement check (2h)**: `state_attestations` rows for `cda_extractions` must advance past the pre-deploy baseline of `rows=0` within 2h after deploy. Any new row = wrapper firing.
- **Record-count signature**: the wrapper writes exactly one `state_attestations` row per cycle. Its payload is one of three shapes:
  - `{"status": "skipped_fresh", "table_age_hours": X}` — wrapper saw a fresh `cda_vendor_extractions` table and bailed (`record_count` = 1)
  - `{"status": "ran", "table_age_hours": X, "issuers_scanned": N, "insert_count": M, "success": ..., "partial": ..., "failed": ..., "skipped": ...}` — wrapper executed `run_collection()` (`record_count` = 1; the `insert_count` field is the ContextVar push-counter described in #207)
  - `{"status": "error", "error_type": ..., "error": ...}` — wrapper caught a top-level exception (`record_count` = 1)

  Because `cda_extractions` is NOT heartbeat-covered per the migration plan in #225, ANY new row in `state_attestations` for this domain is unambiguous evidence the wrapper fired (no fallback can write here).

- **Halt rule**: if the wrapper still doesn't fire after 2h, both LIVE-PATH call sites must be investigated specifically:
  1. `app/worker.py:1886` is guarded by `cda_age_hours >= cda_interval_hours` (default 24h). If `cda_vendor_extractions` was just written, this outer gate stays closed for ~24h. Verify by reading `MAX(extracted_at)` from `cda_vendor_extractions` against the worker cycle start time.
  2. `app/enrichment_worker.py:674` is gated by `_db_gate("SELECT MAX(extracted_at) AS latest FROM cda_vendor_extractions", min_hours=24)`. Same gate as above; same investigation.
  3. If both outer gates are open and the wrapper still hasn't fired, the worker/enrichment task itself may be skipping (e.g., the slow-cycle CDA `try:` block at `app/worker.py:1871` swallows exceptions). Surface specifically.

Reference #225 (Phase 0 classification + PR template #175 wrapper-verification section) as the structural justification for moving the canonical call site from `main.py:163` to the LIVE-PATH writers.

## Test plan

- [ ] CI green
- [ ] After merge, monitor `state_attestations` row count for `domain='cda_extractions'` for 2h; expect advancement past 0
- [ ] Verify first attestation payload `status` field is one of `skipped_fresh` / `ran` / `error`
- [ ] If `ran`, confirm `insert_count` matches the expected per-cycle insert volume (typical: 10-30 per active-issuer cycle)
- [ ] Confirm coherence report `cda_extractions` domain transitions from `silent` to `fresh`

https://claude.ai/code/session_017QJC4gmqRh6kdkNk3onqkB

---
_Generated by [Claude Code](https://claude.ai/code/session_017QJC4gmqRh6kdkNk3onqkB)_