### PR TITLE
refactor(v9.12): rpi_components module-canonical (DRAFT — path decision pending)

### DIFF
--- a/app/rpi/scorer.py
+++ b/app/rpi/scorer.py
@@ -645,6 +645,178 @@ def sync_all_lens_components(protocols: list[str]) -> dict:
 
 
 # =============================================================================
+# Module-canonical wrapper for rpi_components attestation (v9.12 Wave 3.1)
+# =============================================================================
+#
+# Background:
+#   rpi_components attestations historically came from two paths:
+#     1. `app.enrichment_worker._run_rpi` — wraps run_rpi_scoring() and
+#        attests with writer_id="enrichment.rpi_scoring" using a list of
+#        {slug, score} records (record_count == #protocols scored).
+#     2. `app.worker._emit_slow_cycle_heartbeats` — fires once per slow
+#        cycle with writer_id="heartbeat.slow_cycle" and a placeholder
+#        payload {status, via, ...} (record_count == 1).
+#
+#   In production today (substrate cite at PR body), 100% of recent rows
+#   come from path (2) — record_count=1, writer_id=null. The enrichment
+#   task's attestation is currently dormant (its 24h gate caps freshness
+#   to once/day, and the heartbeat fires every slow cycle).
+#
+#   Phase 2.3a (the next PR) will remove rpi_components from the heartbeat
+#   loop in worker.py. This wrapper is the module-canonical replacement
+#   the heartbeat path will drop into; the enrichment worker can also be
+#   migrated to call it instead of attesting inline.
+#
+# Distinguishable signatures (Lesson 12):
+#   - heartbeat path:  record_count == 1, payload = {"status": "...",
+#     "via": "run_slow_cycle_parallel", ...}
+#   - wrapper ran:     record_count == #protocols scored (>=1, usually
+#     13+ given current RPI_TARGET_PROTOCOLS list), payload entries are
+#     {"slug": ..., "score": ...} dicts. NEVER contains "via".
+#   - wrapper skipped_fresh: record_count == 1, payload =
+#     {"status": "skipped_fresh", "table_age_minutes": X}
+#   - wrapper error: record_count == 1, payload =
+#     {"status": "error", "table_age_minutes": X, "error": "..."}
+#
+# Mirrors #198 (exchange_collector) / #193 (peg_monitor) / #240
+# (psi_collector). Freshness gate at 24h matches the existing enrichment
+# task gate (`SELECT MAX(computed_at) FROM rpi_scores`, min_hours=24).
+# =============================================================================
+
+# RPI is a slow/daily cycle. Match the enrichment-worker gate exactly.
+# 1440 min = 24h. Use a slightly smaller value so the wrapper "ran" branch
+# can fire on a cycle that races ahead of the gate (e.g., if rpi_scores
+# was last written 23h59m ago we should still let it run).
+_RPI_FRESHNESS_MINUTES = 1380  # 23h
+
+
+async def run_rpi_scoring_scheduled(
+    cycle_ts: datetime | None = None,
+) -> dict:
+    """Module-canonical scheduler entry for rpi_components per v9.12.
+
+    Returns a status dict regardless of branch:
+      - {"status": "skipped_fresh", "table_age_minutes": X}
+      - {"status": "ran", "protocols_scored": N, ...}
+      - {"status": "error", "error": str}
+
+    The state_attestations row for ``rpi_components`` fires inside this
+    function on every branch (skipped_fresh / ran / error). Schedulers
+    (worker.py slow-cycle heartbeat, enrichment_worker._run_rpi) MUST NOT
+    re-attest after calling this wrapper.
+
+    Freshness gate keys on ``rpi_scores.computed_at`` — the table that
+    ``run_rpi_scoring`` writes via ``store_rpi_score``. ``rpi_components``
+    is BOTH the attestation domain AND a real table (component values per
+    protocol); the freshness anchor we use here is the parent ``rpi_scores``
+    table because that is what ``run_rpi_scoring`` produces as its final
+    output, matching the gate in app.enrichment_worker.
+
+    Args:
+      cycle_ts: optional timestamp passed by scheduler. Not stored —
+        state_attestations uses NOW(). Accepted for caller-symmetry with
+        ``run_psi_discovery_monitor_scheduled`` (#230).
+    """
+    from app.state_attestation import attest_state
+
+    _ = cycle_ts  # currently unused; reserved for future symmetry
+
+    table_age_minutes: float = float(_RPI_FRESHNESS_MINUTES)
+    try:
+        latest = await asyncio.to_thread(
+            fetch_one, "SELECT MAX(computed_at) AS t FROM rpi_scores"
+        )
+        if latest and latest.get("t"):
+            _t = latest["t"]
+            if hasattr(_t, "tzinfo") and _t.tzinfo is None:
+                _t = _t.replace(tzinfo=timezone.utc)
+            if hasattr(_t, "timestamp"):
+                table_age_minutes = (
+                    datetime.now(timezone.utc) - _t
+                ).total_seconds() / 60
+    except Exception as e:
+        logger.warning(f"[rpi.scorer] freshness check failed: {e}")
+        table_age_minutes = float(_RPI_FRESHNESS_MINUTES)
+
+    if table_age_minutes < _RPI_FRESHNESS_MINUTES:
+        skipped_payload = {
+            "status": "skipped_fresh",
+            "table_age_minutes": round(table_age_minutes, 2),
+        }
+        try:
+            await asyncio.to_thread(
+                attest_state,
+                "rpi_components",
+                [skipped_payload],
+                None,
+                "module.rpi_scorer",
+            )
+        except Exception as e:
+            logger.warning(f"[rpi.scorer] skipped-fresh attest failed: {e}")
+        return skipped_payload
+
+    try:
+        rpi_results = await asyncio.to_thread(run_rpi_scoring)
+        # Preserve the payload shape `_run_rpi` used pre-Wave-3.1:
+        # one dict per protocol with {slug, score}. entity_id stays NULL,
+        # matching the existing 30-row rpi_components attestation history.
+        attest_records = [
+            {"slug": r.get("protocol_slug", ""), "score": r.get("overall_score")}
+            for r in (rpi_results or [])
+            if isinstance(r, dict)
+        ]
+        if attest_records:
+            try:
+                await asyncio.to_thread(
+                    attest_state,
+                    "rpi_components",
+                    attest_records,
+                    None,
+                    "module.rpi_scorer",
+                )
+            except Exception as e:
+                logger.warning(f"[rpi.scorer] ran attest failed: {e}")
+        else:
+            # Attest even when zero protocols scored so the domain stays
+            # fresh. Same lesson as psi_components (#240) and
+            # psi_discoveries (#137) — gating on non-empty results lets
+            # the domain go silent on transient failures.
+            try:
+                await asyncio.to_thread(
+                    attest_state,
+                    "rpi_components",
+                    [{"status": "ran", "protocols_scored": 0}],
+                    None,
+                    "module.rpi_scorer",
+                )
+            except Exception as e:
+                logger.warning(f"[rpi.scorer] ran-empty attest failed: {e}")
+        return {
+            "status": "ran",
+            "table_age_minutes": round(table_age_minutes, 2),
+            "protocols_scored": len(attest_records),
+        }
+    except Exception as e:
+        logger.warning(f"[rpi.scorer] scheduled run failed: {e}")
+        error_payload = {
+            "status": "error",
+            "table_age_minutes": round(table_age_minutes, 2),
+            "error": str(e)[:200],
+        }
+        try:
+            await asyncio.to_thread(
+                attest_state,
+                "rpi_components",
+                [error_payload],
+                None,
+                "module.rpi_scorer",
+            )
+        except Exception:
+            pass
+        return {"status": "error", "error": str(e)[:500]}
+
+
+# =============================================================================
 # Orchestrator
 # =============================================================================
 


