### PR TITLE
fix(v9.12): close Q4 — route psi_discoveries heartbeat through wrapper (#223)

### DIFF
--- a/app/worker.py
+++ b/app/worker.py
@@ -2604,7 +2604,17 @@ async def _emit_slow_cycle_heartbeats(
 
     try:
         from app.state_attestation import attest_state
-        for _domain in ("wallets", "web_research", "psi_discoveries", "rpi_components"):
+        # psi_discoveries is owned by the module-canonical wrapper
+        # (`run_psi_discovery_monitor_scheduled`). Routing the heartbeat
+        # through it preserves cadence while letting the wrapper own the
+        # payload shape + freshness gate. Q4 closure for v9.12 #198 / #223:
+        # heartbeat previously wrote a generic `{status: ok|..., via, ...}`
+        # placeholder via attest_state directly — produced 1 row/cycle
+        # with the wrapper's `ran` branch never reached because Path A in
+        # run_slow_cycle is dead in steady state. The wrapper handles the
+        # `SELECT MAX(snapshot_date) FROM protocol_collateral_exposure`
+        # gate internally and emits skipped_fresh|ran|error payloads.
+        for _domain in ("wallets", "web_research", "rpi_components"):
             try:
                 await asyncio.to_thread(attest_state, _domain, [base_payload])
             except Exception as e:
@@ -2613,6 +2623,32 @@ async def _emit_slow_cycle_heartbeats(
                 )
     except Exception as e:
         logger.warning(f"slow-cycle heartbeat import failed: {e}")
+
+    # Route psi_discoveries through the module-canonical wrapper. Map the
+    # heartbeat's pipeline outcome to the wrapper's status vocabulary:
+    #   pipeline_failed -> error  (preserves "ran but errored" signal)
+    #   ok | ran_no_result -> skipped_unknown  (wrapper checks the gate
+    #     and emits skipped_fresh when protocol_collateral_exposure is
+    #     <24h old, or ran with zero counts when the gate is open)
+    # Counts are zero from the heartbeat path — when Path C runs and
+    # produces discoveries, it has its own attest. The wrapper's job
+    # here is keeping the domain fresh with the correct payload shape.
+    try:
+        from app.data_layer.psi_discovery_monitor import (
+            run_psi_discovery_monitor_scheduled,
+        )
+        if pipeline_error:
+            _wrapper_status = "error"
+        else:
+            _wrapper_status = "skipped_unknown"
+        await run_psi_discovery_monitor_scheduled(
+            cycle_ts=datetime.now(timezone.utc),
+            status=_wrapper_status,
+        )
+    except Exception as e:
+        logger.warning(
+            f"slow-cycle heartbeat psi_discoveries wrapper call failed: {e}"
+        )
 
 
 async def run_slow_cycle_parallel():


### PR DESCRIPTION
## Summary

Closes Q4 from #198 / #200 by routing the slow-cycle heartbeat at `app/worker.py:_emit_slow_cycle_heartbeats` through the module-canonical wrapper `run_psi_discovery_monitor_scheduled`.

Per D1 audit (#223): the wrapper's `ran` branch had never fired in production because Path A (`run_slow_cycle`) is dead in steady state — `run_slow_cycle_parallel` succeeds and never falls through. The 9 rows / 19h cadence visible in substrate was being produced by this heartbeat writing a generic `{status, via, ...}` placeholder via `attest_state` directly, not by J's wrapper.

After this PR: the heartbeat hands off to the wrapper, which:
- checks the 24h freshness gate on `protocol_collateral_exposure`,
- emits `skipped_fresh|ran|error` payloads with the Q2=C shape `{status, synced, discovered, enriched, promoted}`,
- becomes the sole writer of `psi_discoveries` from LIVE worker paths.

The other three heartbeat domains (`wallets`, `web_research`, `rpi_components`) are untouched.

## Status mapping

| Pipeline outcome | Wrapper status arg | Wrapper terminal branch |
|---|---|---|
| `pipeline_failed` | `error` | `error` payload |
| `ok` / `ran_no_result` | `skipped_unknown` | gate decides: `skipped_fresh` (fresh <24h) or `ran` with zeros (gate open) |

Counts from the heartbeat path are zero; Path C (`enrichment_worker._run_psi_expansion`) is the actual freshness keeper of `protocol_collateral_exposure` and has its own attest path. The wrapper's job here is to keep the domain fresh with the **correct payload shape**.

## #217 Phase 2 — rewritten plan (DOCUMENTATION ONLY, not executed here)

D1 surfaced that #217's safety argument is **backwards**: the original Phase 2 plan claimed "Path A keeps `protocol_collateral_exposure` fresh, so Paths B/C stay gate-closed", but Path A is dead. The actual freshness keeper is **Path C itself** (`enrichment_worker.py:_run_psi_expansion` calls `collect_collateral_exposure()` at line 272).

Rewritten plan posted as a comment on #217. New ordering:

1. **Step 1**: Delete Path B alone (`main.py:226-266`) — truly dead, no consumers depend on it.
2. **Step 2**: Relocate `collect_collateral_exposure()` from inside `_run_psi_expansion` to a dedicated scheduler entry (new task `_run_collect_collateral_exposure` registered as a peer to `_run_psi_expansion`).
3. **Step 3**: Substrate-verify Step 2 over a 24h window — confirm `protocol_collateral_exposure.MAX(snapshot_date)` stays fresh on the same cadence as today (when Path C was feeding it).
4. **Step 4**: Only after Step 3's 24h substrate confirms freshness, delete Path C body (`enrichment_worker.py:288-305`) + registration (`774-781`).

**Gate**: do NOT proceed to Step 4 until Step 3 substrate-verifies. Phase 2 stays blocked on #217 until this rewritten plan is approved by the operator.

## Substrate verification

### Pre-deploy

```
SELECT COUNT(*) AS rows, COUNT(DISTINCT batch_hash) AS hashes,
       AVG(record_count) AS avg_rcount, MAX(cycle_timestamp) AS latest
FROM state_attestations WHERE domain = 'psi_discoveries';

  rows | hashes |       avg_rcount       |          latest
 ------+--------+------------------------+--------------------------
   28  |   18   | 1.00000000000000000000 | 2026-05-13 18:16:19.822+00
```

```
-- record_count distribution: today is uniformly 1 (heartbeat placeholder)
SELECT record_count, COUNT(*) FROM state_attestations
WHERE domain = 'psi_discoveries' AND cycle_timestamp > NOW() - INTERVAL '7 days'
GROUP BY 1 ORDER BY 1;

  record_count | count
 --------------+-------
        1      |   23
```

```
-- protocol_collateral_exposure freshness (informs Phase 2 safety rewrite)
SELECT MAX(snapshot_date), COUNT(*) FROM protocol_collateral_exposure;

       max         | count
 ------------------+-------
  2026-05-13       | 11099
```

```
-- Recent batch_hash distribution (heartbeat shape baseline)
SELECT batch_hash, record_count, cycle_timestamp FROM state_attestations
WHERE domain = 'psi_discoveries' ORDER BY cycle_timestamp DESC LIMIT 10;

  254da178da09… | 1 | 2026-05-13 18:16:19
  254da178da09… | 1 | 2026-05-13 16:03:34
  61d9af833…    | 1 | 2026-05-13 13:50:57
  61d9af833…    | 1 | 2026-05-13 11:44:11
  bbfa44f062…   | 1 | 2026-05-13 10:36:24
  61d9af833…    | 1 | 2026-05-13 08:30:24
  254da178da09… | 1 | 2026-05-13 06:14:08
  8c6b6aa902…   | 1 | 2026-05-13 03:43:32
  b9080fff4d…   | 1 | 2026-05-13 01:36:03
  61d9af833…    | 1 | 2026-05-12 23:20:16
```

The pre-deploy heartbeat payload shape is `{status: ok|pipeline_failed|ran_no_result, via: run_slow_cycle_parallel, succeeded: N, total_tasks: N}`. The wrapper payload shape is `{status: skipped_fresh|ran|error|skipped_unknown, synced: N, discovered: N, enriched: N, promoted: N}` — completely different keyset, so **batch_hash changes deterministically post-deploy**.

### Post-deploy halt criteria

(Wrapper ran-branch flavor per #225's PR template update — substrate verification MUST distinguish wrapper's `ran` branch from any fallback.)

The distinguishing signature here is **`batch_hash` shape**, not `record_count` — both heartbeat and wrapper write single-element record lists (`record_count = 1`). The wrapper produces a different hash because the payload keys differ.

**Expected post-deploy** (substrate state today: `protocol_collateral_exposure` snapshot_date = 2026-05-13, fresh; gate is closed):
- All new rows should have `record_count = 1`
- All new rows should have a **new batch_hash** not seen in the pre-deploy 7-day window (i.e., `254da178…`, `61d9af83…`, `bbfa44f0…`, `8c6b6aa9…`, `b9080fff…` should NOT appear in post-deploy rows)
- The new batch_hash should be **deterministic and stable** — wrapper's `skipped_fresh` payload `{status: "skipped_fresh", synced: 0, discovered: 0, enriched: 0, promoted: 0}` is constant when gate is closed, so we expect a single repeated batch_hash across cycles.

**Halt rule (4h)**: if 4h post-deploy any row's `batch_hash` matches a pre-deploy heartbeat hash → wrapper is not the new writer; the routing didn't take. Investigate.

**Secondary signal**: when `protocol_collateral_exposure` ages past 24h (gate opens), the wrapper's `ran` branch will write `{status: "ran", synced: 0, ...}` — a third distinct batch_hash. This is expected during the natural daily cycle and confirms the gate logic works end-to-end.

## Pre-flight verifications

- `collect_collateral_exposure` call-site audit: confirmed via grep across the repo. Call sites: `main.py:224` (Path B, dead), `app/worker.py:2343` (Path A, dead), `app/enrichment_worker.py:272` (Path C, LIVE keeper), `app/server.py:5003` (admin route, on-demand), `app/budget/daily_cycle.py:143` (budget cycle). D1's finding holds — Path C is the live keeper.
- `attest_state` writes `record_count = len(records)`. Both heartbeat and wrapper pass single-element lists, so the distinguishing signature is `batch_hash`, not `record_count`. PR template's record_count rubric does not apply 1:1 here; called out explicitly in the halt-rule section above.
- Wrapper's `skipped_fresh` branch DOES produce a `state_attestations` row (verified at `psi_discovery_monitor.py:91`).

## Out of scope

- Phase 2 execution (delete Path B / relocate-then-delete Path C). Plan rewrite captured in #217 comment; execution is a future PR gated on operator approval + Step 3 substrate verification.

## Test plan
- [ ] CI green
- [ ] 4h post-deploy substrate check: `SELECT batch_hash, COUNT(*) FROM state_attestations WHERE domain='psi_discoveries' AND cycle_timestamp > '' GROUP BY 1` — expect single new hash, none matching pre-deploy set
- [ ] 24h post-deploy: confirm wrapper's `ran` branch fires at least once (third distinct hash appears when gate opens)
- [ ] Cadence preserved: ~1 row per slow cycle (~2h)

Refs: #225 (PR template), #223 (D1 finding), #198 / #200 (Q4 deferral), #216 (Phase 1, merged), #217 (Phase 2 plan rewrite captured in comment).
Closes #223.

https://claude.ai/code/session_017QJC4gmqRh6kdkNk3onqkB

---
_Generated by [Claude Code](https://claude.ai/code/session_017QJC4gmqRh6kdkNk3onqkB)_