### PR TITLE
fix(api): split /api/health into a trivial liveness probe + /api/health/deep

### DIFF
--- a/app/server.py
+++ b/app/server.py
@@ -1428,13 +1428,38 @@ async def readyz():
 
 
 # =============================================================================
-# 1. GET /api/health
+# 1. GET /api/health — trivial liveness probe
+#    GET /api/health/deep — full integrity-layer status
 # =============================================================================
+# /api/health must stay cheap (well under 100ms): it confirms only that the
+# process is alive and the database connection is reachable. It does NOT run
+# the integrity layer. The internal monitor
+# (app/ops/tools/health_checker.py::check_api_health) and any orchestrator
+# poll this endpoint — heavy work here cascades into false `api: down`
+# alerts when an unrelated domain is slow. The per-domain integrity
+# aggregation lives at /api/health/deep.
 
 @app.get("/api/health")
 async def get_health():
-    """System health check — powered by the integrity layer."""
-    cached = _cache.get("health", ttl=60)
+    """Liveness + DB-reachability probe. Trivial by design — returns in
+    well under 100ms. For the full per-domain integrity status, use
+    /api/health/deep."""
+    ok, reason = await asyncio.to_thread(_probe_db_quick)
+    payload = {
+        "status": "healthy" if ok else "unhealthy",
+        "database": {"reachable": ok, "detail": reason},
+        "formula_version": FORMULA_VERSION,
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+    }
+    return JSONResponse(payload, status_code=200 if ok else 503)
+
+
+@app.get("/api/health/deep")
+async def get_health_deep():
+    """Full system health — the integrity layer across every domain.
+    Heavier than /api/health (runs check_all over all domains); cached
+    60s. Not for liveness polling."""
+    cached = _cache.get("health_deep", ttl=60)
     if cached:
         return cached
 
@@ -1463,7 +1488,7 @@ async def get_health():
         "formula_version": FORMULA_VERSION,
         "timestamp": result["checked_at"],
     }
-    _cache.set("health", response_data)
+    _cache.set("health_deep", response_data)
     return response_data
 
 

--- a/tests/e2e_test.py
+++ b/tests/e2e_test.py
@@ -67,6 +67,54 @@ class TestEndpointSmoke:
         assert resp.json() is not None
 
 
+class TestHealthEndpoint:
+    """`/api/health` must be a trivial liveness probe — process alive + DB
+    reachable — and must NOT run the integrity layer. The rich per-domain
+    status lives at `/api/health/deep`. A heavy `/api/health` is what
+    caused the `api: down` ('read operation timed out') outage: the
+    internal monitor polls it."""
+
+    def test_health_is_fast(self, api):
+        """A liveness probe must return quickly. Server-side work is a
+        single SELECT 1; the ceiling here is generous to absorb network
+        latency to a remote deployment while still catching the timeout
+        regression (which manifested as multi-second / 20s+ responses)."""
+        import time
+        start = time.time()
+        resp = api("/api/health")
+        elapsed = time.time() - start
+        assert resp.status_code in (200, 503), (
+            f"/api/health returned {resp.status_code}"
+        )
+        assert elapsed < 2.0, (
+            f"/api/health took {elapsed:.2f}s — a liveness probe must be "
+            f"trivial. Heavy work here re-introduces the api-down outage."
+        )
+
+    def test_health_does_not_run_integrity_layer(self, api):
+        """The trivial probe must not carry the per-domain integrity
+        payload — that work is exactly what made it time out."""
+        resp = api("/api/health")
+        data = resp.json()
+        assert data is not None
+        assert "status" in data
+        assert "domains" not in data, (
+            "/api/health must not run the integrity layer; the per-domain "
+            "view belongs on /api/health/deep"
+        )
+
+    def test_health_deep_carries_full_status(self, api):
+        """The split-out deep endpoint still exposes the integrity-layer
+        per-domain status for dashboards that need it."""
+        resp = api("/api/health/deep")
+        if resp.status_code == 404:
+            pytest.skip("/api/health/deep not deployed yet")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data is not None
+        assert "domains" in data and "status" in data
+
+
 # =============================================================================
 # 2. Data Consistency
 # =============================================================================


### PR DESCRIPTION
## Summary

- `/api/health` was timing out (`api: down`, "read operation timed out"). It ran `check_all()` from the integrity layer on every request — a sequential per-domain sweep of freshness + coherence DB queries.
- `/api/health` is now a trivial liveness probe (process alive + DB reachable), returning in well under 100ms.
- The integrity-layer aggregation moved verbatim to a new `/api/health/deep` endpoint.

## Root cause

`app/server.py::get_health` did:

```python
from app.integrity import check_all
result = await check_all()        # <-- the heavy work
```

`check_all()` (`app/integrity.py:550`) loops every domain and `await`s `check_domain(name)` sequentially — each domain runs freshness (`MAX(timestamp)`, row counts) and coherence-rule queries. With ~a dozen domains that is dozens of serialized DB round-trips on every health request.

