### PR TITLE
refactor: extract phase-trigger functions for testability

### DIFF
--- a/main.py
+++ b/main.py
@@ -153,16 +153,8 @@ def run_worker_loop():
         hours_since_cda = (time.time() - last_cda_at) / 3600
         if hours_since_cda >= cda_interval_hours:
             try:
-                logger.info("Running CDA collection pipeline...")
-                # v9.12 module-canonical: scheduler wrapper attests
-                # skipped_fresh / ran / error inline. Replaces the
-                # post-hoc 2h SELECT attest that left
-                # state_attestations.domain='cda_extractions' empty for
-                # 30+ days (#207). Do NOT re-attest here.
-                from app.services.cda_collector import run_collection_scheduled
-                cda_result = asyncio.run(run_collection_scheduled())
+                asyncio.run(_run_cda_cycle_once())
                 last_cda_at = time.time()
-                logger.info(f"CDA collection complete: {cda_result.get('status')}")
             except Exception as e:
                 logger.warning(f"CDA collection failed: {e}")
 
@@ -213,42 +205,8 @@ def run_worker_loop():
         hours_since_expansion = (time.time() - last_expansion_at) / 3600
         if hours_since_expansion >= 24:
             try:
-                from app.collectors.psi_collector import (
-                    collect_collateral_exposure,
-                    sync_collateral_to_backlog,
-                    discover_protocols,
-                    enrich_protocol_backlog,
-                    promote_eligible_protocols,
-                )
-                logger.info("Running PSI expansion pipeline...")
-                collect_collateral_exposure()
-                synced = sync_collateral_to_backlog()
-                discovered = discover_protocols()
-                enriched = enrich_protocol_backlog()
-                promoted = promote_eligible_protocols()
+                _run_psi_expansion_cycle_once()
                 last_expansion_at = time.time()
-                logger.info(
-                    f"PSI expansion: {synced} stablecoins synced, {discovered} discovered, "
-                    f"{enriched} enriched, {promoted} promoted"
-                )
-                # Attest PSI discoveries — always, even with discovered=0 and
-                # promoted=0. The enrichment-task path (#137) added the same
-                # fix at app/enrichment_worker.py, but its db_gate stays
-                # closed because main.py's `collect_collateral_exposure()`
-                # call above keeps `protocol_collateral_exposure` fresh —
-                # so the enrichment task never actually fires in production.
-                # That made #137's fix a no-op for the live code path and
-                # left psi_discoveries silent. Dropping the gate here too.
-                try:
-                    from app.state_attestation import attest_state
-                    attest_state(
-                        "psi_discoveries",
-                        [{"synced": synced, "discovered": discovered,
-                          "enriched": enriched, "promoted": promoted}],
-                        writer_id="main.inline.psi_discoveries",
-                    )
-                except Exception as ae:
-                    logger.debug(f"PSI discovery attestation skipped: {ae}")
             except Exception as e:
                 logger.warning(f"PSI expansion pipeline failed: {e}")
 
@@ -293,22 +251,8 @@ def run_worker_loop():
                 logger.warning(f"Profile rebuild failed: {e}")
 
         # Verification agent cycle — runs after every scoring cycle
-        # F2 (#221): the attest_state("assessments", ...) call previously
-        # here is dead — run_agent_cycle() is async (app/agent/watcher.py:
-        # 259) but this site calls it without `await`, so `result` is a
-        # coroutine and `.get(...)` raises AttributeError which the broad
-        # except below swallows. Net: 0 rows in state_attestations for
-        # 'assessments' over 19.4h despite 125+ watcher events. The
-        # attest has been moved to app/worker.py's awaited live-path
-        # caller (see comment there). The coroutine bug at the next line
-        # is intentionally left in place — same bug class N cleaned up
-        # for wallets in PR #214, separate cleanup sweep tracked
-        # outside F2's scope.
         try:
