### PR TITLE
fix(flows_collection): demote no-data Etherscan responses from api_error

### DIFF
--- a/app/collectors/flows.py
+++ b/app/collectors/flows.py
@@ -107,8 +107,20 @@ async def _fetch_recent_transfers(
                 error_message=result_str[:500],
             )
 
-        # Etherscan returned a non-success status (e.g. invalid key, bad params)
+        # Etherscan returned a non-success status. Discriminate between
+        # "no transactions in window" (status="0" with `result` empty or
+        # absent, often accompanied by message "No transactions found")
+        # which is a *genuine zero* outcome, not an API failure, vs.
+        # actual API errors (invalid key, bad params, etc).
         if data.get("status") != "1":
+            message = str(data.get("message", "")).lower()
+            no_data = (
+                "no transactions found" in message
+                or result_str in ("", "[]", "None")
+            )
+            if no_data:
+                # Treat as success-with-zero-transfers; caller logs at info.
+                return _FlowsFetchResult(success=True, transfers=[])
             return _FlowsFetchResult(
                 success=False,
                 transfers=[],


### PR DESCRIPTION
## Summary

- `_fetch_recent_transfers` treats every `status != "1"` Etherscan response as an API failure and writes a `flows_api_error` cycle_errors row.
- Etherscan's convention for "no transactions found in the requested window" is `status="0"`, `message="No transactions found"`, `result=[]` (sometimes `None`). That is a soft, expected outcome — not an API error — and the downstream caller already logs the zero-transfer case at `logger.info`.
- Discriminate the no-data case in `_fetch_recent_transfers` and return a successful zero-transfer result, removing the noise from `cycle_errors`.

## Root cause

`flows.py:111-117` is the only failure branch besides rate-limit / timeout / transport, so any non-success status — including the routine "empty window" — falls through to `error_type="api_error"`. The dispatched message format `f"{stablecoin_id}: {result_str}"` (line 351 in the caller) explains why all observed rows have the shape `<slug>: []` or `<slug>: None`.

## Substrate verification

### Pre-deploy

Distinct error messages on `flows_api_error` over the last 7d (small-scene-57890564):

```sql
SELECT DISTINCT error_message FROM cycle_errors
WHERE cycle_phase = 'flows_collection'
  AND error_type = 'flows_api_error'
  AND occurred_at > NOW() - INTERVAL '7 days';
-- eurs: []
-- ousd: None
-- pyusd: None
-- usdt: []
```

All four observed patterns are stringified empty `result` (`[]`) or missing `result` (`None`) — every recorded `flows_api_error` is a no-data outcome, not a real error. No invalid-key / bad-param messages are present.

24h baseline: 18 occurrences. 7d total: 135.

### Post-deploy halt criteria (2h)

```sql
SELECT COUNT(*) FROM cycle_errors
WHERE cycle_phase = 'flows_collection'
  AND error_type = 'flows_api_error'
  AND occurred_at > '<deploy_ts>'::timestamptz;
-- expect: 0
```

Secondary check: confirm that no *real* errors are getting silently swallowed by querying for any prior 7d window containing a non-`[]`/non-`None` `result_str` — if one appears post-deploy with `error_type` set, that's the expected behavior. If we see a regression where genuine zero-rows stop appearing in `component_readings` for a stablecoin that previously had them, revert (the demotion was too permissive).

### Writer provenance

N/A — read path; the cycle_errors write itself is being avoided, not gated by a wrapper attest.

## Refs

- `docs/audits/2026-05-14-cycle-errors-taxonomy.md` — `## flows_collection` section + Investigation queue item 4
- Post-kill-switch (#252) residual sweep, 2026-05-14

https://claude.ai/code/session_017QJC4gmqRh6kdkNk3onqkB

---
_Generated by [Claude Code](https://claude.ai/code/session_017QJC4gmqRh6kdkNk3onqkB)_