### PR TITLE
feat(v9.12): writer_id column for state_attestations (#235 Option A, W2.1)

### DIFF
--- a/app/data_layer/provenance_scaling.py
+++ b/app/data_layer/provenance_scaling.py
@@ -166,10 +166,15 @@ def attest_data_batch(
     data_type: str,
     records: list[dict],
     entity_id: str = None,
+    writer_id: str = None,
 ) -> str:
     """
     Attest a batch of data from a data layer collector.
     Calls state_attestation.attest_state() and returns the hash.
+
+    writer_id (per #235 Option A, W2.1): operator-set provenance label
+    threaded through to state_attestations.writer_id. NULL acceptable;
+    W2.2 will populate the data_layer call sites.
 
     Usage in collectors:
         from app.data_layer.provenance_scaling import attest_data_batch
@@ -178,7 +183,7 @@ def attest_data_batch(
     try:
         from app.state_attestation import attest_state
         domain = f"data_layer:{data_type}"
-        return attest_state(domain, records, entity_id=entity_id)
+        return attest_state(domain, records, entity_id=entity_id, writer_id=writer_id)
     except Exception as e:
         logger.warning(f"State attestation failed for {data_type}: {e}")
         try:

--- a/app/state_attestation.py
+++ b/app/state_attestation.py
@@ -45,25 +45,40 @@ def store_attestation(
     record_count: int,
     entity_id: str = None,
     methodology_version: str = None,
+    writer_id: str = None,
 ) -> None:
     """Store a state attestation record. Sync because called from sync
-    attest_state(), which itself has many sync callers."""
+    attest_state(), which itself has many sync callers.
+
+    writer_id (per #235 Option A, W2.1): operator-set provenance label
+    e.g. "module.peg_monitor", "heartbeat.slow_cycle",
+    "worker.inline.psi_components". NULL acceptable — W2.2 will fill in
+    the existing call sites; new ones may pass it directly."""
     execute(
         """
         INSERT INTO state_attestations
-            (domain, entity_id, batch_hash, record_count, methodology_version, cycle_timestamp)
-        VALUES (%s, %s, %s, %s, %s, NOW())
+            (domain, entity_id, batch_hash, record_count, methodology_version, writer_id, cycle_timestamp)
+        VALUES (%s, %s, %s, %s, %s, %s, NOW())
         """,
-        (domain, entity_id, batch_hash, record_count, methodology_version or FORMULA_VERSION),
+        (domain, entity_id, batch_hash, record_count, methodology_version or FORMULA_VERSION, writer_id),
     )
 
 
-def attest_state(domain: str, records: list[dict], entity_id: str = None) -> str:
-    """Compute hash and store attestation in one call. Returns the hash."""
+def attest_state(
+    domain: str,
+    records: list[dict],
+    entity_id: str = None,
+    writer_id: str = None,
+) -> str:
+    """Compute hash and store attestation in one call. Returns the hash.
+
+    writer_id (per #235 Option A, W2.1): see store_attestation. Defaults
+    to NULL so legacy callers continue to work; W2.2 will populate the
+    ~20-25 known call sites with explicit labels."""
     if not records:
         return ""
     batch_hash = compute_batch_hash(records)
-    store_attestation(domain, batch_hash, len(records), entity_id)
+    store_attestation(domain, batch_hash, len(records), entity_id, writer_id=writer_id)
     logger.info(f"State attested: domain={domain} entity={entity_id} records={len(records)} hash={batch_hash[:16]}...")
     return batch_hash
 

--- a/migrations/111_state_attestations_writer_id.sql
+++ b/migrations/111_state_attestations_writer_id.sql
@@ -1,0 +1,49 @@
+-- Migration 111: writer_id column for state_attestations (per #235 Option A).
+--
+-- Background
+-- ----------
+-- Issue #235 Problem 2: state_attestations rows are written by multiple
+-- code paths (module-canonical wrappers, dispatcher heartbeat in
+-- worker.py:2650, inline cycle work). Today every writer lands in the
+-- same `domain` bucket with no provenance discriminator — distinguishing
+-- "heartbeat wrote this" vs "wrapper wrote this" requires parsing
+-- payloads row-by-row, which is not query-friendly.
+--
+-- A5's recommendation on #235 selected Option A: add a `writer_id`
+-- VARCHAR(64) column. This unblocks Phase 2.3 staged heartbeat
+-- dissolution by making "wrapper is firing independently for 24-48h"
+-- a single-query check.
+--
+-- Per the v9.12 W2.1/W2.2/W2.3/W2.4 split:
+--   W2.1 (this PR)  — add column NULL-able, thread kwarg through
+--                     attest_state() / attest_data_batch(). New rows
+--                     default NULL until W2.2 fills them in.
+--   W2.2            — ~20-25 call-site updates to populate
+--                     writer_id labels (e.g. "module.peg_monitor",
+--                     "heartbeat.slow_cycle", "worker.inline.psi_components").
+--   W2.3            — PR template + migration plan doc update to
+--                     reference the discriminator.
+--   W2.4            — CREATE INDEX CONCURRENTLY in a separate
+--                     migration once writer_id has been populated and
+--                     soaked for 24h.
+--
+-- Why this is safe on prod (PG 17, no lock)
+-- -----------------------------------------
+-- ADD COLUMN ... NULL with no DEFAULT is a metadata-only change on
+-- PostgreSQL 11+. The table is NOT rewritten; only pg_attribute is
+-- updated. The lock taken is AccessExclusive but is released in
+-- microseconds because there is no per-row work.
+--
+-- Reference: PostgreSQL 17 docs, "Notes" on ALTER TABLE ADD COLUMN —
+-- "When you add a column to the table, ... if no default is specified,
+-- NULL is used. In neither case is a rewrite of the table required."
+--
+-- Idempotent: IF NOT EXISTS gate. Safe to re-run.
+
+ALTER TABLE state_attestations
+  ADD COLUMN IF NOT EXISTS writer_id VARCHAR(64) NULL;
+
+COMMENT ON COLUMN state_attestations.writer_id IS
+  'Writer provenance label per #235 Option A. Examples: module.peg_monitor, heartbeat.slow_cycle, worker.inline.psi_components, enrichment.<task>. NULL acceptable for legacy rows and writers that have not yet been labeled (W2.2 will fill them in).';
+
+INSERT INTO migrations (name) VALUES ('111_state_attestations_writer_id') ON CONFLICT DO NOTHING;


### PR DESCRIPTION
## Summary

- Adds `writer_id VARCHAR(64) NULL` column to `state_attestations` via migration 111 (metadata-only, no table rewrite, no lock under PG 17).
- Threads `writer_id=None` kwarg through `attest_state()`, `store_attestation()`, and `attest_data_batch()` signatures so future callers can label themselves. Existing callers are untouched and continue to write `NULL`.
- This is **W2.1** of A5's 4-PR sequence on #235 Problem 2. W2.2 (callsite labels), W2.3 (PR template + plan doc), W2.4 (`CREATE INDEX CONCURRENTLY`) are separate PRs; this PR closes nothing yet — W2.4 will close the Phase 2.3 prerequisite chain.

## Why

Issue #235 Problem 2: today every writer of `state_attestations` lands in the same `domain` bucket with no provenance discriminator. Distinguishing "heartbeat wrote this" vs "wrapper wrote this" requires parsing payloads row-by-row, which is not query-friendly. This blocks Phase 2.3 staged heartbeat dissolution because we cannot run "wrapper is the sole remaining writer in this domain over the last N hours" as a single query.

A5's recommendation selected Option A (add column) over Option B (payload signature) and Option C (convention-only reserved key). Option A is cleanest and the migration is cheap under PG 17 — `ADD COLUMN ... NULL` with no `DEFAULT` updates only `pg_attribute` and takes `AccessExclusive` for microseconds (no per-row work).

## Diff scope

```
 app/data_layer/provenance_scaling.py            |  7 +++-
 app/state_attestation.py                        | 29 +++++++++++----
 migrations/111_state_attestations_writer_id.sql | 49 +++++++++++++++++++++++++
 3 files changed, 77 insertions(+), 8 deletions(-)
```

Backward compatibility: every existing caller passes `(domain, records)` positionally and at most `entity_id=` as kwarg. `writer_id` is added at the end as the final kwarg with a `None` default, so no existing callsite needs to change. Tests in `tests/test_rpi_attestation.py` and `tests/test_divergence_attestation.py` mock `attest_state` directly and are unaffected.

## Halt surfaced (mirrors PR #197 precedent)

The brief called for a `schema_heal.py` edit adding `writer_id` to a `state_attestations` expected-columns entry. Reading the file shows `schema_heal.py` is **table-existence only** — `EXPECTED_TABLES: frozenset[tuple[str, str]]` of `(schema, name)` pairs, with no column-level structure. PR #197 surfaced the exact same gap when its brief asked for column-level entries in `schema_heal.py`, and chose to surface-and-skip rather than bundle a structural change to the fail-loud boot contract into a focused migration PR. I am following that precedent here: **no `schema_heal.py` edit in W2.1**. If column-level verification is desired, it should be its own PR with a deliberate design — likely a parallel `EXPECTED_COLUMNS: frozenset[tuple[str, str, str]]` of `(schema, table, column)` plus a second info-schema query in `verify_schema`.

## Substrate verification

### Pre-deploy

A Neon temp-branch verification was attempted via `mcp__fc897feb...__create_branch` but was **denied by harness permissions** in this dispatch (worktree agent does not hold Neon branch-create capability). The queries below are the ones the human reviewer or the merge operator should run on a temp branch derived from `BasisProtocol/main` (project `small-scene-57890564`, PG 17) before applying to prod. Each is small, idempotent against the temp branch, and bounded.

**Query 1 — column visible after migration:**

```sql
SELECT column_name, data_type, is_nullable, character_maximum_length
FROM information_schema.columns
WHERE table_name = 'state_attestations' AND column_name = 'writer_id';
```

Expected output:
```
 column_name | data_type         | is_nullable | character_maximum_length
-------------+-------------------+-------------+--------------------------
 writer_id   | character varying | YES         | 64
```

**Query 2 — existing rows have writer_id=NULL (no backfill expected):**

```sql
SELECT writer_id, COUNT(*) AS n
FROM state_attestations
GROUP BY writer_id
ORDER BY n DESC
LIMIT 5;
```

Expected output: a single row where `writer_id = NULL` and `n = <total row count of state_attestations>`. The grouping should not produce any non-NULL `writer_id` value because no caller has been updated yet (W2.2 will do that).

**Query 3 — backward-compat: new attestation with `writer_id = NULL` still inserts:**

```sql
INSERT INTO state_attestations (domain, batch_hash, cycle_timestamp, record_count, writer_id)
VALUES ('_w2_1_test', 'test_hash_w2_1', NOW(), 1, NULL)
RETURNING id, writer_id;

DELETE FROM state_attestations WHERE domain = '_w2_1_test';
```

Expected output: `RETURNING` row shows the inserted id and `writer_id = NULL`. The `DELETE` cleans up the test row.

**Query 4 — ALTER timing:**

```sql
\timing on
ALTER TABLE state_attestations ADD COLUMN IF NOT EXISTS writer_id VARCHAR(64) NULL;
```

Expected: well under 1 second. PG 17 ADD COLUMN with `NULL` default does not rewrite the table; only `pg_attribute` is updated. The lock is `AccessExclusive` but held for microseconds. Re-running the same statement produces a `NOTICE:  column "writer_id" of relation "state_attestations" already exists, skipping` with no error.

### Post-deploy halt criteria

After the migration runs on prod (via the normal `inline run_migrations()` step in `main.py` boot), the deploy is considered HEALTHY iff:

1. Query 1 above returns the expected row on prod (column present, VARCHAR(64), nullable).
2. `SELECT name, applied_at FROM migrations WHERE name = '111_state_attestations_writer_id';` returns exactly one row.
3. The next scoring cycle completes without raising in `attest_state()` — the kwarg threading is a no-op for current callers, but a syntax-level regression would surface as an exception in `_record_cycle_error` rows for `attest_state` failures.
4. `SELECT COUNT(*) FROM state_attestations WHERE writer_id IS NOT NULL;` returns `0` immediately after deploy (no caller writes a label yet) and stays `0` until W2.2 lands.

If any of the above fail, **HALT and roll back** before W2.2 dispatches.

## Wrapper ran-branch verification (v9.12 refactors only)

N/A for this PR. W2.1 does not wire any wrapper; it only widens the substrate schema so W2.2 can later distinguish wrapper-vs-heartbeat writes. The ran-branch verification gate applies starting at W2.2 when call sites are labeled and the discriminator becomes observable.

## Sequence note

This PR ships **W2.1 only**. Subsequent PRs in the sequence (NOT in scope here):

- **W2.2** — ships AFTER W2.1 deploys and Post-deploy queries pass. ~20-25 callsite updates adding `writer_id` labels (e.g. `"module.peg_monitor"`, `"heartbeat.slow_cycle"`, `"worker.inline.psi_components"`). Mechanical. Separate PR.
- **W2.3** — ships AFTER W2.2 verifies on prod. PR template + migration plan doc update to reference the discriminator (so future contributors know to label their writers).
- **W2.4** — ships AFTER 24h soak of W2.2's labels. `CREATE INDEX CONCURRENTLY idx_state_attestations_writer_id ON state_attestations (writer_id) WHERE writer_id IS NOT NULL` in migration 112. Closes the Phase 2.3 prerequisite chain.

## Test plan

- [ ] Reviewer or merge operator: create a Neon temp branch off `BasisProtocol/main`, apply `migrations/111_state_attestations_writer_id.sql`, run Queries 1-4 above, quote raw output in a PR comment before merge.
- [ ] Post-merge: confirm Query 1, Query 2, and the `migrations` row check pass on prod within 5 min of deploy.
- [ ] Watch `cycle_errors` for any `attest_state` / `store_attestation` / `attest_data_batch` failures in the next scoring cycle (should be zero — kwarg is a default-None no-op for all existing callers).

## References

- #235 — follow-up issue (Problem 2 is what this PR addresses; A5's recommendation cited Option A)
- PR #175 — current PR template with `## Substrate verification` and wrapper ran-branch sections
- PR #197 — precedent for surface-and-skip on `schema_heal.py` column-level edits
- PR #225 — wrapper-verification section + lesson 12 (codifies fallback-writer distinguishability)
- `app/state_attestation.py:42-93` — sole writer of `state_attestations` rows in the codebase (modulo `attest_data_batch` which delegates here)
- `app/worker.py:2650` — dispatcher heartbeat (one of the writers W2.2 will label)

---

https://claude.ai/code/session_017QJC4gmqRh6kdkNk3onqkB

---
_Generated by [Claude Code](https://claude.ai/code/session_017QJC4gmqRh6kdkNk3onqkB)_