-            from app.agent.watcher import run_agent_cycle
-            result = run_agent_cycle()
-            if result:
-                logger.info(f"Agent cycle: {result.get('assessments', 0)} assessments")
+            _run_agent_cycle_once()
         except Exception as e:
             logger.error(f"Agent cycle error: {e}")
 
@@ -464,14 +408,7 @@ def run_worker_loop():
             #  Bug B: chain inside payload, entity_id stays NULL for consumers.)
             for edge_chain in ["ethereum", "base", "arbitrum", "solana"]:
                 try:
-                    from app.indexer.edges import run_edge_builder_scheduled
-                    logger.info(f"Running edge builder for {edge_chain} (top 200 unbuilt wallets by value)...")
-                    edge_outcome = asyncio.run(run_edge_builder_scheduled(edge_chain, time.time()))
-                    logger.info(
-                        f"Edge builder ({edge_chain}) {edge_outcome.get('status', 'unknown')}: "
-                        f"wallets={edge_outcome.get('wallets_processed', 0)}, "
-                        f"edges={edge_outcome.get('edges_upserted', 0)}"
-                    )
+                    asyncio.run(_run_edges_cycle_once(edge_chain))
                 except Exception as e:
                     logger.warning(f"Edge building failed for {edge_chain}: {e}")
 
@@ -578,6 +515,103 @@ def run_worker_loop():
 
         logger.info(f"Worker sleeping {WORKER_INTERVAL} minutes...")
         time.sleep(WORKER_INTERVAL * 60)
+
+
+# =============================================================================
+# Phase-trigger functions
+# =============================================================================
+# Each function is one iteration of that phase's work, decoupled from the
+# time-gate checks in run_worker_loop. Enables harness-based scenario testing
+# where each phase can be triggered as a stable function call regardless of
+# fix-shape variation (canonical wrapper vs. in-place fix vs. alternative).
+# Production goes through run_worker_loop, which calls these on the same
+# schedule as before. Underscore prefix = internal; scenarios import them
+# directly.
+
+
+async def _run_cda_cycle_once():
+    """Run one iteration of CDA collection. Wrapper attests
+    skipped_fresh / ran / error inline; no caller-side attest."""
+    logger.info("Running CDA collection pipeline...")
+    from app.services.cda_collector import run_collection_scheduled
+    cda_result = await run_collection_scheduled()
+    logger.info(f"CDA collection complete: {cda_result.get('status') if cda_result else 'no result'}")
+    return cda_result
+
+
+async def _run_edges_cycle_once(chain: str):
+    """Run one iteration of edges building for the given chain."""
+    from app.indexer.edges import run_edge_builder_scheduled
+    logger.info(f"Running edge builder for {chain} (top 200 unbuilt wallets by value)...")
+    edge_outcome = await run_edge_builder_scheduled(chain, time.time())
+    logger.info(
+        f"Edge builder ({chain}) {edge_outcome.get('status', 'unknown')}: "
+        f"wallets={edge_outcome.get('wallets_processed', 0)}, "
+        f"edges={edge_outcome.get('edges_upserted', 0)}"
+    )
+    return edge_outcome
+
+
+def _run_agent_cycle_once():
+    """Run one iteration of the verification agent.
+
+    F2 (#221): run_agent_cycle is async (app/agent/watcher.py:259) but
+    this site calls it without `await`, so `result` is a coroutine and
+    `.get(...)` raises AttributeError which the caller's broad except
+    swallows. The attest_state("assessments", ...) call previously here
+    has been moved to app/worker.py's awaited live-path caller. The
+    coroutine bug at the next line is intentionally left in place —
+    same bug class as wallets PR #214, separate cleanup sweep tracked
+    outside F2's scope.
+    """
+    from app.agent.watcher import run_agent_cycle
+    result = run_agent_cycle()
+    if result:
+        logger.info(f"Agent cycle: {result.get('assessments', 0)} assessments")
+    return result
+
+
+def _run_psi_expansion_cycle_once():
+    """Run one iteration of the PSI expansion pipeline
+    (collect → sync → discover → enrich → promote → attest).
+
+    Attest psi_discoveries always, even with discovered=0 and promoted=0.
+    The enrichment-task path (#137) added the same fix at
+    app/enrichment_worker.py, but its db_gate stays closed because
+    collect_collateral_exposure here keeps protocol_collateral_exposure
+    fresh — so the enrichment task never actually fires in production.
+    That made #137's fix a no-op for the live code path and left
+    psi_discoveries silent. Dropping the gate here too.
+    """
+    from app.collectors.psi_collector import (
+        collect_collateral_exposure,
+        sync_collateral_to_backlog,
+        discover_protocols,
+        enrich_protocol_backlog,
+        promote_eligible_protocols,
+    )
+    logger.info("Running PSI expansion pipeline...")
+    collect_collateral_exposure()
+    synced = sync_collateral_to_backlog()
+    discovered = discover_protocols()
+    enriched = enrich_protocol_backlog()
+    promoted = promote_eligible_protocols()
+    logger.info(
+        f"PSI expansion: {synced} stablecoins synced, {discovered} discovered, "
+        f"{enriched} enriched, {promoted} promoted"
+    )
+    try:
+        from app.state_attestation import attest_state
+        attest_state(
+            "psi_discoveries",
+            [{"synced": synced, "discovered": discovered,
+              "enriched": enriched, "promoted": promoted}],
+            writer_id="main.inline.psi_discoveries",
+        )
+    except Exception as ae:
+        logger.debug(f"PSI discovery attestation skipped: {ae}")
+    return {"synced": synced, "discovered": discovered,
+            "enriched": enriched, "promoted": promoted}
 
 
 def run_migrations():