### PR DESCRIPTION
## Halt note

**Awaiting operator decision on path before flipping draft → ready.**
Specifically: confirm Path A (this PR) is correct, or pivot to Path B / C / D.
No callsite has been migrated; nothing in the existing pipeline behaviour changes by merging this PR. Wave 3.1 is the wrapper only; **Phase 2.3a is a separate PR** that removes `rpi_components` from `_emit_slow_cycle_heartbeats` and starts routing the slow-cycle through the wrapper.

## Path chosen: A (wrapper in existing module)

`app/rpi/scorer.py` already contains `run_rpi_scoring()` (a clean orchestrator: revenue cache → lens sync → per-slug `collect_raw_values` + `score_rpi_base` + `store_rpi_score`). It is wrapped today by `app.enrichment_worker._run_rpi`, which already attests `rpi_components` with `writer_id="enrichment.rpi_scoring"` and a `{slug, score}` records list.

The wrapper sits next to `run_rpi_scoring` and is the single canonical owner of the `rpi_components` attestation domain. Mirrors:
- `app/data_layer/exchange_collector.py::run_exchange_collection_scheduled` (#198)
- `app/data_layer/peg_monitor.py::run_peg_monitoring_scheduled` (#193)
- `app/collectors/psi_collector.py::run_psi_scoring_scheduled` (#240)

## Alternative paths considered

- **Path B (extract from worker.py / heartbeat):** Rejected — the heartbeat doesn't *compute* `rpi_components`, it only emits a placeholder. No logic lives in `worker.py` to extract. Extraction would be a no-op rename.
- **Path C (new file in `app/collectors/`):** Rejected — RPI scoring logic already has a home at `app/rpi/scorer.py` (684 lines, cleanly factored). Creating `app/collectors/rpi_collector.py` would split a cohesive module across two files for no architectural gain. Diverges from how PSI's wrapper is structured: PSI scoring lives in `app/collectors/psi_collector.py` because that *is* PSI's module home; for RPI, the module home is `app/rpi/`.
- **Path D (heartbeat-only domain):** Rejected — the `rpi_scores` table has 221 rows over multiple weeks, and the enrichment worker's `_run_rpi` does produce real `rpi_components` attestations historically (avg `record_count` = 3.00 over the 30-row lifetime of the domain). RPI is a real domain with a real writer; the heartbeat has just been the dominant writer recently.

## Substrate verification

### Pre-deploy (this PR)

Full domain history:
```
SELECT COUNT(*) AS rows, COUNT(DISTINCT writer_id) AS writers,
       AVG(record_count)::numeric(10,2) AS avg_rc,
       MIN(cycle_timestamp), MAX(cycle_timestamp)
FROM state_attestations WHERE domain = 'rpi_components';
```
```
rows | writers | avg_rc | min_ts                    | max_ts
30   | 0       | 3.00   | 2026-04-12 14:08:45.284Z  | 2026-05-13 23:04:34.126Z
```

> `writers = 0` because **all 30 rows have `writer_id IS NULL`** — W2.2 (#241) labels haven't propagated to the production deploy yet, and `_run_rpi`'s attestation path doesn't pass `writer_id`. Avg `record_count` of 3.00 reflects the mix of heartbeat (rc=1) and historical enrichment writes (rc=#protocols).

Last 24 hours (only heartbeat is firing):
```
writer_id | n  | avg_rc | last_ts
NULL      | 10 | 1.00   | 2026-05-13 23:04:34.126Z
```

Last 10 rows in domain — all `record_count = 1`, all `writer_id = NULL` (heartbeat-only signature):
```
2026-05-13 23:04:34  rc=1  hash=254da178…
2026-05-13 20:52:47  rc=1  hash=254da178…
2026-05-13 18:16:20  rc=1  hash=254da178…
... (repeating heartbeat payload)
```

Freshness anchor table:
```sql
SELECT MAX(computed_at) AS latest_rpi_score, COUNT(*) AS row_count FROM rpi_scores;
```
```
latest_rpi_score          | row_count
2026-05-12 16:17:37.828Z  | 221
```

So `rpi_scores` is ~30 hours stale — the enrichment task's 24h gate should have fired today but apparently hasn't (or fired but the attest path silently errored). This is **further evidence the heartbeat is masking a real coherence signal** and motivates the move away from "rpi_components-as-heartbeat".

### Post-deploy halt criteria (placeholder — fills in when flipped to ready)

After Phase 2.3a (next PR) routes the heartbeat through this wrapper and removes `rpi_components` from the `_emit_slow_cycle_heartbeats` for-loop, post-deploy substrate should show:

```sql
SELECT writer_id, COUNT(*), AVG(record_count)::numeric(10,2), MAX(cycle_timestamp)
FROM state_attestations
WHERE domain = 'rpi_components' AND cycle_timestamp > NOW() - INTERVAL '6 hours'
GROUP BY writer_id ORDER BY MAX(cycle_timestamp) DESC;
```

Expected:
- `module.rpi_scorer` appears as a writer
- `heartbeat.slow_cycle` no longer appears for this domain
- At least one of `skipped_fresh` / `ran` rows fires per slow cycle
- `ran` branch produces `record_count >= 13` (matching `len(RPI_TARGET_PROTOCOLS)`)
- No null `writer_id` rows for this domain after the deploy timestamp

(Currently TBD — fills in once Phase 2.3a lands and we have ≥6h of post-deploy data.)

## Wrapper shape (mirrors #198/#193/#240)

```python
async def run_rpi_scoring_scheduled(cycle_ts: datetime | None = None) -> dict:
    # 1. Check freshness via SELECT MAX(computed_at) FROM rpi_scores
    # 2. If table_age_minutes < 1380 → attest skipped_fresh, return
    # 3. Else: await asyncio.to_thread(run_rpi_scoring)
    #          attest list of {slug, score} dicts (record_count = N protocols)
    # 4. On exception → attest error payload, return error status
    # All branches go through writer_id="module.rpi_scorer"
```

### Distinguishable `ran` signature (Lesson 12)

| Path | record_count | writer_id | payload distinguisher |
|------|-------------:|-----------|------------------------|
| heartbeat (current) | 1 | `heartbeat.slow_cycle` (when #241 deploys) | contains `"via": "run_slow_cycle_parallel"` |
| wrapper `ran` | N protocols (≥1, currently 13+) | `module.rpi_scorer` | list of `{"slug", "score"}` dicts; no `"via"` key |
| wrapper `skipped_fresh` | 1 | `module.rpi_scorer` | `{"status": "skipped_fresh", "table_age_minutes": ...}`; no `"via"` |
| wrapper `error` | 1 | `module.rpi_scorer` | `{"status": "error", ...}`; no `"via"` |

So even in the `skipped_fresh`/`error` corner where the wrapper also lands on `record_count == 1`, the `writer_id` is `module.rpi_scorer` (not `heartbeat.slow_cycle`) and the payload has no `"via"` key — Lesson 12 is satisfied.

## Wrapper code

172-line addition to `app/rpi/scorer.py`, all under one block (`# Module-canonical wrapper for rpi_components attestation`). Reuses the file's existing imports (`asyncio`, `datetime`, `timezone`, `fetch_one`, `logger`); only `attest_state` is imported at function scope to avoid circular import risk. Constant: `_RPI_FRESHNESS_MINUTES = 1380` (23 hours) — matches the existing 24h enrichment-worker gate with a 1-hour margin so a slow-cycle racing the gate still gets to run.

## Pre-existing tests

`tests/test_rpi_attestation.py` exists and patches `app.rpi.scorer.run_rpi_scoring` + asserts `attest_state` is called with domain `"rpi_components"` and a `[{"slug": ..., "score": ...}]` list. That test exercises the **current** `_run_rpi` enrichment path, not the new wrapper. The wrapper-level test will go in alongside Phase 2.3a when call-sites flip; this draft intentionally adds no test (no behaviour change yet, nothing to assert beyond "the function is importable").

## What this PR does NOT do (out of scope; deferred to Phase 2.3a)

- Does **not** call `run_rpi_scoring_scheduled` from anywhere
- Does **not** remove `rpi_components` from `_emit_slow_cycle_heartbeats`
- Does **not** modify `app.enrichment_worker._run_rpi` to call the wrapper
- Does **not** add a test for the wrapper

Pure additive: a new async function in `app/rpi/scorer.py` that no caller is wired to yet. Importable, syntactically valid, dead code until Phase 2.3a flips it on. Safe to merge as draft → review → ready once path is confirmed.

## Halt rules considered

- ☑ Wrapper code under 300 lines (172 lines added, well within limit)
- ☑ No schema changes required (uses existing `state_attestations` and `rpi_scores` tables)
- ☑ Lesson-10 reading complete: read `_emit_slow_cycle_heartbeats`, `_run_rpi`, `run_rpi_scoring`, three precedent wrappers (psi, peg, exchange), `attest_state` signature, `tests/test_rpi_attestation.py`, full substrate state
- ☐ **Architectural surprise:** the enrichment task's `_run_rpi` already does the attestation. After Phase 2.3a we'll need a *follow-up decision*: should `_run_rpi` also be migrated to call the wrapper, or should the heartbeat-only path be the wrapper's caller? Both options leave the wrapper's contract unchanged but have different blast radii. Surfacing for operator awareness — not blocking this PR.

https://claude.ai/code/session_017QJC4gmqRh6kdkNk3onqkB

---
_Generated by [Claude Code](https://claude.ai/code/session_017QJC4gmqRh6kdkNk3onqkB)_