The internal monitor `app/ops/tools/health_checker.py::check_api_health` polls `https://basisprotocol.xyz/api/health` with a 20s client timeout. When the integrity sweep ran long, the monitor's read timed out → `ops_health_checks` recorded `system=api, status=down, error="The read operation timed out"`, firing the `health_failure` alert. `report_endpoints` stayed green because lighter endpoints were unaffected — this was specific to `/api/health` doing real work.

This matches suspected cause (a): a heavy query path inside the health check. It is **not** pool exhaustion (the handler took one pooled connection at a time) and **not** a degraded downstream dependency — `check_all` is all first-party DB work. So no pool retuning is proposed.

## The fix

`/api/health` — trivial liveness probe. Reuses the existing `_probe_db_quick()` helper (pooled `SELECT 1`) already backing `/healthz` / `/readyz`:

```python
@app.get("/api/health")
async def get_health():
    ok, reason = await asyncio.to_thread(_probe_db_quick)
    payload = {
        "status": "healthy" if ok else "unhealthy",
        "database": {"reachable": ok, "detail": reason},
        "formula_version": FORMULA_VERSION,
        "timestamp": datetime.now(timezone.utc).isoformat(),
    }
    return JSONResponse(payload, status_code=200 if ok else 503)
```

It counts no rows, calls no external API, validates no schema, and touches no wallet-graph or scoring table. No timeout was raised and no `try/except` swallows errors — a DB-down result is reported honestly as `unhealthy` + `503`.

`/api/health/deep` — the previous rich handler body, moved verbatim (cache key `health` → `health_deep`). Dashboards that want the per-domain integrity view use this.

## Internal monitor

`check_api_health` polls `/api/health` and only inspects status code + latency. With `/api/health` now cheap it gets a fast `200` → `api` returns to `healthy`. **No monitor change is required** — the URL it already polls is the correct cheap endpoint. (The split moved the *rich* logic to a new path; the monitor was never meant to poll the rich path.)

No code consumer reads `/api/health`'s `domains` field — verified by grep. The legacy embedded admin page `loadHealth()` (`server.py:3281`) reads a `d.scores` / `d.scoring_issues` shape that the *current* handler already does not return, so it is pre-existing dead/stale code and is unaffected by this change.

## Before / after latency

| | Before | After |
|---|---|---|
| `/api/health` server work | full `check_all()` — dozens of serialized domain queries; intermittently >20s | one pooled `SELECT 1` |
| Expected response | timeout → `api: down` | `200` in <100ms server-side |

Live before/after numbers could not be captured here — `DATABASE_URL` is unset in this environment and there is no running server to `curl`. See Substrate verification.

## Substrate verification

### Pre-deploy

No running server / DB in this environment. After deploy the verifier should, against the deployment (or PR preview) URL:

```bash
# Must be 200 and fast (server work is a single SELECT 1).
for i in 1 2 3; do curl -m 5 -s -o /dev/null -w "%{http_code} %{time_total}s\n" \
  https://basisprotocol.xyz/api/health ; done

# Trivial probe must NOT carry the integrity payload.
curl -m 5 -s https://basisprotocol.xyz/api/health | jq 'has("domains")'        # -> false
# Rich status still available on the new path.
curl -s https://basisprotocol.xyz/api/health/deep | jq '.domains | length'     # -> >0
```

```sql
-- The monitor should stop recording `api` as down once /api/health is cheap.
SELECT status, details, checked_at
FROM ops_health_checks
WHERE system = 'api' ORDER BY checked_at DESC LIMIT 5;
```

Expected post-deploy: `/api/health` returns `200` in <500ms consistently (server-side <100ms); `has("domains")` is `false`; `/api/health/deep` returns the per-domain map; the next `ops_health_checks` row for `system=api` flips to `healthy` and the `health_failure` alert clears.

The bundled `tests/e2e_test.py::TestHealthEndpoint` automates the latency + shape checks (`BASE_URL=<url> pytest tests/e2e_test.py -k TestHealthEndpoint`).

## Tests

`tests/e2e_test.py::TestHealthEndpoint` (3 cases): `/api/health` responds fast, `/api/health` carries no `domains`, `/api/health/deep` still exposes `domains`. Syntax-checked and collected; they require a live `BASE_URL` to run (the established e2e convention).

## Proposed new scenario (not authored here — for a scenarios-session)

Bug class not yet in scenarios. Recommended slug: **`health-endpoint-heavy-work`** (fits better than `liveness-probe-mismatch` — the probe path was correct; it was doing expensive work).

- **`bug.patch` shape:** revert `app/server.py` so `get_health` calls `await check_all()` and returns the per-domain payload under `/api/health` (collapsing `/api/health/deep` back in).
- **`stage_1.sql` shape:** seed one integrity domain's source table so a freshness/coherence query in `check_domain` is slow (e.g. a large unindexed table, or many rows forcing a scan), making `check_all()` exceed a few seconds. The grader asserts `/api/health` p95 latency is below a small bound and the response has no `domains` key; the buggy handler blows the latency bound.

## Test plan

- [x] `app/server.py` + `tests/e2e_test.py` syntax-checked; new tests collect.
- [ ] Post-deploy: run the Substrate verification `curl`s and confirm `ops_health_checks` `system=api` returns to `healthy`.

---
🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GwJew2syH7S64YnviofCg2)_