### PR TITLE
fix(parameter_history): kill-switch Aave + Compound decoders pending design (#251)

### DIFF
--- a/app/collectors/parameter_history.py
+++ b/app/collectors/parameter_history.py
@@ -27,6 +27,23 @@ logger = logging.getLogger(__name__)
 
 
 # ---------------------------------------------------------------------------
+# Kill-switch
+# ---------------------------------------------------------------------------
+# Kill-switch for protocols whose decoder is known-broken pending architectural
+# fix. The Aave V3 registry entries decode `getReserveData(address)` as a flat
+# uint256 array (field indices 1-12) but the actual return type is the packed
+# struct `ReserveDataLegacy` whose field 0 (`configuration`) is bit-packed and
+# fields 1-6 are Ray-scaled (~10**27). The Compound `getAssetInfoByAddress`
+# decoder is also broken (zero rows ever landed in `protocol_parameters`).
+# Together this produces ~1500/7d numeric-overflow cycle_errors.
+#
+# Skipping these protocols is lossless: the data being written is wrong.
+# Re-enable by removing the slug from this set once the proper decoder ships.
+# See follow-up issue #251 + PR #250 (A5.4 forensic investigation).
+KILLED_PROTOCOLS: frozenset[str] = frozenset({"aave", "compound-finance"})
+
+
+# ---------------------------------------------------------------------------
 # RPC helpers
 # ---------------------------------------------------------------------------
 
@@ -584,7 +601,15 @@ async def check_parameter_changes() -> dict:
         "errors": [],
     }
 
+    if KILLED_PROTOCOLS:
+        logger.info(
+            f"[parameter_history] Kill-switch skipping {sorted(KILLED_PROTOCOLS)} "
+            f"(see KILLED_PROTOCOLS comment + follow-up issue)"
+        )
+
     for protocol_slug, param_specs in PROTOCOL_PARAMETER_REGISTRY.items():
+        if protocol_slug in KILLED_PROTOCOLS:
+            continue  # see KILLED_PROTOCOLS doc comment
         try:
             protocol_id = 0
 
@@ -692,6 +717,8 @@ async def collect_parameter_history() -> dict:
 
     # Store daily snapshots for each protocol
     for protocol_slug in PROTOCOL_PARAMETER_REGISTRY:
+        if protocol_slug in KILLED_PROTOCOLS:
+            continue  # see KILLED_PROTOCOLS doc comment
         try:
             await _store_daily_snapshot(protocol_slug, 0, results)
         except asyncio.CancelledError:


### PR DESCRIPTION
## Summary

Stops the largest active error class in production: ~1500/7d numeric-overflow `cycle_errors` from `parameter_history` (1564 over 7d / 610 over 24h at the moment of this PR). Per the A5.4 forensic investigation in **PR #250**, the Aave V3 registry entries decode `getReserveData(address)` as a flat uint256 array, but the actual return type is the packed struct `ReserveDataLegacy` whose field 0 (`configuration`) is bit-packed and fields 1-6 are Ray-scaled (~10^27). Compound's `getAssetInfoByAddress` decoder is separately broken (zero rows ever landed in `protocol_parameters` for `compound-finance`). Architectural fix tracked in follow-up issue **#251**.

This PR is **lossless** (the data going in is wrong; see substrate below) and **reversible** (remove the slug from `KILLED_PROTOCOLS` once the proper decoder ships).

## Mechanism

Adds `KILLED_PROTOCOLS: frozenset[str] = frozenset({"aave", "compound-finance"})` at the top of `app/collectors/parameter_history.py` (right after `logger`) and early-skips at both registry-iteration points:

- `check_parameter_changes()` change-check loop (`for protocol_slug, param_specs in PROTOCOL_PARAMETER_REGISTRY.items()`): `if protocol_slug in KILLED_PROTOCOLS: continue`
- `collect_parameter_history()` snapshot loop (`for protocol_slug in PROTOCOL_PARAMETER_REGISTRY`): same skip

One `logger.info` per cycle names the skipped slugs (NOT per-spec — that would spam). Total diff: 27 lines, of which 17 are the documenting comment block above the constant; the implementation itself is 5 lines (constant + log + two `continue` skips).

## Note on the kill set

A5.4 documented the protocol slug as `aave-v3`, but the actual code uses `"aave"` (`registry["aave"] = aave_params` at line 219). Used the actual-code slug. Compound slug is `"compound-finance"` (verified against `registry["compound-finance"]` at line 238).

## Substrate verification

### Pre-deploy

**cycle_errors baseline (numeric-overflow only, last 7d):**

