### PR TITLE
fix(v9.12): move assessments attest to awaited live-path call site (#221)

### DIFF
--- a/app/worker.py
+++ b/app/worker.py
@@ -1442,11 +1442,31 @@ async def run_fast_cycle():
     # -------------------------------------------------------------------------
     # Verification agent cycle — every cycle
     # -------------------------------------------------------------------------
+    # F2 (#221): assessments attest moved here from main.py:322. main.py:296
+    # calls run_agent_cycle() without `await` and the broad except at
+    # main.py:307-308 swallows the resulting AttributeError when `.get(...)`
+    # is invoked on a coroutine — so the main.py attest never executed
+    # (state_attestations.domain='assessments' had 0 rows over 19.4h
+    # despite 125+ watcher events). This call site awaits correctly and
+    # the result dict already exposes the assessments count + severities
+    # — exactly the wrapper-shape payload M's PR #213 intended. The
+    # coroutine bug at main.py:296 is left in place; same bug class N
+    # cleaned up for wallets in PR #214 — out of scope for F2 (separate
+    # cleanup sweep). #225 classification + #221.
     try:
         from app.agent.watcher import run_agent_cycle
         result = await run_agent_cycle()
         if result:
             logger.info(f"Agent cycle: {result.get('assessments', 0)} assessments")
+            try:
+                from app.state_attestation import attest_state
+                if result.get("assessments", 0) > 0:
+                    attest_state("assessments", [{
+                        "assessments": result.get("assessments", 0),
+                        "severities": result.get("severities", {}),
+                    }])
+            except Exception as ae:
+                logger.debug(f"Assessments attestation skipped: {ae}")
     except Exception as e:
         logger.warning(f"Agent cycle error: {e}")
 

--- a/main.py
+++ b/main.py
@@ -292,18 +292,22 @@ def run_worker_loop():
                 logger.warning(f"Profile rebuild failed: {e}")
 
         # Verification agent cycle — runs after every scoring cycle
+        # F2 (#221): the attest_state("assessments", ...) call previously
+        # here is dead — run_agent_cycle() is async (app/agent/watcher.py:
+        # 259) but this site calls it without `await`, so `result` is a
+        # coroutine and `.get(...)` raises AttributeError which the broad
+        # except below swallows. Net: 0 rows in state_attestations for
+        # 'assessments' over 19.4h despite 125+ watcher events. The
+        # attest has been moved to app/worker.py's awaited live-path
+        # caller (see comment there). The coroutine bug at the next line
+        # is intentionally left in place — same bug class N cleaned up
+        # for wallets in PR #214, separate cleanup sweep tracked
+        # outside F2's scope.
         try:
             from app.agent.watcher import run_agent_cycle
             result = run_agent_cycle()
             if result:
                 logger.info(f"Agent cycle: {result.get('assessments', 0)} assessments")
-                # Attest actor classifications
-                try:
-                    from app.state_attestation import attest_state
-                    if result.get('assessments', 0) > 0:
-                        attest_state("assessments", [{"assessments": result.get('assessments', 0), "severities": result.get('severities', {})}])
-                except Exception as ae:
-                    logger.debug(f"Actor attestation skipped: {ae}")
         except Exception as e:
             logger.error(f"Agent cycle error: {e}")
 


### PR DESCRIPTION
## Summary

- **F2 — actors coroutine-await fix** (v9.12 Phase 1, classification per #225).
- D4's finding: `main.py:296` calls `run_agent_cycle()` (async, defined at `app/agent/watcher.py:259`) without `await`. The broad `except` at `main.py:307-308` swallows the resulting `AttributeError` when `.get(...)` is invoked on a coroutine — so the `attest_state("assessments", ...)` block M added at `main.py:322` in PR #213 was dead. Net: 0 `state_attestations` rows for `'assessments'` over 19.4h despite 125+ watcher events firing.
- Moved the attest to `app/worker.py:1445-1451` — the LIVE-PATH caller that already `await`s `run_agent_cycle()` and exposes the exact wrapper-shape `result` dict M's PR #213 intended (`assessments` count + `severities`).
- The coroutine bug at `main.py:296` is **intentionally left in place** — same bug class N cleaned up for `wallets` in PR #214. Out of scope for F2; tracked as a separate cleanup sweep. (Now harmless to `'assessments'` since the attest moved off that code path.)
- M's bimodality framing in PR #213 was based on a substrate misread (per D4): pre-merge bimodality didn't exist — `main.py`'s writer had been silently broken the whole time, and all 118 pre-merge `actors` rows came from `actor_classification.py` alone. The split is still correct hygiene.
- Diff: 31 insertions, 7 deletions across `app/worker.py` + `main.py` (mostly comments + a call relocation).
- `assessments` is already in `app/coherence.py` `ALL_DOMAINS` (line 35) and `app/pulse_generator.py` `ATTESTATION_DOMAINS` (line 251) — added by M in #213. No domain-list edits needed.

## Substrate verification

### Pre-deploy

```
SELECT COUNT(*) AS rows, MAX(cycle_timestamp) AS latest
FROM state_attestations WHERE domain = 'assessments';
-- rows=0, latest=NULL  (confirms F2's bug)

SELECT COUNT(*) AS actors_rows, MAX(cycle_timestamp) AS actors_latest
FROM state_attestations WHERE domain = 'actors';
-- actors_rows=146, actors_latest=2026-05-13T18:17:31.427Z
-- (sanity: classification writers still firing; F2 doesn't touch them)

SELECT COUNT(*) AS watcher_events_24h
FROM assessment_events
WHERE created_at > NOW() - INTERVAL '24 hours';
-- watcher_events_24h=130
-- (confirms watcher.py IS firing events — pure attest-gap)
```

### Post-deploy halt criteria

(Wrapper ran-branch flavor per #225's PR template update — substrate verification MUST distinguish wrapper's `ran` branch from any fallback.)

- `state_attestations` for `'assessments'` advances past 0 within 4h, **conditional on** the watcher firing events in that window (lesson 11 — assessments is an event-driven domain; rate-based: 4h is the minimum reasonable observation window since quiet hours can legitimately produce 0 rows).
- `'actors'` continues advancing (classification writers in `worker.py:1446`, `worker.py:2299`, `worker.py:2703`, `enrichment_worker.py:603` untouched — Q3 deferral).
- **Halt rule**: if `assessments=0` after 4h **AND** watcher events fired in the window → `worker.py:1445-1471` is itself gated somehow (e.g., `run_fast_cycle` not invoked, attest exception swallowed); surface.

### Verification queries (post-deploy)

```sql
-- Should show new rows within 4h if watcher fired
SELECT COUNT(*), MAX(cycle_timestamp)
FROM state_attestations
WHERE domain = 'assessments' AND cycle_timestamp > NOW() - INTERVAL '4 hours';

-- Watcher activity in same window (denominator for halt rule)
SELECT COUNT(*) FROM assessment_events
WHERE created_at > NOW() - INTERVAL '4 hours';

-- Sanity: actors still advancing
SELECT COUNT(*), MAX(cycle_timestamp)
FROM state_attestations
WHERE domain = 'actors' AND cycle_timestamp > NOW() - INTERVAL '4 hours';
```

## Test plan

- [ ] CI green (Python parse + existing test suite).
- [ ] After merge + deploy, run the three post-deploy queries above at the 4h mark.
- [ ] If `assessments > 0` and `actors > 0` advancing → F2 verified.
- [ ] If `assessments = 0` and watcher fired >= 1 event → halt + surface.

Closes #221. Refs #225 classification + #213.

https://claude.ai/code/session_017QJC4gmqRh6kdkNk3onqkB

---
_Generated by [Claude Code](https://claude.ai/code/session_017QJC4gmqRh6kdkNk3onqkB)_