### PR TITLE
fix(schema-drift): stablecoin_id IS NOT NULL → is_stablecoin = TRUE

### DIFF
--- a/app/collectors/dex_pools.py
+++ b/app/collectors/dex_pools.py
@@ -296,7 +296,7 @@ def compute_collateral_diversity(protocol_slug: str) -> dict:
         has_stablecoin = False
         try:
             row = fetch_one(
-                "SELECT COUNT(*) as cnt FROM protocol_collateral_exposure WHERE protocol_slug = %s AND stablecoin_id IS NOT NULL",
+                "SELECT COUNT(*) as cnt FROM protocol_collateral_exposure WHERE protocol_slug = %s AND is_stablecoin = TRUE",
                 (protocol_slug,),
             )
             has_stablecoin = row and row.get("cnt", 0) > 0


### PR DESCRIPTION
## Summary

Surgical 1-line fix in `app/collectors/dex_pools.py:299`. The `protocol_collateral_exposure` table has no `stablecoin_id` column; the query has been failing with `column "stablecoin_id" does not exist` for at least 24h (78 occurrences in `cycle_errors`). The table's own partial index `idx_collateral_stablecoins` is defined `WHERE (is_stablecoin = true)`, which is the canonical filter and matches the boolean has-exposure semantics of the downstream usage (`row['cnt'] > 0 → has_stablecoin`).

**Diff:** 1 line changed (1 insertion, 1 deletion).

**Before:** `WHERE protocol_slug = %s AND stablecoin_id IS NOT NULL`
**After:**  `WHERE protocol_slug = %s AND is_stablecoin = TRUE`

References A2 audit; operator-authorized as A5.2.

## Substrate verification

### Pre-deploy

**cycle_errors for dex_pools (last 1h, last 24h):**
```
last 1h:  0 errors
last 24h: 78 errors  (first 2026-05-13T03:07:38Z, last 2026-05-14T00:49:08Z)
error_message ILIKE '%column "stablecoin_id" does not exist%'
```
(1h is quiet because the worker is between cycles; 24h confirms this is a live, recurring failure.)

**Schema (information_schema.columns):**
```
column_name    | data_type
---------------+----------
is_stablecoin  | boolean
```
`stablecoin_id` does NOT exist on `protocol_collateral_exposure`.

**Partial index definition (pg_indexes):**
```
indexname                   | indexdef
----------------------------+--------------------------------------------------------------------------------
idx_collateral_stablecoins  | CREATE INDEX idx_collateral_stablecoins ON public.protocol_collateral_exposure
                            |   USING btree (is_stablecoin, protocol_slug) WHERE (is_stablecoin = true)
```

**Q1 — Per-protocol stablecoin pool counts (top 20):**
```
 protocol_slug    | pool_count
------------------+-----------
 curve-finance    | 3140
 uniswap          | 2366
 morpho           | 2300
 convex-finance   | 1135
 aave             |  669
 raydium          |  662
 compound-finance |  164
```
Plausible distribution — concentrated in DEX/lending protocols known for stablecoin pools. No zero counts among scored protocols; no absurd values.

**Q2 — is_stablecoin distribution:**
```
 is_stablecoin | count
---------------+-------
 false         |   706
 true          | 10436
```
Both sides populated → filter is non-degenerate. (TRUE-majority reflects upstream filtering of pools to stablecoin-relevant ones; not a degeneracy.)

**Q3 — EXPLAIN ANALYZE for the proposed query:**
```
EXPLAIN ANALYZE
SELECT COUNT(*) FROM protocol_collateral_exposure
WHERE protocol_slug = 'aave-v3' AND is_stablecoin = TRUE;

Aggregate  (cost=8.17..8.18 rows=1 width=8) (actual time=0.805..0.806 rows=1 loops=1)
  ->  Index Scan using idx_collateral_exposure_unique on protocol_collateral_exposure
        (cost=0.29..8.17 rows=1 width=0) (actual time=0.799..0.799 rows=0 loops=1)
        Index Cond: ((protocol_slug)::text = 'aave-v3'::text)
        Filter: is_stablecoin
Planning Time: 1.763 ms
Execution Time: 0.828 ms
```
Planner uses `idx_collateral_exposure_unique` (compound index keyed on `protocol_slug`) and applies `is_stablecoin` as a residual filter. Sub-millisecond, no sequential scan. The partial index `idx_collateral_stablecoins` is also available; planner selected the unique index for this protocol-equality query, which is acceptable — both index paths confirm `is_stablecoin` is a known, indexed boolean filter.

### Semantic equivalence claim

The downstream usage at `app/collectors/dex_pools.py:302` is `has_stablecoin = row and row.get("cnt", 0) > 0` — a pure boolean check ("does this protocol have any stablecoin exposure?"). That maps directly to "any row with `is_stablecoin = TRUE`". The table's own `idx_collateral_stablecoins` partial index uses `WHERE is_stablecoin = TRUE`, and EXPLAIN confirms the proposed query is index-served. Per-protocol pool counts (Q1) match expected stablecoin-pool distribution; Q2 confirms `is_stablecoin` is genuinely a filtering boolean (not all-TRUE or all-FALSE).

### Post-deploy halt criteria (2h)

```sql
SELECT COUNT(*) FROM cycle_errors
WHERE cycle_phase = 'dex_pools'
  AND error_message ILIKE '%column "stablecoin_id" does not exist%'
  AND occurred_at > '<deploy_ts>'::timestamptz;
-- Expected: 0
```
If non-zero after 2h post-deploy, revert.

## Test plan

- [ ] Deploy to Railway (`valiant-celebration`)
- [ ] Confirm worker dex_pools cycle completes without `column "stablecoin_id" does not exist` for 2h
- [ ] Run post-deploy halt-criteria SQL above; expect 0

https://claude.ai/code/session_017QJC4gmqRh6kdkNk3onqkB

---
_Generated by [Claude Code](https://claude.ai/code/session_017QJC4gmqRh6kdkNk3onqkB)_