### PR TITLE
refactor(v9.12): remove web_research from slow-cycle heartbeat (Phase 2.3a)

### DIFF
--- a/app/worker.py
+++ b/app/worker.py
@@ -2643,9 +2643,9 @@ async def _emit_slow_cycle_heartbeats(
         base_payload["total_tasks"] = pipeline_result.get("total_tasks")
 
     # data_layer:dex_pool_ohlcv uses the attest_data_batch helper which
-    # prepends "data_layer:" to the domain. wallets / web_research /
-    # psi_discoveries use plain attest_state — they're top-level domains,
-    # not data_layer ones.
+    # prepends "data_layer:" to the domain. wallets / psi_discoveries
+    # use plain attest_state — they're top-level domains, not data_layer
+    # ones.
     try:
         from app.data_layer.provenance_scaling import attest_data_batch
         await asyncio.to_thread(
@@ -2666,7 +2666,14 @@ async def _emit_slow_cycle_heartbeats(
         # run_slow_cycle is dead in steady state. The wrapper handles the
         # `SELECT MAX(snapshot_date) FROM protocol_collateral_exposure`
         # gate internally and emits skipped_fresh|ran|error payloads.
-        for _domain in ("wallets", "web_research", "rpi_components"):
+        # Phase 2.3a (#235): 'web_research' removed from the heartbeat.
+        # The module-canonical wrapper run_web_research_scheduled() owns
+        # the 'web_research' domain's attestation in every branch
+        # (skipped_fresh / ran / error), so the heartbeat fallback was a
+        # redundant second writer. Staged dissolution — one domain per
+        # PR, verify the wrapper still fires solo post-deploy, then the
+        # next ('rpi_components' → 'wallets').
+        for _domain in ("wallets", "rpi_components"):
             try:
                 await asyncio.to_thread(attest_state, _domain, [base_payload], None, "heartbeat.slow_cycle")
             except Exception as e:


### PR DESCRIPTION
## Summary

Phase 2.3a of the `#235` staged heartbeat dissolution. Removes `'web_research'` from the domain tuple in `_emit_slow_cycle_heartbeats` (`app/worker.py`), making the module-canonical wrapper `run_web_research_scheduled()` the sole writer of the `web_research` domain.

Tuple change: `("wallets", "web_research", "rpi_components")` → `("wallets", "rpi_components")`. Two adjacent comment lines were also updated — a stale comment that listed `web_research` among the plain-`attest_state` domains, and a new rationale comment for the removal. The functional diff is the single tuple line.

## Substrate verification

### Pre-deploy

Pre-PR 48h baseline (verified directly via Neon at 2026-05-16T23:09Z):

```
domain=web_research, writer_id=module.web_research:    17 rows
domain=web_research, writer_id=heartbeat.slow_cycle:   22 rows
Both writers active. Wrapper has been firing independently for 48h+.
```

Post-deploy 4h gate (operator runs this query after merge):

```sql
SELECT writer_id, COUNT(*), MAX(cycle_timestamp), (NOW() - MAX(cycle_timestamp))::interval(0) AS staleness
FROM state_attestations
WHERE domain = 'web_research'
  AND cycle_timestamp > '<merge_ts>'::timestamptz
GROUP BY writer_id;
```

Expected: `module.web_research` rows continue accruing; `heartbeat.slow_cycle` rows = 0 for `web_research` after deploy.
Halt if `module.web_research` stops firing for >6h post-deploy.

## Observed cadence note

The wrapper is hitting its 24h freshness gate with a non-trivial staleness pattern — the latest `module.web_research` row is 5h32m old in the pre-PR window. That's well within the 24h gate but worth noting; if post-deploy substrate shows the wrapper's cadence degrading further, a follow-up issue should track the wrapper's gate behavior. Not a blocker for this PR — the wrapper has fired 17 times in 48h, more than the heartbeat would have triggered on its own.

## Rollback plan

```
git revert <merge_sha>
```

Heartbeat resumes covering `web_research`. No data lost — the wrapper writes to the real underlying `generic_index_scores`; the heartbeat only writes `state_attestations` rows.

## Test plan

- [ ] CI green.
- [ ] Post-deploy: `module.web_research` rows continue in `state_attestations`.
- [ ] Post-deploy: `heartbeat.slow_cycle` rows for `web_research` drop to 0.

## Refs

- `#235` (Phase 2.3 staged heartbeat dissolution)
- `#201` (web_research module-canonical wrapper)
