### PR TITLE
fix(governance_forum_posts): correct column names in two readers

### DIFF
--- a/app/collectors/dao_collector.py
+++ b/app/collectors/dao_collector.py
@@ -586,15 +586,17 @@ def _automate_dao_transparency(entity: dict, static: dict) -> dict:
                            'monthly update', 'financial update', 'budget report',
                            'spending report', 'treasury update']
 
-        # Check governance_forum_posts table for report-like posts
+        # Check governance_forum_posts table for report-like posts.
+        # Schema: timestamp column is `posted_at` (not `collected_at`),
+        # body text is `body_excerpt` (not `raw_text`).
         row = fetch_one("""
             SELECT COUNT(*) AS report_count
             FROM governance_forum_posts
             WHERE protocol_slug = %s
-              AND collected_at >= NOW() - INTERVAL '365 days'
+              AND posted_at >= NOW() - INTERVAL '365 days'
               AND (
                   LOWER(title) SIMILAR TO %s
-                  OR LOWER(raw_text) SIMILAR TO %s
+                  OR LOWER(body_excerpt) SIMILAR TO %s
               )
         """, (
             protocol_slug,

--- a/app/rpi/scorer.py
+++ b/app/rpi/scorer.py
@@ -531,15 +531,18 @@ def _sync_lens_vendor_diversity(slug: str) -> float | None:
     read the count and write the normalized score to rpi_components.
     """
     try:
+        # governance_forum_posts schema: `mentioned_vendors` is JSONB
+        # (array of strings), the post timestamp is `posted_at`.
         row = fetch_one("""
             SELECT COUNT(DISTINCT vendor_name) AS vendor_count
             FROM (
-                SELECT UNNEST(vendor_mentions) AS vendor_name
+                SELECT jsonb_array_elements_text(mentioned_vendors) AS vendor_name
                 FROM governance_forum_posts
                 WHERE protocol_slug = %s
-                  AND collected_at >= NOW() - INTERVAL '365 days'
-                  AND vendor_mentions IS NOT NULL
-                  AND ARRAY_LENGTH(vendor_mentions, 1) > 0
+                  AND posted_at >= NOW() - INTERVAL '365 days'
+                  AND mentioned_vendors IS NOT NULL
+                  AND jsonb_typeof(mentioned_vendors) = 'array'
+                  AND jsonb_array_length(mentioned_vendors) > 0
             ) sub
         """, (slug,))
 


### PR DESCRIPTION
## Summary

Two readers of `governance_forum_posts` were querying columns that don't exist on that table:

- `app/rpi/scorer.py` referenced `vendor_mentions` and treated it as a Postgres array. Actual column is `mentioned_vendors` and it's JSONB. Switched to `jsonb_array_elements_text` / `jsonb_array_length` / `jsonb_typeof` and changed `collected_at` to `posted_at`.
- `app/collectors/dao_collector.py` referenced `collected_at` (wrong) and `raw_text` (wrong). Switched to `posted_at` and `body_excerpt`.

Both queries were caught by the surrounding try/except, but each iteration appended a row to `cycle_errors`. Two files bundled because they share a single defect class (governance_forum_posts column drift) and the total diff is <30 lines.

Refs: `docs/audits/2026-05-14-cycle-errors-taxonomy.md` (PR #243).

## Substrate verification

### Pre-deploy

24h baselines:
```sql
SELECT cycle_phase, COUNT(*)
FROM cycle_errors
WHERE occurred_at > NOW() - INTERVAL '24 hours'
  AND (
    (cycle_phase = 'dao_collector' AND error_message LIKE 'column "collected_at" does not exist%')
    OR (cycle_phase = 'rpi_scorer' AND error_message LIKE 'column "vendor_mentions" does not exist%')
  )
GROUP BY cycle_phase;
-- dao_collector: 7
-- rpi_scorer:    last fired 2026-05-12T16:17 (not in last 24h, but pattern is real;
--                rpi_scorer runs less frequently than dao_collector)
```

### Post-deploy halt criteria (2h)

- `dao_collector` / `column "collected_at" does not exist`: 0 new occurrences after deploy.
- `rpi_scorer` / `column "vendor_mentions" does not exist`: 0 new occurrences after deploy.
- New regression check: 0 errors of class `column "body_excerpt" does not exist` or `column "posted_at" does not exist` or `jsonb_typeof ...` — the schema check was run against `information_schema.columns` before authoring, so this should hold.

Verification:
```sql
SELECT cycle_phase, LEFT(error_message, 80), COUNT(*)
FROM cycle_errors
WHERE occurred_at > <deploy_ts>
  AND cycle_phase IN ('dao_collector', 'rpi_scorer')
GROUP BY 1, 2;
```

https://claude.ai/code/session_017QJC4gmqRh6kdkNk3onqkB

---
_Generated by [Claude Code](https://claude.ai/code/session_017QJC4gmqRh6kdkNk3onqkB)_