--- a/tests/test_phase_triggers.py
+++ b/tests/test_phase_triggers.py
@@ -1,0 +1,275 @@
+"""Unit tests for main.py's phase-trigger functions.
+
+These tests verify that each `_run_<phase>_cycle_once` function can be
+called in isolation with mocked collaborators, returns the expected
+shape, and wires to the canonical module function — independent of the
+time-gate scheduling logic in run_worker_loop.
+
+Used by basis-protocol/scenarios-harness as a stable entry-point shape
+so scenario fix-evaluation works regardless of how CC's fix is shaped
+(canonical wrapper vs. in-place patch vs. alternative).
+"""
+
+import asyncio
+import inspect
+import sys
+import types
+from unittest.mock import MagicMock
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Module-level harness: stub heavy imports so `import main` works in CI
+# without a live DB or full app stack.
+# ---------------------------------------------------------------------------
+
+def _stub(name, **attrs):
+    mod = types.ModuleType(name)
+    for k, v in attrs.items():
+        setattr(mod, k, v)
+    sys.modules[name] = mod
+    return mod
+
+
+# Stubs that main.py imports at module level. Only attrs touched at
+# import time need to exist; runtime attrs are set per-test below.
+_stub("uvicorn")
+_stub("app")
+_stub(
+    "app.database",
+    init_pool=MagicMock(),
+    close_pool=MagicMock(),
+    health_check=MagicMock(),
+    fetch_one=MagicMock(),
+    fetch_all=MagicMock(),
+    execute=MagicMock(),
+)
+
+
+class _SchemaDriftError(Exception):
+    pass
+
+
+_stub("app.schema_heal", verify_schema=MagicMock(), SchemaDriftError=_SchemaDriftError)
+_stub("app.server", app=MagicMock())
+
+
+import main  # noqa: E402  — after the stubs are in place
+
+
+# ---------------------------------------------------------------------------
+# _run_cda_cycle_once
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_cda_cycle_calls_run_collection_scheduled():
+    fake_result = {"status": "ran", "extracted": 7}
+
+    async def _fake_run_collection_scheduled():
+        return fake_result
+
+    fake_mod = types.ModuleType("app.services.cda_collector")
+    fake_mod.run_collection_scheduled = _fake_run_collection_scheduled
+    sys.modules["app.services.cda_collector"] = fake_mod
+    # Parent package must also exist for the `from app.services... import` form.
+    sys.modules.setdefault("app.services", types.ModuleType("app.services"))
+
+    result = await main._run_cda_cycle_once()
+
+    assert result is fake_result
+    assert result["status"] == "ran"
+
+
+@pytest.mark.asyncio
+async def test_cda_cycle_returns_result_when_wrapper_returns_no_result():
+    """Wrapper may legitimately return None on a no-op cycle; the
+    trigger must not raise."""
+    async def _fake():
+        return None
+
+    fake_mod = types.ModuleType("app.services.cda_collector")
+    fake_mod.run_collection_scheduled = _fake
+    sys.modules["app.services.cda_collector"] = fake_mod
+
+    result = await main._run_cda_cycle_once()
+    assert result is None
+
+
+# ---------------------------------------------------------------------------
+# _run_edges_cycle_once
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_edges_cycle_calls_scheduled_with_chain_and_timestamp():
+    captured = {}
+
+    async def _fake_scheduled(chain, cycle_ts):
+        captured["chain"] = chain
+        captured["cycle_ts"] = cycle_ts
+        return {
+            "status": "ran",
+            "wallets_processed": 200,
+            "edges_upserted": 1234,
+        }
+
+    fake_mod = types.ModuleType("app.indexer.edges")
+    fake_mod.run_edge_builder_scheduled = _fake_scheduled
+    sys.modules["app.indexer.edges"] = fake_mod
+    sys.modules.setdefault("app.indexer", types.ModuleType("app.indexer"))
+
+    outcome = await main._run_edges_cycle_once("ethereum")
+
+    assert captured["chain"] == "ethereum"
+    assert isinstance(captured["cycle_ts"], float)
+    assert outcome["wallets_processed"] == 200
+    assert outcome["edges_upserted"] == 1234
+
+
+@pytest.mark.asyncio
+async def test_edges_cycle_propagates_exception_from_wrapper():
+    async def _boom(chain, cycle_ts):
+        raise RuntimeError("explorer down")
+
+    fake_mod = types.ModuleType("app.indexer.edges")
+    fake_mod.run_edge_builder_scheduled = _boom
+    sys.modules["app.indexer.edges"] = fake_mod
+
+    with pytest.raises(RuntimeError, match="explorer down"):
+        await main._run_edges_cycle_once("base")
+
+
+# ---------------------------------------------------------------------------
+# _run_agent_cycle_once
+# ---------------------------------------------------------------------------
+
+def test_agent_cycle_calls_run_agent_cycle_and_returns_result():
+    fake_result = {"assessments": 5, "severities": {"silent": 5}}
+    fake_mod = types.ModuleType("app.agent.watcher")
+    fake_mod.run_agent_cycle = MagicMock(return_value=fake_result)
+    sys.modules["app.agent.watcher"] = fake_mod
+    sys.modules.setdefault("app.agent", types.ModuleType("app.agent"))
+
+    result = main._run_agent_cycle_once()
+
+    fake_mod.run_agent_cycle.assert_called_once()
+    assert result is fake_result
+
+
+def test_agent_cycle_returns_none_when_inner_returns_none():
+    fake_mod = types.ModuleType("app.agent.watcher")
+    fake_mod.run_agent_cycle = MagicMock(return_value=None)
+    sys.modules["app.agent.watcher"] = fake_mod
+
+    assert main._run_agent_cycle_once() is None
+
+
+# ---------------------------------------------------------------------------
+# _run_psi_expansion_cycle_once
+# ---------------------------------------------------------------------------
+
+def test_psi_expansion_runs_all_five_steps_and_attests():
+    fake_collector = types.ModuleType("app.collectors.psi_collector")
+    fake_collector.collect_collateral_exposure = MagicMock()
+    fake_collector.sync_collateral_to_backlog = MagicMock(return_value=3)
+    fake_collector.discover_protocols = MagicMock(return_value=7)
+    fake_collector.enrich_protocol_backlog = MagicMock(return_value=2)
+    fake_collector.promote_eligible_protocols = MagicMock(return_value=1)
+    sys.modules["app.collectors.psi_collector"] = fake_collector
+    sys.modules.setdefault("app.collectors", types.ModuleType("app.collectors"))
+
+    fake_attest = types.ModuleType("app.state_attestation")
+    fake_attest.attest_state = MagicMock()
+    sys.modules["app.state_attestation"] = fake_attest
+
+    result = main._run_psi_expansion_cycle_once()
+
+    fake_collector.collect_collateral_exposure.assert_called_once()
+    fake_collector.sync_collateral_to_backlog.assert_called_once()
+    fake_collector.discover_protocols.assert_called_once()
+    fake_collector.enrich_protocol_backlog.assert_called_once()
+    fake_collector.promote_eligible_protocols.assert_called_once()
+
+    assert result == {
+        "synced": 3,
+        "discovered": 7,
+        "enriched": 2,
+        "promoted": 1,
+    }
+
+    # Attest must fire unconditionally (the #137 fix that this body
+    # encodes: drop the `if discovered or promoted` gate).
+    fake_attest.attest_state.assert_called_once()
+    args, kwargs = fake_attest.attest_state.call_args
+    assert args[0] == "psi_discoveries"
+    payload = args[1]
+    assert payload == [{"synced": 3, "discovered": 7, "enriched": 2, "promoted": 1}]
+    assert kwargs.get("writer_id") == "main.inline.psi_discoveries"
+
+
+def test_psi_expansion_attests_with_all_zero_counts():
+    """Zero-result cycles must still emit an attestation — that's the
+    whole point of #137's gate drop. Silence here is a regression."""
+    fake_collector = types.ModuleType("app.collectors.psi_collector")
+    fake_collector.collect_collateral_exposure = MagicMock()
+    fake_collector.sync_collateral_to_backlog = MagicMock(return_value=0)
+    fake_collector.discover_protocols = MagicMock(return_value=0)
+    fake_collector.enrich_protocol_backlog = MagicMock(return_value=0)
+    fake_collector.promote_eligible_protocols = MagicMock(return_value=0)
+    sys.modules["app.collectors.psi_collector"] = fake_collector
+
+    fake_attest = types.ModuleType("app.state_attestation")
+    fake_attest.attest_state = MagicMock()
+    sys.modules["app.state_attestation"] = fake_attest
+
+    main._run_psi_expansion_cycle_once()
+
+    fake_attest.attest_state.assert_called_once()
+
+
+def test_psi_expansion_swallows_attest_failure():
+    """Attest path is best-effort — a failure there must not abort the
+    cycle (caller-side last_expansion_at update depends on this)."""
+    fake_collector = types.ModuleType("app.collectors.psi_collector")
+    fake_collector.collect_collateral_exposure = MagicMock()
+    fake_collector.sync_collateral_to_backlog = MagicMock(return_value=0)
+    fake_collector.discover_protocols = MagicMock(return_value=0)
+    fake_collector.enrich_protocol_backlog = MagicMock(return_value=0)
+    fake_collector.promote_eligible_protocols = MagicMock(return_value=0)
+    sys.modules["app.collectors.psi_collector"] = fake_collector
+
+    fake_attest = types.ModuleType("app.state_attestation")
+    fake_attest.attest_state = MagicMock(side_effect=RuntimeError("DB locked"))
+    sys.modules["app.state_attestation"] = fake_attest
+
+    # Must not raise — the trigger's inner try/except catches it.
+    result = main._run_psi_expansion_cycle_once()
+    assert result["discovered"] == 0
+
+
+# ---------------------------------------------------------------------------
+# Smoke test — run_worker_loop scheduler shape preserved
+# ---------------------------------------------------------------------------
+
+def test_phase_triggers_are_module_level_and_signatured():
+    """Scenarios harness imports these by qualified name. Pin the
+    public shape so accidental renames or signature drift fail loudly."""
+    assert inspect.iscoroutinefunction(main._run_cda_cycle_once)
+    assert inspect.iscoroutinefunction(main._run_edges_cycle_once)
+    assert not inspect.iscoroutinefunction(main._run_agent_cycle_once)
+    assert not inspect.iscoroutinefunction(main._run_psi_expansion_cycle_once)
+
+    edges_sig = inspect.signature(main._run_edges_cycle_once)
+    assert list(edges_sig.parameters) == ["chain"]
+    assert edges_sig.parameters["chain"].annotation is str
+
+
+def test_run_worker_loop_dispatches_to_phase_triggers():
+    """Smoke test: run_worker_loop's source references each trigger
+    name. This is the cheapest insurance against someone re-inlining
+    a phase body and silently breaking the harness."""
+    src = inspect.getsource(main.run_worker_loop)
+    assert "_run_cda_cycle_once" in src
+    assert "_run_edges_cycle_once" in src
+    assert "_run_agent_cycle_once" in src
+    assert "_run_psi_expansion_cycle_once" in src