```sql
SELECT cycle_phase, COUNT(*) AS occurrences_7d,
       COUNT(*) FILTER (WHERE occurred_at > NOW() - INTERVAL '24 hours') AS occurrences_24h
FROM cycle_errors
WHERE cycle_phase = 'parameter_history'
  AND error_message ILIKE '%numeric%overflow%'
  AND occurred_at > NOW() - INTERVAL '7 days'
GROUP BY cycle_phase;
```

```
 cycle_phase       | occurrences_7d | occurrences_24h
-------------------+----------------+-----------------
 parameter_history | 1564           | 610
```

**`protocol_parameters` distribution:**

```sql
SELECT protocol_slug, COUNT(*) FROM protocol_parameters
GROUP BY protocol_slug ORDER BY COUNT(*) DESC;
```

```
 protocol_slug | count
---------------+-------
 aave          | 6
```

Confirms A5.4: `compound-finance` has zero rows (decoder silently failing); `aave` has 6 rows — the small subset whose bogus values happen to fit inside `numeric(30,8)`. The other ~19 Aave specs overflow on every insert attempt.

### Post-deploy halt criteria (2h after deploy)

Expect zero new numeric-overflow errors from `parameter_history` after the cycle in flight drains:

```sql
SELECT COUNT(*) FROM cycle_errors
WHERE cycle_phase = 'parameter_history'
  AND error_message ILIKE '%numeric%overflow%'
  AND occurred_at > '<deploy_ts>'::timestamptz;
-- Expected: 0 (one cycle in flight at deploy time may still drain ~25-50)
```

Also expect to see the `[parameter_history] Kill-switch skipping ['aave', 'compound-finance']` info log once per slow cycle.

### Writer provenance (post-W2.2)

Not applicable. This PR doesn't add a wrapper attest — it suppresses writes for two known-broken protocol decoders. Existing attests for unaffected protocols (none currently — Morpho is registry-deferred) are untouched.

## Downstream-consumer audit

Grepped `app/`, `frontend/src/` for `protocol_parameters` / `protocol_parameter_changes` / `protocol_parameter_snapshots` / `PROTOCOL_PARAMETER_REGISTRY` consumers. Findings:

- `app/server.py` (lines 9590, 9605, 9621, 9653, 9666, 9679) — SELECT-only API routes; filter by `protocol_slug` from request, do not assume specific protocols are present
- `app/report.py:633` — SELECTs from `protocol_parameter_changes`; renders whatever rows exist
- `app/enrichment_worker.py:580` — `MAX(snapshot_date)` aggregator; degrades gracefully
- `app/coherence.py:60-61, 100-101` — coherence freshness thresholds; will skip both tables when no rows arrive but won't fail
- `app/data_layer/state_growth.py` — row-count aggregator
- `app/worker.py:1672, 3151` and `app/schema_heal.py:174-176` — table registration/DDL; no row-level dependency

**No consumer expects Aave or Compound rows to be present.** Operator's "lossless" claim is validated.

## Out of scope (separate PRs after the architectural fix)

- Deleting the 6 bogus `aave` rows in `protocol_parameters` so the change-detector doesn't fire spurious "changes" when the proper decoder relaunches (A5.4 noted this; can be a cleanup PR scoped after the design call)
- The actual decoder fix — tracked in **#251** with two architectural options: (1) switch to Aave `PoolDataProvider` helper views, (2) bit-unpack the `configuration` word. Either path needs Compound's `getAssetInfoByAddress` audited in the same pass.

## Reversal

Single-line revert: delete a slug from `KILLED_PROTOCOLS` (or the whole set) and redeploy. No migration, no payload change, no state-attestation impact.

## Refs

- **PR #250** — A5.4 investigation (full forensic trace + substrate evidence + architectural options)
- **#251** — follow-up issue (architectural fix, Option 1 vs Option 2 design call)
- **#243** — cycle_errors taxonomy (where this surfaced as the top live error class)

## Test plan

- [ ] Merge during a low-traffic window so the cycle currently in flight can drain
- [ ] Tail `parameter_history` logs after deploy; confirm the single info log line `Kill-switch skipping ['aave', 'compound-finance']` per cycle
- [ ] Run the halt-criteria SQL 2h post-deploy; expect 0 new numeric-overflow rows
- [ ] Confirm no new cycle_errors of any class from `parameter_history` (kill-switch should not introduce regressions; the snapshot loop and change-check loop both no-op when registry yields nothing after filter)
- [ ] Verify `coherence.py` does not flag `protocol_parameter_changes` / `protocol_parameter_snapshots` as a regression — these were already gated by row-count, not protocol-coverage

https://claude.ai/code/session_017QJC4gmqRh6kdkNk3onqkB

---
_Generated by [Claude Code](https://claude.ai/code/session_017QJC4gmqRh6kdkNk3onqkB)_