### PR TITLE
fix(parameter_history): scored_at -> computed_at on scores table

### DIFF
--- a/app/collectors/parameter_history.py
+++ b/app/collectors/parameter_history.py
@@ -323,7 +323,7 @@ async def _get_concurrent_scores(protocol_slug: str, asset_symbol: str | None) -
         sii_row = await fetch_one_async(
             """SELECT overall_score FROM scores
                WHERE stablecoin_id = LOWER(%s)
-               ORDER BY scored_at DESC LIMIT 1""",
+               ORDER BY computed_at DESC LIMIT 1""",
             (asset_symbol,),
         )
         if sii_row:


### PR DESCRIPTION
## Summary

One-line fix. `app/collectors/parameter_history.py:326` ordered `scores` rows by `scored_at`, but the `scores` table exposes `computed_at` / `updated_at` (column `scored_at` lives on `psi_scores`, not `scores`). The collector caught the exception but recorded a `cycle_errors` row every iteration.

Refs: `docs/audits/2026-05-14-cycle-errors-taxonomy.md` (PR #243).

## Substrate verification

### Pre-deploy

24h baseline of `column "scored_at" does not exist` errors in `parameter_history`:
```sql
SELECT COUNT(*)
FROM cycle_errors
WHERE cycle_phase = 'parameter_history'
  AND error_message LIKE 'column "scored_at" does not exist%'
  AND occurred_at > NOW() - INTERVAL '24 hours';
-- → 136
```

### Post-deploy halt criteria (2h)

Target: `<10` new occurrences in the 2h window after deploy (allowing one cycle of stragglers from in-flight cycles already past the catch block).

Verification query:
```sql
SELECT COUNT(*)
FROM cycle_errors
WHERE cycle_phase = 'parameter_history'
  AND error_message LIKE 'column "scored_at" does not exist%'
  AND occurred_at > <deploy_ts>;
```

If the count is >= 10 at the 2h mark, halt and investigate (most likely another callsite missed; `grep -rn "ORDER BY scored_at" app/` should still show zero `FROM scores` hits).

https://claude.ai/code/session_017QJC4gmqRh6kdkNk3onqkB

---
_Generated by [Claude Code](https://claude.ai/code/session_017QJC4gmqRh6kdkNk3onqkB)_