### PR TITLE
docs(v9.12): web_research → DONE + Phase 2.3 staging requirement

### DIFF
--- a/docs/audits/2026-05-11-module-canonical-migration-plan.md
+++ b/docs/audits/2026-05-11-module-canonical-migration-plan.md
@@ -172,6 +172,36 @@ Per orchestrator: do NOT collapse until every P0 + P1 + (most) P2
 domain in §Refactor sweep order shows fresh attestations within
 expected cadence. The legacy fallback may still be serving them.
 
+**Staging requirement (added 2026-05-13 post-#201 review).** The
+dispatcher heartbeat at `worker.py:2650`
+(`for _domain in ("wallets","web_research","rpi_components")`)
+currently writes the same domains that the new module-canonical
+wrappers also write. Until we can definitively distinguish
+wrapper-vs-heartbeat row provenance for each of these three
+domains (e.g., a `payload_size_signature` column or a `writer_id`
+discriminator on `state_attestations` — see follow-up issue), the
+collapse cannot remove all three at once: a silent wrapper failure
+would be masked by the heartbeat right up until the heartbeat
+itself is deleted.
+
+**Phase 2.3 must stage the heartbeat dissolution. Remove one
+domain from the heartbeat list per PR; verify
+`state_attestations` continues firing for that domain post-removal
+(at least one full slow cycle elapsed, fresh row from the
+wrapper's distinct payload shape); only then proceed to the next.**
+Order of removal — least-risky first (most-confident wrapper
+behavior in substrate):
+
+1. `rpi_components` — daily-gated, low blast radius.
+2. `web_research` — daily-gated, well-exercised wrapper (#201).
+3. `wallets` — last; v9.12-exempt layered-defense path, see #202.
+
+Each removal PR must include: (a) a 24-48h substrate query showing
+the wrapper has fired for that domain independently of the
+heartbeat (distinct `batch_hash` from the heartbeat's
+`base_payload` shape), and (b) the rollback plan if cadence
+regresses.
+
 ## Session scope note
 
 This audit lists the entire v9.12 migration surface but the

--- a/docs/audits/2026-05-11-module-canonical-migration-plan.md
+++ b/docs/audits/2026-05-11-module-canonical-migration-plan.md
@@ -33,7 +33,7 @@ schedule the module from worker.py.
 | ~~`data_layer:exchange_snapshots`~~ ✅ | ~~worker.py:1186-1246 inline~~ removed | `app/data_layer/exchange_collector.py::run_exchange_collection_scheduled` | **P0 → DONE** | `LIVE-PATH (verified post-DONE)` | Q1 answered by #197 (migration 109 — schema replay). Q2 answered: 15 exchanges (worker._EX list), `_EX_FIX` legacy-slug remap ported into module. 35 additional exchanges deferred to Q2-extension (see below). enrichment_worker.py task entry removed (was kept closed by inline; lesson 6 family). main.py daily lambda switched. Dispatcher heartbeat at worker.py:2787 left in place until Phase 2.3. Wrapper call verified at `worker.py:1196` (live path). |
 | ~~`data_layer:dex_pool_ohlcv`~~ ✅ | ~~worker.py inline~~ removed | `app/data_layer/ohlcv_collector.py::run_ohlcv_collection_scheduled` | **P0 → DONE** | `LIVE-PATH (verified post-DONE)` | Pilot landed this session; module-canonical via `run_ohlcv_collection_scheduled()`. Dispatcher heartbeat at worker.py:2778 left in place until Phase 2.3. Wrapper call verified at `worker.py:2066` (live path). |
 | `wallets` | `worker.py:1957` (Path A), `worker.py:2642` (Path D heartbeat) | `app/indexer/pipeline.py:811` (Path B inner attest) | **v9.12-exempt** | `LIVE-PATH` (Paths A/B/D); Path C `LEGACY-DEAD-CODE` (deleted #214) | Wave 1 + Wave 3 + Wave 5b. **v9.12-exempt** — layered defense: 4 writers each covering a failure mode added under fire (#142/#155/#163). Path C (`main.py:197-208`) deleted in #214 as dead code (coroutine-never-awaited — `run_pipeline_batch` is `async def` but called without `await`, swallowed by outer except). Paths A/B/D retained intentionally. See #202 for rationale. |
-| `web_research` | `worker.py:1960`, also 2787 | `app/collectors/web_research.py:563` | **P1** | `LIVE-PATH` | Wave 1 + Wave 3 + Wave 5b. |
+| ~~`web_research`~~ ✅ | ~~`worker.py:1816-1863` inline~~ removed | `app/collectors/web_research.py::run_web_research_scheduled` | **P1 → DONE** | `LIVE-PATH (verified post-DONE)` | Wrapper landed in #201 (#198 pattern): 24h gate via `MAX(computed_at)` across `web_research_*` index_ids; skip/ran/error branches; ran branch defers to existing module attest at `web_research.py:563`. Worker.py main loop awaits the wrapper at `worker.py:1844`. enrichment_worker.py task at `enrichment_worker.py:530` also routes through the wrapper (external `_db_gate` removed since the wrapper's internal gate is authoritative). Dispatcher heartbeat at `worker.py:2650` (`for _domain in ("wallets","web_research","rpi_components")`) left in place until Phase 2.3. record_count signature: 1 on skipped_fresh/error (wrapper), 50/51 on ran (module per-component list) or 1 on ran-no-scores. Wrapper call verified at `worker.py:1844` (live path) and `enrichment_worker.py:530` (live path). |
 | `psi_components` | `worker.py:1100`, `main.py:224` | (enrichment task) | **P1** | `LIVE-PATH` (worker.py site); `main.py:224` is **LEGACY-DEAD-CODE** | Two live paths post-Wave-1. Note: `main.py:224` only fires in the API container, which has `WORKER_ENABLED=false`; in steady state the worker.py:1100 site is the only live writer. |
 | `cda_extractions` | `main.py:167` | (enrichment task wraps `app/services/cda_collector.py`) | **P0** | `LEGACY-DEAD-CODE` (per D2) | Reclassified from P2 — coherence gap: 0 attestations despite vendor churn (see #207). Live writers at `worker.py:1885` + `enrichment_worker.py:673`; `main.py:163` wrapper (#212) never fires because `Dockerfile.api` disables worker. |
 | `wallet_profiles` | `main.py:301` | (`app/wallet_profile.py`) | **P2** | `LEGACY-DEAD-CODE` | Verified via lesson 10: `main.py:301` only reachable inside `run_worker_loop`, which is gated by `WORKER_ENABLED=true`. `Dockerfile.api` sets it false and `Dockerfile.worker` bypasses main.py entirely. Module-side attest in `rebuild_all_profiles()` is the only live writer. |
@@ -148,8 +148,11 @@ Halt conditions:
 5. `wallets` — driven by pipeline; the worker.py attest is the
    wave-3 + wave-5b heartbeat. Move into the pipeline's own status
    surface.
-6. `web_research` — worker.py:1960 + Wave 5b heartbeat; module
-   exists at `collectors/web_research.py:563`. Coordinate.
+6. ~~`web_research`~~ ✅ — worker.py:1816-1863 inline + Wave 5b heartbeat;
+   module exists at `collectors/web_research.py:563`. **DONE** in #201:
+   wrapper `run_web_research_scheduled` owns the 24h gate; worker.py and
+   enrichment_worker.py both route through it. Dispatcher heartbeat
+   retained for Phase 2.3.
 7. `psi_components` — two live paths (worker.py:1100, main.py:224);
    enrichment task in PSI scorer.
 8. `cda_extractions`, `wallet_profiles`, `actors`, `edges` —
@@ -294,7 +297,7 @@ Suggested per-domain path:
   paths' actual outputs over the next 24h of substrate. Then pick
   one as canonical and retire the other two.
 
-The remaining P1/P2 domains (`wallets`, `web_research`,
+The remaining P1/P2 domains (`wallets`, ~~`web_research`~~ (done #201),
 `psi_components`, `cda_extractions`, `wallet_profiles`, `actors`,
 `edges`) are likely each their own variant of the same problem.
 Each needs the lesson-10 reading before any refactor commit lands.


### PR DESCRIPTION
## Summary

Mechanical doc-only reconciliation of `docs/audits/2026-05-11-module-canonical-migration-plan.md` against what's actually in production. Two commits, both touching only the migration plan doc.

### 1. Flip `web_research` row to DONE (377f461)

The web_research wrapper + call-site refactor already landed in **#201** (commit `7bd59f5`), but the migration plan still listed the row as **P1 LIVE-PATH**. This commit reconciles the doc with reality:

- Row 6 in the DUAL_WRITER table: **P1** → **P1 → DONE**
- Refactor sweep order item 6: marked DONE (same shape as items 32-34)
- Lesson-10 follow-up paragraph: strike `web_research` from the remaining-P1/P2 list

Verified on this branch:
- `app/collectors/web_research.py:588` — `run_web_research_scheduled` wrapper with 24h gate + skip/ran/error branches
- `app/worker.py:1844` — main loop awaits the wrapper
- `app/enrichment_worker.py:530` — task routes through the wrapper

The flip is structurally correct because #201 is already on the live path; this is purely a doc-status alignment.

### 2. Phase 2.3 staged-dissolution requirement (fa67f3d)

This is the **new substantive addition**. Post-#201 review surfaced a Phase 2.3 risk:

The dispatcher heartbeat at `app/worker.py:2650` covers three domains:

```python
for _domain in ("wallets", "web_research", "rpi_components"):
```

These are the same three domains now also written by module-canonical wrappers. **Dropping all three from the heartbeat in one PR would mask a silent wrapper failure** until the heartbeat itself was deleted — exactly the failure mode the audit batch in **#225** (lesson 12: verify wrapper is on live path) was built to prevent.

The requirement added to §Dispatcher collapse:

1. **One domain per PR** — order: `rpi_components` → `web_research` → `wallets` (lowest-blast-radius first)
2. **24-48h substrate verification** between each removal — wrapper must demonstrably fire independently of the heartbeat (distinct `batch_hash` from base_payload shape)
3. **Rollback plan** documented per PR

This forbids the bulk-collapse pattern and mandates staged dissolution. Cross-references follow-up issue **#235** which tracks the writer_id / payload-shape discriminator work needed to make staged dissolution mechanically verifiable.

### Why this matters for the next session

The next CC session will read the migration plan from `main`. Without these commits merged:
- `web_research` looks unfinished (it isn't)
- The Phase 2.3 staging requirement is invisible
- The next dispatcher-collapse attempt may bulk-remove all three domains

## Substrate verification

### N/A

Docs-only PR — no code paths, schemas, or runtime behavior changed. Both commits modify only `docs/audits/2026-05-11-module-canonical-migration-plan.md`.

https://claude.ai/code

---
_Generated by [Claude Code](https://claude.ai/code/session_017QJC4gmqRh6kdkNk3onqkB)_