### PR TITLE
fix(v9.12): remove assessments attest gate — write every cycle (mirror actors)

### DIFF
--- a/app/worker.py
+++ b/app/worker.py
@@ -1460,9 +1460,29 @@ async def run_fast_cycle():
             logger.info(f"Agent cycle: {result.get('assessments', 0)} assessments")
             try:
                 from app.state_attestation import attest_state
-                if result.get("assessments", 0) > 0:
+                # Mirror actor_classification.py:388-393 — write an attestation
+                # every cycle the agent runs cleanly, with `status=ran_no_results`
+                # when total_processed==0. Previous gate
+                # `if result.get("assessments", 0) > 0` filtered out clean-but-quiet
+                # cycles, so consumers could not distinguish "agent healthy, no
+                # triggers" from "agent silently broken" — exactly the lesson-12
+                # observability hazard #221/#225 set out to cure. Substrate
+                # evidence (5h post-#227 deploy): 117 SII cycles → 1 assessments
+                # row, despite multiple cycles where the watcher ran fine and
+                # heartbeats were stored at 20:01Z and 22:21Z. assessments has
+                # a 24h freshness floor in app/coherence.py:75, so the gate
+                # could silently break the coherence contract on any quiet day.
+                count = result.get("assessments", 0)
+                if count > 0:
                     attest_state("assessments", [{
-                        "assessments": result.get("assessments", 0),
+                        "status": "ran",
+                        "assessments": count,
+                        "severities": result.get("severities", {}),
+                    }])
+                else:
+                    attest_state("assessments", [{
+                        "status": "ran_no_results",
+                        "assessments": 0,
                         "severities": result.get("severities", {}),
                     }])
             except Exception as ae:


### PR DESCRIPTION
## Summary

- **Path B fix** per #225's lesson-12 classification. PR #227 (F2) moved the `assessments` attest from `main.py:322` (coroutine-bug dead path) to `app/worker.py:1463` (awaited live path) — but **kept a `if result.get("assessments", 0) > 0` gate**. That gate is the actual reason `state_attestations.domain='assessments'` has only 1 row in 5h+ post-deploy, despite 117 fast-cycle iterations.
- Mirror the pattern from `app/actor_classification.py:388-393`: write a `ran` attestation when `total_processed > 0`, write a `ran_no_results` attestation otherwise. Consumers can now distinguish "agent healthy, no triggers" from "agent silently broken."
- The coroutine bug at `main.py:296` remains intentionally untouched per F2 scope. `psi_collector.py:1783` writes `psi_score_change` events directly to `assessment_events`, bypassing `run_agent_cycle`'s `total_processed` counter — separate cleanup, not in this PR.
- Diff: +22 / -2 in `app/worker.py`. No new imports, no scope creep.

## Why the gate broke the contract

`app/coherence.py:75` sets `DOMAIN_FREQUENCIES["assessments"] = 24` (24h freshness floor, added by M in #213). The gate at `worker.py:1463` only attests when `result.get("assessments", 0) > 0`. On any quiet 24h period (no SII score changes, no large movements, no concentration shifts, no depegs, daily_cycle already ran today), `total_processed == 0` and the coherence freshness check silently fails. That's the lesson-12 hazard `#221`/`#225` set out to cure — the new live-path call site is structurally correct but **still gated against the actor-pattern**, which always attests.

## Substrate verification

### Pre-deploy

```sql
-- State at 2026-05-14T00:40Z (5h00m after #227 deploy at 2026-05-13T19:40Z)
SELECT COUNT(*), MIN(cycle_timestamp), MAX(cycle_timestamp)
FROM state_attestations WHERE domain = 'assessments';
-- 1 row | 2026-05-14T00:37:59Z | 2026-05-14T00:37:59Z

-- Fast-cycle iterations since #227 deploy (proxy: sii_components is unconditional, every cycle)
SELECT COUNT(*) FROM state_attestations
WHERE domain = 'sii_components'
  AND cycle_timestamp > '2026-05-13T19:40:00Z'::timestamptz;
-- 117 cycles

-- Watcher activity in window — proves agent IS firing events
SELECT trigger_type, COUNT(*) FROM assessment_events
WHERE created_at > '2026-05-13T19:40:00Z'::timestamptz
GROUP BY 1 ORDER BY 2 DESC;
-- daily_cycle:100 | psi_score_change:5 | heartbeat:2
```

Heartbeats at 20:01Z and 22:21Z prove `total_processed == 0` cycles ran cleanly. Yet `state_attestations` records nothing for those cycles — exactly the gate's behaviour. The 5 `psi_score_change` events were written by `app/collectors/psi_collector.py:1783` (PSI collector path, not `run_agent_cycle`), so they don't increment `total_processed` and don't trip the gate even though they're real assessment events. Net: the gate is invisible to PSI-driven activity and silent on quiet cycles.

### Post-deploy halt criteria

Per #225's PR template wrapper-verification section. Expected substrate signature **distinguishes the new ran-branch from the previous gated behavior**:

- `state_attestations.domain='assessments'` advances **every fast cycle** (every ~150s, matching `sii_components` cadence). Both `status='ran'` and `status='ran_no_results'` payloads are acceptable — distinguish via `batch_hash` inspection.
- `record_count = 1` per row (single-element list). `payload` json contains the `status` key (`ran` or `ran_no_results`).
- **Halt rule**: if `state_attestations` count for `assessments` after 4h is less than 95% of the `sii_components` count for the same window → the gate fix didn't land or another upstream blocker exists; surface. (Allowing 5% slack for transient `attest_state` exceptions, which are debug-logged but don't crash the cycle.)

### Verification queries (post-deploy)

```sql
-- Should grow roughly 1:1 with sii_components
WITH win AS (SELECT NOW() - INTERVAL '4 hours' AS t)
SELECT
  (SELECT COUNT(*) FROM state_attestations s, win WHERE s.domain='assessments' AND s.cycle_timestamp > win.t) AS assessments,
  (SELECT COUNT(*) FROM state_attestations s, win WHERE s.domain='sii_components' AND s.cycle_timestamp > win.t) AS sii_cycles;

-- Confirm the ran / ran_no_results split is observable in payload
SELECT
  COUNT(*) FILTER (WHERE batch_hash IS NOT NULL) AS rows,
  COUNT(DISTINCT batch_hash) AS distinct_hashes
FROM state_attestations
WHERE domain = 'assessments'
  AND cycle_timestamp > NOW() - INTERVAL '4 hours';

-- actors should be unchanged — sanity that this PR didn't accidentally touch the classification writers
SELECT COUNT(*), MAX(cycle_timestamp)
FROM state_attestations WHERE domain='actors';
```

## Test plan

- [ ] CI green (Python parse + existing test suite).
- [ ] After merge + deploy, run the three queries above at the 4h mark.
- [ ] If `assessments` >= 0.95 * `sii_cycles` in window → fix verified.
- [ ] If `assessments` < 0.95 * `sii_cycles` → halt + surface (gate fix didn't land OR another blocker).
- [ ] Sanity: `actors` row count + latest timestamp unchanged from pre-merge — this PR doesn't touch classification writers.

Closes the observability gap surfaced post-#227. Refs #227, #221, #225, #213.

https://claude.ai/code/session_017QJC4gmqRh6kdkNk3onqkB

---
_Generated by [Claude Code](https://claude.ai/code/session_017QJC4gmqRh6kdkNk3onqkB)_