### PR TITLE
feat(v9.12): migration 115 — CREATE INDEX for writer_id (#235 W2.4, renumbered from 112, non-concurrent)

### DIFF
--- a/docs/audits/2026-05-11-module-canonical-migration-plan.md
+++ b/docs/audits/2026-05-11-module-canonical-migration-plan.md
@@ -428,3 +428,48 @@ include all events in its counter.
 
 **Refs:** #238 (gate fix), #235 (writer_id discriminator), #208 +
 #221 (original `actors`/`assessments` domain split history).
+
+### Migration runner wraps every migration in a transaction (CONCURRENTLY incompatible)
+
+**Surfaced:** 2026-05-15 W2.4 pre-flight by CC agent.
+
+**Finding:** `app/database.py:280-293` `run_migration()` opens migrations via
+`with get_conn() as conn: cur.execute(sql)`. psycopg2's `with conn:` is a
+transaction block — no autocommit. `CREATE INDEX CONCURRENTLY` and
+`DROP INDEX CONCURRENTLY` cannot run inside a transaction; Postgres
+hard-errors.
+
+**Hidden severity:** the glob loop at `main.py:746-780` catches the error,
+logs "failed (objects may already exist — recorded anyway)", and STILL
+inserts the migration name into the `migrations` table (lines 769-776).
+The index never exists and the migration is never retried on subsequent
+boots. A genuine CONCURRENTLY requirement would silently fail forever.
+
+**Possible prior instance — verify in prod:**
+`migrations/061_attestation_domain_index.sql` already uses
+`CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_state_attestations_domain_ts`.
+If migration 061 went through `run_migration()`, the index creation would
+have hard-errored, been swallowed, and `061_attestation_domain_index`
+recorded as applied anyway. The coherence-sweep covering index it was
+meant to create may not exist on prod. Verify with:
+`SELECT indexname FROM pg_indexes WHERE tablename = 'state_attestations';`
+— if `idx_state_attestations_domain_ts` is absent, this entry's priority
+should be raised (coherence-sweep queries are doing seq scans).
+
+**Class:** Foot-gun in shared infrastructure.
+
+**Priority:** P2 *(pending the 061 verification above — raise to P1 if the
+index is confirmed missing)*. No live failure from W2.4 itself (we dodge
+by using non-CONCURRENT `CREATE INDEX` for the 3,100-row
+`state_attestations` table, where plain `CREATE` completes in <1s with
+negligible lock).
+
+**When picked up:** add an opt-out path to `run_migration()` for migrations
+that need to run outside a transaction (sniff filename suffix like
+`_concurrent.sql`, or read a directive comment in the SQL header). Then
+either fail-loud OR auto-retry on the error class that indicates "needs
+no-transaction" instead of silently recording as applied.
+
+**Refs:** `app/database.py:280-293`, `main.py:746-780`,
+`migrations/061_attestation_domain_index.sql`, W2.4 pre-flight halt
+(this session).

--- a/docs/audits/2026-05-11-module-canonical-migration-plan.md
+++ b/docs/audits/2026-05-11-module-canonical-migration-plan.md
@@ -445,24 +445,25 @@ inserts the migration name into the `migrations` table (lines 769-776).
 The index never exists and the migration is never retried on subsequent
 boots. A genuine CONCURRENTLY requirement would silently fail forever.
 
-**Possible prior instance — verify in prod:**
-`migrations/061_attestation_domain_index.sql` already uses
+**Prior instance — verified RESOLVED (2026-05-15):**
+`migrations/061_attestation_domain_index.sql` also uses
 `CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_state_attestations_domain_ts`.
-If migration 061 went through `run_migration()`, the index creation would
-have hard-errored, been swallowed, and `061_attestation_domain_index`
-recorded as applied anyway. The coherence-sweep covering index it was
-meant to create may not exist on prod. Verify with:
+W2.4 pre-flight flagged it as a possible silent failure. Architect ran
 `SELECT indexname FROM pg_indexes WHERE tablename = 'state_attestations';`
-— if `idx_state_attestations_domain_ts` is absent, this entry's priority
-should be raised (coherence-sweep queries are doing seq scans).
+against the production Neon branch — `idx_state_attestations_domain_ts`
+**IS present**. Migration 061 did not silently fail (it predates the
+current glob runner, or was applied via a path that did not wrap it in a
+transaction). No coherence-sweep regression. This does not retire the
+entry: the runner foot-gun remains a class issue for any *future*
+CONCURRENTLY migration.
 
 **Class:** Foot-gun in shared infrastructure.
 
-**Priority:** P2 *(pending the 061 verification above — raise to P1 if the
-index is confirmed missing)*. No live failure from W2.4 itself (we dodge
-by using non-CONCURRENT `CREATE INDEX` for the 3,100-row
-`state_attestations` table, where plain `CREATE` completes in <1s with
-negligible lock).
+**Priority:** P2. No live failure today — 061's index is confirmed
+present (above), and W2.4 dodges the runner entirely by using
+non-CONCURRENT `CREATE INDEX` for the 3,100-row `state_attestations`
+table (plain `CREATE` completes in <1s with negligible lock). Bites the
+next time a large hot table genuinely needs a CONCURRENTLY index/drop.
 
 **When picked up:** add an opt-out path to `run_migration()` for migrations
 that need to run outside a transaction (sniff filename suffix like

--- a/migrations/112_state_attestations_writer_id_index.sql
+++ b/migrations/112_state_attestations_writer_id_index.sql
@@ -1,0 +1,21 @@
+-- Migration 112: index for writer_id (per #235 Option A, W2.4).
+--
+-- Plain CREATE INDEX (NOT CONCURRENTLY) because:
+--   (a) state_attestations is ~3,100 rows; AccessShare lock < 1s.
+--   (b) app/database.py:280-293 wraps every migration in a
+--       transaction via `with conn:`. CONCURRENTLY requires no
+--       transaction and would error. Worse, main.py:769-776
+--       silently records the migration as applied on failure,
+--       leaving the index missing and unretryable. (Wave-N entry
+--       in migration plan doc.)
+--
+-- Partial index: WHERE writer_id IS NOT NULL excludes legacy
+-- pre-W2.2 NULL rows, reducing storage overhead.
+--
+-- Idempotent: IF NOT EXISTS gate. Safe to re-run.
+
+CREATE INDEX IF NOT EXISTS idx_state_attestations_writer_id
+  ON state_attestations (writer_id)
+  WHERE writer_id IS NOT NULL;
+
+INSERT INTO migrations (name) VALUES ('112_state_attestations_writer_id_index') ON CONFLICT DO NOTHING;


### PR DESCRIPTION
## Summary

W2.4 of the `#235` Option A sequence. Adds `migrations/112_state_attestations_writer_id_index.sql` — a partial index on `state_attestations(writer_id)`.

- **`idx_state_attestations_writer_id`** — `CREATE INDEX ... ON state_attestations (writer_id) WHERE writer_id IS NOT NULL`. Partial: excludes legacy pre-W2.2 NULL rows. Idempotent via `IF NOT EXISTS`.
- Unblocks `#235` Phase 2.3 staged heartbeat dissolution — "is the wrapper firing independently of the heartbeat?" becomes a single indexed query.
- Builds on `#237` (W2.1 — `writer_id` column, migration 111) and the W2.2 call-site population.

## Non-concurrent — deliberate

The spec originally called for `CREATE INDEX CONCURRENTLY`. W2.4 pre-flight found that is structurally incompatible with this repo's migration runner: `run_migration()` (`app/database.py:280-293`) executes every migration inside a psycopg2 transaction; `CREATE INDEX CONCURRENTLY` cannot run in a transaction, and `main.py:769-776` records the migration as applied even on failure. `state_attestations` is ~3,100 rows, so a plain `CREATE INDEX` completes in <1s. Tracked as a Wave-N entry (included in this PR's doc commit).

## Substrate verification

### Pre-deploy

Pre-deploy substrate (run now — confirms the W2.1/W2.2 column is populated, so the index is meaningful):

```sql
SELECT COUNT(*) FROM state_attestations WHERE writer_id IS NOT NULL;
```
Expected: ~3,000+ rows (W2.2 population since 2026-05-14 01:36Z).

Queries the deploy verifier runs once the migration applies (next worker boot):

```sql
SELECT indexname, indexdef FROM pg_indexes
WHERE tablename = 'state_attestations' AND indexname = 'idx_state_attestations_writer_id';

EXPLAIN ANALYZE SELECT COUNT(*) FROM state_attestations
WHERE writer_id = 'module.peg_monitor' AND cycle_timestamp > NOW() - INTERVAL '24 hours';
```
Expected post-deploy: the index is present with the `WHERE` clause in `indexdef`; `EXPLAIN` shows an index scan on `idx_state_attestations_writer_id`.

## Pre-flight verification

Migration 061's `idx_state_attestations_domain_ts` **IS present on prod** — architect ran `SELECT indexname FROM pg_indexes WHERE tablename = 'state_attestations';` against the production Neon branch. Migration 061 (which also uses `CREATE INDEX CONCURRENTLY`) did not silently fail. The Wave-N entry still applies to future CONCURRENTLY migrations as a class issue.

Migration 111 (`writer_id` column) confirmed present; W2.1 signature changes in `app/state_attestation.py`; W2.2 population across 25 `app/` modules. Migration number 112 free; no index name collision.

## Test plan

- [ ] CI green.
- [ ] Post-deploy: `idx_state_attestations_writer_id` exists in `pg_indexes` with the partial `WHERE` clause.
- [ ] Post-deploy: `EXPLAIN` shows an index scan for a `writer_id` equality filter.
- [ ] Migration runner records `112_state_attestations_writer_id_index` as applied **and** the index actually exists (plain `CREATE INDEX` is transaction-safe, so this succeeds cleanly).

## Refs

- `#235` (Option A — `writer_id` discriminator)
- `#237` (W2.1 — `writer_id` column, migration 111)
- Wave-N entry: migration runner CONCURRENTLY incompatibility
