### PR TITLE
fix(wallet_profiles): rebuild_all_profiles returns built=0 (#228)

### DIFF
--- a/app/indexer/profiles.py
+++ b/app/indexer/profiles.py
@@ -153,14 +153,41 @@ def rebuild_all_profiles(limit: int = 0) -> dict:
 
     Args:
         limit: Max wallets to process (0 = unlimited, stalest first).
+
+    The picks query (v9.12 #228 fix) restricts candidates to wallets that
+    have *something to profile*: fresh holdings (last 7 days). Previously
+    the work-queue was poisoned by ~700K "shell" wallets seeded by the
+    expander without holdings, which produced trivial all-zero profiles
+    and starved the cycle of useful work. The substrate evidence: 2000
+    upserts/cycle were happening but every attestation reported
+    `ran_no_results` with `built=0`, because the queue head was
+    dominated by shell wallets whose `build_unified_profile()` calls
+    diverged silently from the in-memory `built` counter. The new
+    `built_substrate` value is sourced post-hoc from the table itself
+    via cycle_start_ts, anchoring the attested value to ground truth.
     """
+    import time as _time
+    cycle_start_ts = datetime.now(timezone.utc)
+    cycle_t0 = _time.monotonic()
+
     if limit > 0:
-        # Stalest profiles first: wallets that either have no profile yet
-        # (LEFT JOIN … IS NULL) or the oldest updated_at in wallet_profiles.
+        # Stalest profiles first, restricted to wallets that have fresh
+        # holdings (last 7 days). Drops "shell" wallets seeded by the
+        # expander that have no holdings and would otherwise dominate
+        # the NULLS FIRST queue (substrate: ~700K shell wallets vs
+        # ~3K wallets with fresh holdings). Holdings is the dominant
+        # signal — wallets with only edges and no holdings produce
+        # trivial profiles anyway. EXPLAIN ANALYZE: 464ms with the
+        # holdings filter vs 783ms unfiltered but yielding shell wallets.
         rows = fetch_all(
             """SELECT w.address, MIN(p.updated_at) AS oldest_profile
                FROM wallet_graph.wallets w
                LEFT JOIN wallet_graph.wallet_profiles p ON w.address = p.address
+               WHERE EXISTS (
+                   SELECT 1 FROM wallet_graph.wallet_holdings h
+                   WHERE LOWER(h.wallet_address) = LOWER(w.address)
+                     AND h.indexed_at > NOW() - INTERVAL '7 days'
+               )
                GROUP BY w.address
                ORDER BY oldest_profile ASC NULLS FIRST
                LIMIT %s""",
@@ -186,13 +213,39 @@ def rebuild_all_profiles(limit: int = 0) -> dict:
         if (i + 1) % 100 == 0:
             logger.info(f"Profile rebuild progress: {i + 1}/{len(addresses)} ({built} built, {errors} errors)")
 
-    logger.info(f"Profile rebuild complete: {built} built, {errors} errors out of {len(addresses)} addresses")
+    # Substrate-anchor the attested `built` value: source it from the
+    # table itself rather than the in-memory counter. This closes the
+    # #228 gap where 2000 upserts/cycle were occurring but `built` was
+    # reported as 0 due to silent intermediate path divergence. The
+    # in-memory `built` is still surfaced (as `built_inmem`) for
+    # observability, but the attestation and return value use the
+    # substrate count, which is what the wallet_profiles table actually
+    # reflects.
+    built_substrate = built
+    try:
+        sub_row = fetch_one(
+            "SELECT COUNT(*) AS cnt FROM wallet_graph.wallet_profiles WHERE updated_at >= %s",
+            (cycle_start_ts,),
+        )
+        if sub_row and sub_row.get("cnt") is not None:
+            built_substrate = int(sub_row["cnt"])
+    except Exception as _sub_err:
+        logger.warning(f"wallet_profiles substrate count failed; falling back to in-memory built: {_sub_err}")
+
+    elapsed_s = round(_time.monotonic() - cycle_t0, 1)
+    logger.info(
+        f"Profile rebuild complete: built_substrate={built_substrate} "
+        f"(built_inmem={built}, errors={errors}, picks={len(addresses)}, elapsed={elapsed_s}s)"
+    )
 
     # Attest wallet profiles
     try:
         from app.state_attestation import attest_state
-        if built > 0:
-            attest_state("wallet_profiles", [{"built": built, "total": len(addresses)}])
+        if built_substrate > 0:
+            attest_state(
+                "wallet_profiles",
+                [{"built": built_substrate, "built_inmem": built, "total": len(addresses)}],
+            )
         else:
             attest_state("wallet_profiles", [{"status": "ran_no_results", "profiles_built": 0}])
     except asyncio.CancelledError:
@@ -209,4 +262,9 @@ def rebuild_all_profiles(limit: int = 0) -> dict:
         except Exception:
             pass
 
-    return {"total": len(addresses), "built": built, "errors": errors}
+    return {
+        "total": len(addresses),
+        "built": built_substrate,
+        "built_inmem": built,
+        "errors": errors,
+    }


### PR DESCRIPTION
## Summary

The `wallet_profiles` wrapper attestation has emitted `ran_no_results` (built=0) every cycle since 2026-05-05 (56/65 attestations carrying the canonical `fd6fa7e4...d3b744` batch_hash) despite ~2000 rows/cycle actually being upserted into `wallet_graph.wallet_profiles`. This PR addresses both compounding causes verified via substrate.

**F5's hypothesis (orphan profiles dominating the LEFT JOIN queue head):** REFUTED. Substrate Q2 shows 0 orphans.

**Actual root cause (verified):**
1. Work-queue poisoning by ~700K "shell" wallets seeded by the expander without holdings.
2. In-memory `built` counter diverging silently from substrate reality.

## Substrate verification

### Pre-deploy

**Q1 — Baseline counts (lesson 8: COUNT first):**
```
profile_total      = 180,815
profiles_fresh_24h = 21,485   <- function IS doing work
wallets_total      = 882,497
wallets_new_24h    = 16,053
```
Note: `profiles_fresh_24h > 0` -> return-value/counter bug, not data-correctness bug (per the diagnosis rubric).

**Q2 — F5's orphan hypothesis:**
```
orphan_profile_count = 0
```
REFUTED. Profiles whose wallet row is gone: none.

**Q3 — top picks from the LIVE query (mirrors `profiles.py:160-167`):**
```
All 10/10 top picks have oldest_profile=NULL.
Picks expanded (2000 rows):
  picks_total                  = 2000
  picks_with_existing_profile  = 0
  picks_without_profile        = 2000
  picks_with_wallet_rows       = 2000   <- wallet row exists, so build_unified_profile proceeds
  picks_with_fresh_holdings    = 0      <- but NO holdings -> trivial all-zero profile
```

**Q4 — actor_classification footprint:**
```
wallets_updated_24h = 18,631
```
`actor_classification.classify_wallet` does `UPDATE wallet_graph.wallet_profiles SET actor_type=..., agent_probability=... WHERE LOWER(address)=%s`. It does NOT alias addresses, does NOT delete rows, does NOT touch `updated_at`. So the 21,485 `updated_at` updates from Q1 are sourced entirely from `app/indexer/profiles.py`'s INSERT...ON CONFLICT — the function IS running end-to-end.

**Cycle-window correlation (additional check):**
```
attestation cycle 16:42 -> 18:55 -> profiles_updated_in_window = 2000
attestation cycle 14:31 -> 16:42 -> profiles_updated_in_window = 2000
attestation cycle 12:20 -> 14:31 -> profiles_updated_in_window = 2000
...
Every 2h cycle: exactly 2000 profiles updated, but attestation reports built=0.
```
Last profile update in the 18:55 cycle window was at 18:55:44.457; attestation at 18:55:44.721 (264ms later). The loop completes and reaches the attestation block — `built` is genuinely 0 at attest time.

**Wallet population breakdown:**
- 3,100 wallets have fresh holdings (last 7d)
- 701,636 wallets have NO profile at all
- 882,497 wallets total
- The `NULLS FIRST` queue head is dominated by the ~700K shell wallets.

### Code-read findings (lesson 10: full file scope)

- **`app/indexer/profiles.py:160-167`** — the picks query uses `LEFT JOIN ... ORDER BY oldest_profile ASC NULLS FIRST LIMIT 2000`. With ~700K wallets lacking profiles, every cycle picks the same kind of shell wallets at the queue head.
- **`app/indexer/profiles.py:177-184`** — the loop: `result = build_unified_profile(addr); if result: built += 1; except: errors += 1`. The counter only advances on truthy return.
- **`app/indexer/profiles.py:191-210`** — attest block: emits `ran_no_results` when `built == 0`, regardless of how many rows were actually written.
- **`app/wallet_profile.py`** — on-demand profile generator (`generate_wallet_profile`), different function; not on the cycle path.
- **`app/actor_classification.py:282-290`** — `classify_wallet` does only `UPDATE wallet_profiles SET actor_type=..., agent_probability=... WHERE LOWER(address)=%s`. No aliasing, no deletion, doesn't touch `updated_at`. Hypothesis "actor_classification interferes with rebuild_all_profiles" is REFUTED.
- **`app/enrichment_worker.py:651-655`** and **`app/worker.py:1995-2000`** — both invoke `rebuild_all_profiles(2000)` via `run_in_executor` with `asyncio.wait_for(timeout=1800)`. The 2h cycle cadence in substrate matches the worker.py call site.

### Chosen fix path: (b) + (c)

Per the diagnosis rubric:
- **(b)** Add a `wallet has fresh holdings` filter to the picks SELECT. Substrate evidence: 700K shell wallets in the NULLS FIRST queue head produce trivial all-zero profiles; restricting to ~3K wallets with fresh holdings ensures the queue does meaningful work.
- **(c)** Make `built` substrate-anchored. Whatever the exact micro-cause of the counter divergence (the in-memory counter ends at 0 despite 2000 rows persisting via auto-committed `execute()` calls), the fix is to source the attested value from the table itself: `SELECT COUNT(*) FROM wallet_profiles WHERE updated_at >= cycle_start_ts`. The in-memory counter is preserved as `built_inmem` for observability — any future divergence is itself attested.

Reasoning for combining (b)+(c): (b) alone fixes data quality (picks become meaningful), but if the counter bug recurs under different conditions the regression repeats; (c) makes the counter resilient to whatever the divergence path is. Both fit in a 73-line diff.

### Post-deploy halt criteria

Run these 2h after deploy (replace `<deploy_ts>` with the actual deploy time):

```sql
-- Wrapper's `ran` branch firing (new batch_hash diversity)
SELECT batch_hash, record_count, COUNT(*) FROM state_attestations
WHERE domain = 'wallet_profiles' AND cycle_timestamp > '<deploy_ts>'::timestamptz
GROUP BY 1, 2 ORDER BY 3 DESC LIMIT 10;
-- Expect: NEW batch_hashes (not fd6fa7e4...d3b744 ran_no_results placeholder).

-- wallet_profiles table itself sees updates
SELECT COUNT(*) AS profiles_updated_post_deploy FROM wallet_graph.wallet_profiles
WHERE updated_at > '<deploy_ts>'::timestamptz;
-- Expect: > 0 within 2h.
```

Both should be non-zero within 2h of deploy. If they are, this PR closes #228.

## Out of scope (deferred)

- **Option 1** (`skipped_fresh` freshness gate per the canonical 3-branch wrapper shape from #198/#193) is deferred to a follow-up issue. This PR addresses Option 2 (correctness) only, per the operator's direction.

## Test plan

- [ ] Verify the picks query plan runs <500ms in production (EXPLAIN ANALYZE in worktree: 464ms).
- [ ] Confirm next cycle's attestation emits a NEW batch_hash (not fd6fa7e4...d3b744).
- [ ] Confirm `state_attestations.batch_hash` payload shows `built > 0` and `built_inmem` value for divergence tracking.
- [ ] Verify `wallet_profiles` is being populated for wallets that have fresh holdings (the new picks predicate).
- [ ] If `built_inmem != built` in any cycle, open a separate issue tracking the divergence path.

Closes #228 (subject to post-deploy substrate verification)
Refs #225, #232

https://claude.ai/code/session_017QJC4gmqRh6kdkNk3onqkB

---
_Generated by [Claude Code](https://claude.ai/code/session_017QJC4gmqRh6kdkNk3onqkB)_