### PR DESCRIPTION
## Summary

Factor `main.py`'s worker loop body into per-phase async functions
(`_run_cda_cycle_once`, `_run_edges_cycle_once`, `_run_agent_cycle_once`,
`_run_psi_expansion_cycle_once`). Each function is one iteration of that
phase's work, decoupled from time conditionals.

Enables harness-based scenario testing where each phase can be triggered
as a stable function call regardless of fix-shape variation (canonical
wrapper vs. in-place fix vs. alternative).

**No production behavior change** — `run_worker_loop` calls these
functions on the same schedule as before. Time-gate checks and
`last_X_at` updates remain in the loop; the work moves into the
trigger functions.

## Scope

4 phases extracted (matching today's scenarios-harness entry points):

| Scenario | Phase | Trigger |
|---|---|---|
| 001 | CDA collection | `async _run_cda_cycle_once()` |
| 002 / 003 | Edges per chain | `async _run_edges_cycle_once(chain: str)` |
| 004 | Agent cycle | `_run_agent_cycle_once()` (sync — preserves the intentional coroutine-never-awaited bug for the scenario fix) |
| 005 | PSI expansion | `_run_psi_expansion_cycle_once()` (sync) |

Other phases (data layer, treasury, health, scoring, watchdog, daily
growth, wallet expansion, profile rebuild, PSI scoring, wallet batch
re-index) deliberately left inline. Add later as scenarios need them.

## Tests

`tests/test_phase_triggers.py` — 11/11 pass in 0.07s:

- Each trigger callable in isolation with stubbed collaborators.
- Return-shape pinned for the harness.
- PSI expansion attest fires unconditionally even with zero counts
  (regression guard for #137's gate-drop; silence here would re-silence
  `psi_discoveries`).
- PSI expansion swallows attest failures so caller-side
  `last_expansion_at` semantics are preserved.
- Signature pin: `_run_edges_cycle_once` takes exactly `chain: str`.
- Smoke test on `inspect.getsource(run_worker_loop)` references each
  trigger name — cheap guard against accidental re-inlining.

## Test plan

- [x] `python -m pytest tests/test_phase_triggers.py` — 11/11 pass
- [x] `python -m py_compile main.py` — clean
- [ ] Post-merge: `import main; main._run_<phase>_cycle_once()`
      entry points referenced by basis-protocol/scenarios-harness
      Prompt B1.

---
_Generated by [Claude Code](https://claude.ai/code/session_01J5MYNshUmfW1pbNdbn6obn)_