### PR TITLE
fix(vault_collector): guard float() against NULL psi_scores.overall_score

### DIFF
--- a/app/collectors/vault_collector.py
+++ b/app/collectors/vault_collector.py
@@ -549,24 +549,33 @@ async def extract_vault_raw_values(entity: dict, all_pools: list[dict]) -> dict:
 
     # CQI lookup for underlying asset quality
     try:
-        # Look up SII score for the underlying stablecoin
+        # Look up SII score for the underlying stablecoin.
+        # Defensive None-check: scores.overall_score is currently always
+        # populated, but the cost of guarding is one comparison.
         if "usdc" in entity["slug"]:
             sii_row = await fetch_one_async("SELECT overall_score FROM scores WHERE stablecoin_id = 'usdc'")
-            if sii_row:
+            if sii_row and sii_row.get("overall_score") is not None:
                 raw["underlying_sii_score"] = float(sii_row["overall_score"])
         elif "dai" in entity["slug"]:
             sii_row = await fetch_one_async("SELECT overall_score FROM scores WHERE stablecoin_id = 'dai'")
-            if sii_row:
+            if sii_row and sii_row.get("overall_score") is not None:
                 raw["underlying_sii_score"] = float(sii_row["overall_score"])
 
-        # Look up PSI score for the underlying protocol
+        # Look up the latest *scored* PSI row. Without the IS NOT NULL
+        # filter the "most recent" row is usually a null-score placeholder
+        # (4477/5006 = 89% of psi_scores have overall_score IS NULL on
+        # 2026-05-14: drift, jupiter-perpetual-exchange, etc.) and
+        # `float(None)` raises — see cycle_errors `vault_collector` /
+        # `collectors_extract_vault_raw_values_failure` (146/7d).
         protocol_slug = entity.get("protocol")
         if protocol_slug:
             psi_row = await fetch_one_async(
-                "SELECT overall_score FROM psi_scores WHERE protocol_slug = %s ORDER BY computed_at DESC LIMIT 1",
+                "SELECT overall_score FROM psi_scores "
+                "WHERE protocol_slug = %s AND overall_score IS NOT NULL "
+                "ORDER BY computed_at DESC LIMIT 1",
                 (protocol_slug,),
             )
-            if psi_row:
+            if psi_row and psi_row.get("overall_score") is not None:
                 raw["underlying_psi_score"] = float(psi_row["overall_score"])
     except asyncio.CancelledError:
         raise


### PR DESCRIPTION
## Summary

- `extract_vault_raw_values` at `app/collectors/vault_collector.py:570` called `float(psi_row["overall_score"])` without checking the column for NULL.
- Substrate (2026-05-14): 4477 of 5006 `psi_scores` rows (89%) have NULL `overall_score`, and the latest row by `computed_at` for protocols like `drift` / `jupiter-perpetual-exchange` is a placeholder written before the scoring engine emits a real value.
- Add `AND overall_score IS NOT NULL` to the psi_scores query, plus defensive `is not None` guards on all three callsites (sii usdc, sii dai, psi).

## Root cause

`if psi_row:` only checked row existence, not the column value. The query selected the latest row by `computed_at` regardless of whether `overall_score` was populated. Path A per the residual-sweep playbook: schema-row returned None where code expected a number → trivial guard.

## Substrate verification

### Pre-deploy

Last-24h baseline as of 2026-05-14T02:35Z (small-scene-57890564):

```sql
SELECT COUNT(*) FROM cycle_errors
WHERE cycle_phase = 'vault_collector'
  AND error_type = 'collectors_extract_vault_raw_values_failure'
  AND occurred_at > NOW() - INTERVAL '24 hours';
-- -> 26
```

7-day total: 148 occurrences.

Population check on `psi_scores`:

```sql
SELECT COUNT(*) AS total_rows,
       COUNT(*) FILTER (WHERE overall_score IS NULL) AS null_overall_score,
       COUNT(DISTINCT protocol_slug) FILTER (WHERE overall_score IS NULL) AS distinct_protocols_with_null
FROM psi_scores;
-- total_rows=5006, null_overall_score=4477, distinct_protocols_with_null=14
```

Confirms the bug class is real and persistent: 14 protocols regularly leave a NULL-score row as the most recent in `psi_scores`.

### Post-deploy halt criteria (2h)

```sql
SELECT COUNT(*) FROM cycle_errors
WHERE cycle_phase = 'vault_collector'
  AND error_type = 'collectors_extract_vault_raw_values_failure'
  AND occurred_at > '<deploy_ts>'::timestamptz;
-- expect: 0
```

If non-zero after 2h post-deploy: the fix did not fully take — investigate the remaining callers and revert.

### Writer provenance

N/A — no attest wrapper involved; this is a read path that feeds the in-memory `raw` dict consumed by `score_vault`.

## Refs

- `docs/audits/2026-05-14-cycle-errors-taxonomy.md` — `## vault_collector` section + Investigation queue item 3
- Post-kill-switch (#252) residual sweep, 2026-05-14

https://claude.ai/code/session_017QJC4gmqRh6kdkNk3onqkB

---
_Generated by [Claude Code](https://claude.ai/code/session_017QJC4gmqRh6kdkNk3onqkB)_