### PR TITLE
fix(schema-drift): entity_id → entity_slug in 4 occurrences

### DIFF
--- a/app/data_layer/entity_discovery.py
+++ b/app/data_layer/entity_discovery.py
@@ -74,11 +74,11 @@ async def _get_existing_entities() -> set:
     existing = set()
     try:
         rows = await fetch_all_async(
-            """SELECT DISTINCT entity_id FROM generic_index_scores
+            """SELECT DISTINCT entity_slug FROM generic_index_scores
                WHERE index_id IN ('lsti', 'bri', 'vsri', 'cxri', 'tti', 'dohi')"""
         )
         if rows:
-            existing.update(r["entity_id"] for r in rows)
+            existing.update(r["entity_slug"] for r in rows)
     except asyncio.CancelledError:
         raise
     except Exception as e:

--- a/app/track_record.py
+++ b/app/track_record.py
@@ -91,7 +91,7 @@ def _get_entity_baseline(entity_slug: str, index_name: str) -> dict:
 
     elif index_name in ("lsti", "bri", "dohi", "vsri", "cxri", "tti"):
         row = fetch_one(
-            "SELECT * FROM generic_index_scores WHERE index_id = %s AND entity_id = %s ORDER BY computed_at DESC LIMIT 1",
+            "SELECT * FROM generic_index_scores WHERE index_id = %s AND entity_slug = %s ORDER BY computed_at DESC LIMIT 1",
             (index_name, entity_slug),
         )
         if row:

--- a/app/track_record_followups.py
+++ b/app/track_record_followups.py
@@ -68,7 +68,7 @@ def _get_current_entity_state(entity_slug: str, index_name: str) -> dict:
 
     elif index_name in ("lsti", "bri", "dohi", "vsri", "cxri", "tti"):
         row = fetch_one(
-            "SELECT overall_score, confidence_tag FROM generic_index_scores WHERE index_id = %s AND entity_id = %s ORDER BY computed_at DESC LIMIT 1",
+            "SELECT overall_score, confidence_tag FROM generic_index_scores WHERE index_id = %s AND entity_slug = %s ORDER BY computed_at DESC LIMIT 1",
             (index_name, entity_slug),
         )
         if row:


### PR DESCRIPTION
## Summary

The `generic_index_scores` table has column `entity_slug`, not `entity_id`. Four call sites referenced the wrong name, causing recurring `column "entity_id" does not exist` errors in the `entity_discovery` cycle and silent baseline/state misses in `track_record` + `track_record_followups` for the `lsti/bri/dohi/vsri/cxri/tti` indices.

Strict column-reference swap — no schema migration, no semantic change. Surrounding SQL columns, indentation, and Python logic preserved exactly. Total diff: 4 line additions, 4 line deletions across 3 files.

Surfaced by A2 audit (halt-and-surface). A2 halted at PATH C because no `RENAME COLUMN` exists in `migrations/`, but the column has been named `entity_slug` in the live schema since table creation — there is no rename to find, just an incorrect call-site reference. The swap is therefore semantically lossless.

## Substrate verification

### Pre-deploy

**Schema check via Neon (`mcp__fc897feb-984f-4733-9115-5f45deac921b__run_sql`, project `small-scene-57890564`):**

```sql
SELECT column_name, data_type FROM information_schema.columns
WHERE table_schema = 'public' AND table_name = 'generic_index_scores'
  AND column_name IN ('entity_id', 'entity_slug')
ORDER BY column_name;
```

Raw output:
```
[
  {
    "column_name": "entity_slug",
    "data_type": "text"
  }
]
```

`entity_slug` present (text), `entity_id` absent. Confirms the call sites are the wrong references.

**Active error substrate query:**

```sql
SELECT cycle_phase, COUNT(*) AS occurrences_1h
FROM cycle_errors
WHERE cycle_phase = 'entity_discovery'
  AND error_message ILIKE '%column "entity_id" does not exist%'
  AND occurred_at > NOW() - INTERVAL '1 hour'
GROUP BY cycle_phase;
```

Raw output:
```
[
  {
    "cycle_phase": "entity_discovery",
    "occurrences_1h": "2"
  }
]
```

Errors are actively recurring — fix is needed.

**File:line → change table (all 4 occurrences):**

| File | Line | Change |
|---|---|---|
| `app/data_layer/entity_discovery.py` | 77 | SQL: `SELECT DISTINCT entity_id` → `SELECT DISTINCT entity_slug` |
| `app/data_layer/entity_discovery.py` | 81 | Dict access: `r["entity_id"]` → `r["entity_slug"]` |
| `app/track_record.py` | 94 | SQL: `AND entity_id = %s` → `AND entity_slug = %s` |
| `app/track_record_followups.py` | 71 | SQL: `AND entity_id = %s` → `AND entity_slug = %s` |

Confirmed via grep that no fifth occurrence exists against `generic_index_scores`; the remaining `entity_id` references in the codebase are for unrelated tables (`sbt_tokens`, `report_attestations`, `contract_surveillance`, oracle key namespacing).

### Post-deploy halt criteria (2h after Railway deploy)

```sql
SELECT COUNT(*) FROM cycle_errors
WHERE cycle_phase = 'entity_discovery'
  AND error_message ILIKE '%column "entity_id" does not exist%'
  AND occurred_at > '<deploy_ts>'::timestamptz;
-- Expected: 0
```

**Halt rule:** if count > 0 at T+2h after deploy is fully live → revert this PR; the rename target may have been wrong (i.e. a fifth call site exists that the grep missed, or the error is being thrown from a path not in this diff).

## References

- A2 audit (halt-and-surface) — the cycle_errors entries above were the surfaced signal.
- No tracker issue was opened by A2 (halt-and-surface, not halt-and-issue).

## Test plan

- [x] Schema verified: `generic_index_scores.entity_slug` exists, `entity_id` does not.
- [x] Diff is exactly 4 line additions + 4 line deletions across the 3 expected files.
- [x] Surrounding SQL columns (`SELECT *`, `SELECT overall_score, confidence_tag`, `WHERE index_id = %s`, `ORDER BY computed_at DESC LIMIT 1`) and Python parameter tuples preserved exactly.
- [ ] CI green.
- [ ] Railway deploy succeeds (no import / runtime errors).
- [ ] T+2h: post-deploy halt-criteria query returns 0.

https://claude.ai/code/session_017QJC4gmqRh6kdkNk3onqkB

---
_Generated by [Claude Code](https://claude.ai/code/session_017QJC4gmqRh6kdkNk3onqkB)_