### PR TITLE
docs(audit): file Wave-N entry for psi_score_change bypass of assessment counter

### DIFF
--- a/docs/audits/2026-05-11-module-canonical-migration-plan.md
+++ b/docs/audits/2026-05-11-module-canonical-migration-plan.md
@@ -385,3 +385,41 @@ Cost: +35 `/exchanges/{id}` + `/exchanges/{id}/volume_chart/30`
 calls per fast cycle (~80 calls / cycle / hour). CG pro tier
 (500/min, 500k credits/month) has ample headroom. Worth a brief
 budget check against the daily usage tracker before flipping.
+
+---
+
+## Wave-N candidates
+
+Items surfaced during v9.12 remediation that are out of scope for the
+current sweep but warrant a tracked entry. Pick up in a future
+v9.13/v9.14-style amendment session or when blocked-on prerequisites
+clear.
+
+### `assessments` — secondary writer bypasses agent counter
+
+**Surfaced:** 2026-05-13 Prompt 2 audit (#238 gate fix).
+
+**Finding:** `app/collectors/psi_collector.py:1783` writes
+`psi_score_change` events directly to `assessment_events` table,
+bypassing `run_agent_cycle`'s `total_processed` counter. Substrate
+cite (5h window): 5 `psi_score_change` events in `assessment_events`,
+but none counted by the agent's gate (now-fixed in #238 to attest
+unconditionally — but `record_count` still won't reflect the
+`psi_score_change` writes).
+
+**Class:** Coherence gap — domain has 2 write surfaces; one isn't
+seen by the canonical writer that drives the attestation.
+
+**Priority:** P2. Not data-quality (events ARE being written and
+stored); just attestation provenance is incomplete. Defer until
+v9.13-style coupled-write design call for `assessments` (or until
+`writer_id` from #235 Option A makes the discrepancy visible via
+Option A query).
+
+**When picked up:** decide whether `psi_collector.py:1783` should also
+attest `'assessments'` with `writer_id='module.psi_collector'`, or
+whether the agent should query `assessment_events` directly to
+include all events in its counter.
+
+**Refs:** #238 (gate fix), #235 (writer_id discriminator), #208 +
+#221 (original `actors`/`assessments` domain split history).


### PR DESCRIPTION
## Summary

Files a Wave-N candidate entry in the migration plan for the architectural finding surfaced during Prompt 2's audit of #227 (the assessments gate fix that became #238).

**Finding (briefly):** `app/collectors/psi_collector.py:1783` writes `psi_score_change` events directly to the `assessment_events` table, bypassing `run_agent_cycle`'s `total_processed` counter. The 2026-05-13 5h substrate window showed 5 `psi_score_change` events stored but invisible to the agent's gate. Even with the unconditional-attest fix in #238, the `record_count` won't reflect these writes — `assessments` has two write surfaces but only one is seen by the canonical writer.

**Class:** Coherence gap. Not data-quality (events ARE being written); attestation provenance is incomplete.

**Priority:** P2. Defer until either:
- a v9.13-style coupled-write design call for `assessments`, OR
- #235 Option A's `writer_id` ships (W2.1 just merged in #237) and makes the discrepancy queryable

## Why a docs PR, not a code fix

Two non-trivial design choices need operator input before any code change:
1. Should `psi_collector.py:1783` also call `attest_state('assessments', ..., writer_id='module.psi_collector')`? That double-writes the `assessments` domain.
2. Or should `run_agent_cycle` query `assessment_events` directly to include all events in its counter?

Neither is mechanical, so this PR just tracks the entry for future pickup.

## Changes

Adds a new `## Wave-N candidates` section at the end of `docs/audits/2026-05-11-module-canonical-migration-plan.md` with the first entry under it.

`+38 / -0` in `docs/audits/2026-05-11-module-canonical-migration-plan.md`.

## Substrate verification

### N/A

Docs-only bookkeeping entry. The substrate evidence (5 `psi_score_change` events in the 5h window) is quoted in the entry body and was substantiated in PR #238's review.

## Refs

- #238 (assessments gate fix, where this was surfaced)
- #235 (writer_id discriminator that would make this queryable)
- #208 + #221 (original `actors`/`assessments` domain split history)

https://claude.ai/code/session_017QJC4gmqRh6kdkNk3onqkB

---
_Generated by [Claude Code](https://claude.ai/code/session_017QJC4gmqRh6kdkNk3onqkB)_