### PR TITLE
fix(edge_builder): gate on build_attempted_at, not wallet_edges.updated_at

### DIFF
--- a/app/indexer/edges.py
+++ b/app/indexer/edges.py
@@ -487,12 +487,24 @@ async def run_edge_builder_scheduled(chain: str, cycle_ts=None) -> dict:
     """
     from app.state_attestation import attest_state
 
-    # Per-chain freshness check via wallet_graph.wallet_edges MAX(updated_at).
-    # Preserves the pre-v9.12 main.py:471 10h cadence (Q4 unanswered in doc).
+    # Per-chain freshness gate: hours since the edge builder last ATTEMPTED a
+    # build for this chain, read from edge_build_status.build_attempted_at.
+    #
+    # This must NOT key on wallet_graph.wallet_edges.updated_at: updated_at is
+    # bumped by decay_edges() (runs every worker cycle once edges are stale) and
+    # by the sibling transfer_edge_builder's steady-state ON CONFLICT upserts.
+    # It therefore never goes stale, which permanently closed this gate and
+    # silently stalled the edge builder from 2026-05-15 onward.
+    #
+    # build_attempted_at is written only by build_edges_for_wallet (this
+    # module), on every attempt regardless of outcome (migration 104). It is
+    # the correct "did the edge builder run recently" signal and preserves the
+    # pre-v9.12 main.py:471 10h cadence.
     table_age_hours: float = float(_EDGE_BUILDER_FRESHNESS_HOURS)
     try:
         latest = await fetch_one_async(
-            "SELECT MAX(updated_at) AS t FROM wallet_graph.wallet_edges WHERE chain = %s",
+            "SELECT MAX(build_attempted_at) AS t "
+            "FROM wallet_graph.edge_build_status WHERE chain = %s",
             (chain,),
         )
         if latest and latest.get("t"):

--- a/tests/test_edge_freshness_smoke.py
+++ b/tests/test_edge_freshness_smoke.py
@@ -1,0 +1,155 @@
+"""
+Edge builder freshness — smoke test + freshness-gate regression test.
+
+Smoke test (DB-backed):
+    Fails when wallet_graph.wallet_edges has not received a NEW row within
+    N hours. N defaults to 8 and is overridable via EDGE_FRESHNESS_MAX_HOURS.
+    "New row" is measured by MAX(created_at) — created_at is set only on a
+    genuine INSERT, never on ON CONFLICT DO UPDATE, so it is the true signal
+    of edge-construction progress (same column the graph_edges health check
+    reads). Skips cleanly when DATABASE_URL is unset.
+
+    Run:
+        DATABASE_URL=<url> pytest tests/test_edge_freshness_smoke.py -v
+        EDGE_FRESHNESS_MAX_HOURS=14 DATABASE_URL=<url> pytest ... -v
+
+Regression test (no DB, runs in CI):
+    Pins run_edge_builder_scheduled's freshness gate to edge_build_status
+    .build_attempted_at. The pre-fix gate keyed on wallet_graph.wallet_edges
+    .updated_at, which decay_edges() and the sibling transfer_edge_builder
+    keep perpetually fresh — that closed the gate forever and silently
+    stalled the edge builder from 2026-05-15 onward.
+"""
+
+import asyncio
+import os
+import unittest
+from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Smoke test — DB-backed edge freshness
+# ---------------------------------------------------------------------------
+
+DEFAULT_MAX_HOURS = 8.0
+
+
+def _max_hours() -> float:
+    """Freshness budget in hours. Default 8, overridable via env."""
+    raw = os.environ.get("EDGE_FRESHNESS_MAX_HOURS")
+    if raw:
+        try:
+            return float(raw)
+        except ValueError:
+            pass
+    return DEFAULT_MAX_HOURS
+
+
+@pytest.mark.skipif(
+    not os.environ.get("DATABASE_URL"),
+    reason="DATABASE_URL not set — skipping DB-backed edge freshness smoke test.",
+)
+def test_wallet_edges_received_a_row_recently():
+    """wallet_graph.wallet_edges must have a row created within N hours."""
+    import psycopg2
+
+    max_hours = _max_hours()
+    with psycopg2.connect(os.environ["DATABASE_URL"]) as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                SELECT MAX(created_at),
+                       EXTRACT(EPOCH FROM (NOW() - MAX(created_at))) / 3600.0
+                FROM wallet_graph.wallet_edges
+                """
+            )
+            last_created, age_hours = cur.fetchone()
+
+    assert last_created is not None, (
+        "wallet_graph.wallet_edges is empty — the edge builder has never "
+        "produced a row."
+    )
+    assert age_hours is not None and age_hours <= max_hours, (
+        f"Edge builder stalled: the newest wallet_graph.wallet_edges row is "
+        f"{age_hours:.1f}h old (created_at={last_created}), which exceeds the "
+        f"{max_hours:.1f}h freshness budget. New rows are not landing — check "
+        f"run_edge_builder_scheduled's freshness gate in app/indexer/edges.py."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Regression test — freshness gate keys on the right column
+# ---------------------------------------------------------------------------
+
+class TestEdgeBuilderFreshnessGate(unittest.TestCase):
+    """run_edge_builder_scheduled must gate on edge_build_status
+    .build_attempted_at, not wallet_graph.wallet_edges.updated_at."""
+
+    def _run_scheduled(self, fetch_return):
+        """Invoke run_edge_builder_scheduled('ethereum') with the freshness
+        query mocked to return `fetch_return`. Returns (payload, mocks)."""
+        from app.indexer import edges
+
+        fetch_mock = AsyncMock(return_value=fetch_return)
+        builder_mock = AsyncMock(return_value={
+            "wallets_processed": 200,
+            "total_edges_created": 1234,
+            "total_transfers": 5678,
+        })
+        coherence_mock = AsyncMock(return_value=None)
+
+        with patch.object(edges, "fetch_one_async", fetch_mock), \
+             patch.object(edges, "run_edge_builder", builder_mock), \
+             patch.object(edges, "_assert_edges_coherence", coherence_mock), \
+             patch("app.state_attestation.attest_state", lambda *a, **k: None):
+            payload = asyncio.run(edges.run_edge_builder_scheduled("ethereum"))
+
+        return payload, fetch_mock, builder_mock
+
+    def test_gate_queries_build_attempted_at_not_updated_at(self):
+        """The freshness query must read edge_build_status.build_attempted_at.
+        Keying on wallet_edges.updated_at is the bug that stalled the builder."""
+        stale = datetime.now(timezone.utc) - timedelta(hours=30)
+        _, fetch_mock, _ = self._run_scheduled({"t": stale})
+
+        sql = " ".join(str(fetch_mock.call_args[0][0]).lower().split())
+        assert "build_attempted_at" in sql, (
+            f"freshness gate must query build_attempted_at; got: {sql}"
+        )
+        assert "edge_build_status" in sql, (
+            f"freshness gate must query edge_build_status; got: {sql}"
+        )
+        assert "updated_at" not in sql, (
+            "freshness gate must NOT key on updated_at — decay_edges() and "
+            f"transfer_edge_builder keep it perpetually fresh. SQL: {sql}"
+        )
+
+    def test_stale_build_attempt_runs_the_builder(self):
+        """A build attempt 30h ago is past the 10h cadence — builder runs."""
+        stale = datetime.now(timezone.utc) - timedelta(hours=30)
+        payload, _, builder_mock = self._run_scheduled({"t": stale})
+
+        assert payload["status"] == "ran", payload
+        builder_mock.assert_awaited_once()
+
+    def test_fresh_build_attempt_skips_the_builder(self):
+        """A build attempt 1h ago is within the 10h cadence — builder skips."""
+        fresh = datetime.now(timezone.utc) - timedelta(hours=1)
+        payload, _, builder_mock = self._run_scheduled({"t": fresh})
+
+        assert payload["status"] == "skipped_fresh", payload
+        builder_mock.assert_not_awaited()
+
+    def test_no_prior_attempt_runs_the_builder(self):
+        """No build_attempted_at row yet — builder must run, not stall."""
+        payload, _, builder_mock = self._run_scheduled({"t": None})
+
+        assert payload["status"] == "ran", payload
+        builder_mock.assert_awaited_once()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- The shared-holder edge builder silently stalled on 2026-05-15: no new row in `wallet_graph.wallet_edges` for ~74h while collectors stayed green.
- Root cause: `run_edge_builder_scheduled`'s freshness gate keyed on `MAX(wallet_graph.wallet_edges.updated_at)` — a column kept perpetually fresh by `decay_edges()` and the sibling `transfer_edge_builder`, so the gate returned `skipped_fresh` forever.
- Fix: gate now reads `MAX(edge_build_status.build_attempted_at)` (written only by the edge builder, migration 104). One-line query change + a smoke/regression test.

## Root cause

The regression is the freshness gate inside `run_edge_builder_scheduled` (the v9.12 module-canonical wrapper for the shared-holder edge builder, `app/indexer/edges.py`). The gate was:

```sql
SELECT MAX(updated_at) FROM wallet_graph.wallet_edges WHERE chain = %s
```

`updated_at` is **not** a "last built" signal. It is bumped to `NOW()` by:

- **`decay_edges()`** — `UPDATE wallet_graph.wallet_edges SET ..., updated_at = NOW() WHERE last_transfer_at < NOW() - INTERVAL '1 day'`. Runs every worker cycle once `edge_build_status` is stale.
- **`transfer_edge_builder`** (`app/data_layer/transfer_edge_builder.py`) — its 30-min loop re-upserts the same mature wallet population; every steady-state `ON CONFLICT DO UPDATE` sets `updated_at = NOW()`.
- The builder's own `ON CONFLICT DO UPDATE` on already-existing edges.

This created a **self-sustaining deadlock**: the gate sees a fresh `updated_at` → returns `skipped_fresh` → `run_edge_builder` never executes → `edge_build_status.last_built_at` never advances → the outer 10h gate (`worker.py`, `enrichment_worker.py`) stays permanently open → `decay_edges()` runs every cycle → `updated_at` stays permanently fresh → gate skips forever. Since 2026-05-15 the builder has not won a single cycle.

`MAX(created_at)` (what the `graph_edges` health check reads) only advances on a genuine `INSERT`, so it correctly shows the table frozen at `2026-05-15T06:28:49`.

### Ruled out
- **Not schema drift.** The writer's `INSERT` column list and `ON CONFLICT (from_address, to_address, chain, edge_type)` target exactly match the post-migration schema (migrations 021/024/099 verified). The May-15 archive move is unrelated to the writer — not modified, per instructions.
- **Not a crash loop.** The wrapper and all callers catch exceptions; a crash would surface as `status: error`, not silent skipping.
- **`wallet_edges_archive` untouched** — this change does not go near the archive or `prune_stale_edges`.

## The fix

`app/indexer/edges.py` — gate now reads:

```sql
SELECT MAX(build_attempted_at) FROM wallet_graph.edge_build_status WHERE chain = %s
```

`build_attempted_at` was added in **migration 104** specifically as the "every attempt regardless of outcome" tracker. It is written **only** by `build_edges_for_wallet` (this module). It is immune to `decay_edges()` (which never touches `edge_build_status`), to `transfer_edge_builder`, and to `solana_edges` (neither writes `build_attempted_at`). It is the correct "did the edge builder run recently" signal and preserves the intended 10h cadence. When no prior attempt exists (`NULL`), the gate opens and the builder runs — no stall.

One-line query change; comments updated. Payload shape (`status`, `table_age_hours`, attestation) unchanged.

## Tests — `tests/test_edge_freshness_smoke.py`

- **Smoke test** (`test_wallet_edges_received_a_row_recently`): fails when `wallet_graph.wallet_edges` has had no new row (`MAX(created_at)`) within **N hours — default 8**, overridable via `EDGE_FRESHNESS_MAX_HOURS`. DB-backed via `DATABASE_URL` (psycopg2), skips cleanly when unset — same convention as `test_engine_pipeline.py`.
- **Regression test** (`TestEdgeBuilderFreshnessGate`, 4 cases, no DB, CI-runnable): pins the gate to `edge_build_status.build_attempted_at`, asserts `updated_at` is **not** queried, and verifies stale → runs / fresh → skips / no-prior-attempt → runs.

All 15 tests in the new file + `test_edge_build_status.py` + `test_fetch_tokentx_errors.py` + `test_phase_triggers.py` pass.

> **Note on cadence vs. the 8h default:** the builder cadence is 10h, so an 8h smoke threshold can flag a healthy system in the ~2h window before a scheduled build. The default is kept at 8 as requested and is fully parameterized — for steady monitoring, operators may want `EDGE_FRESHNESS_MAX_HOURS=14`.

## Substrate verification

### Pre-deploy

This fix touches a running system, but live-DB verification could not be performed in this environment (`DATABASE_URL` unset; Neon MCP access denied), so the result is not yet known. The deploy verifier should run the following after one build cadence (~10h) has elapsed post-deploy:

```sql
-- (1) Newest edge row must advance past the stall point.
SELECT MAX(created_at) AS newest_edge,
       EXTRACT(EPOCH FROM (NOW() - MAX(created_at)))/3600 AS age_hours
FROM wallet_graph.wallet_edges;

-- (2) The wrapper's `ran` branch must fire (pre-fix: permanently `skipped_fresh`).
SELECT (state ->> 'status') AS status, COUNT(*), MAX(cycle_timestamp)
FROM state_attestations
WHERE domain = 'edges'
  AND cycle_timestamp > '<deploy_ts>'::timestamptz
GROUP BY 1;

-- (3) Archive must be untouched by this change.
SELECT COUNT(*) FROM wallet_graph.wallet_edges_archive;  -- compare to pre-deploy baseline
```

Expected post-deploy (within ~10h):
- Query (1): `MAX(created_at)` advances past `2026-05-15T06:28:49`; `age_hours` drops below the 10h cadence.
- Query (2): `status='ran'` rows appear for `domain='edges'` (pre-fix window shows only `skipped_fresh`).
- Query (3): `wallet_graph.wallet_edges_archive` count equals the pre-deploy baseline — this PR does not touch the archive or `prune_stale_edges`.

The bundled smoke test `tests/test_edge_freshness_smoke.py` automates query (1) — run it with `DATABASE_URL` set and `EDGE_FRESHNESS_MAX_HOURS=14`.

Pre-merge facts already confirmed by code analysis: the writer `INSERT`/`ON CONFLICT` matches the current `wallet_edges` schema (no migration regression); the change is confined to the gate query; regression + existing edge tests are green.

## Proposed new scenario (not authored here — for a scenarios-session)

This is a bug class not yet in scenarios. Recommended slug: **`silent-stall-on-migration`** (fits better than `writer-schema-drift` — the writer never drifted; a freshness gate keyed on a column that a *sibling* writer keeps perpetually warm is what stalled it after a release).

- **`bug.patch` shape:** revert `app/indexer/edges.py` `run_edge_builder_scheduled` so the freshness gate reads `MAX(updated_at) FROM wallet_graph.wallet_edges WHERE chain = %s` instead of `MAX(build_attempted_at) FROM wallet_graph.edge_build_status WHERE chain = %s`.
- **`stage_1.sql` shape:** seed `wallet_graph.wallet_edges` with rows whose `created_at` is old (e.g. 80h) but whose `updated_at` is recent (within 1h) — i.e. a `decay_edges()`-style mutation — plus `edge_build_status` rows with a stale `build_attempted_at`. The fixed gate runs the builder; the buggy gate skips on the fresh `updated_at`. The grader asserts a new `created_at` lands.

## Test plan

- [x] `tests/test_edge_freshness_smoke.py` regression cases pass (stale → runs, fresh → skips, no-prior-attempt → runs, gate queries `build_attempted_at`).
- [x] Existing `test_edge_build_status.py`, `test_fetch_tokentx_errors.py`, `test_phase_triggers.py` still pass.
- [ ] Post-deploy: run the Substrate verification queries above after one ~10h cadence.

---
🤖 Generated with [Claude Code](https://claude.ai/code)