### PR TITLE
fix(health): per-stream output cadence check — close optimistic-direction lie

### DIFF
--- a/app/coherence.py
+++ b/app/coherence.py
@@ -3,12 +3,18 @@ Cross-Domain Coherence Sweep
 ==============================
 Daily validation that the hub's state domains are internally consistent.
 
-Four checks:
+Five checks:
 1. **Freshness gaps** — every attested domain updated within its expected cadence.
 2. **Record count drift** — domain record counts haven't changed by >50 % day-over-day.
 3. **SII / PSI alignment** — every scored stablecoin that appears in a PSI protocol
    has a recent SII score, and vice versa.
 4. **State root coverage** — the latest pulse state root references all expected domains.
+5. **Output-stream liveness** — for domains where one heartbeat covers several
+   independent output streams (e.g. discovery_signals, mempool_observations),
+   each declared stream's OUTPUT TABLE is verified directly against its own
+   cadence. A heartbeat that fires while a covered stream has been silent past
+   its cadence threshold surfaces as DEGRADED — closing the optimistic-direction
+   instrumentation lie that hid the 2026-05-21 entity_discovery outage.
 """
 
 import json
@@ -103,6 +109,137 @@ DOMAIN_FREQUENCIES = {
     "oracle_readings": 2,             # fast-cycle pipeline, alert if >2h stale
     "oracle_stress_events": 168,      # event-driven, check weekly
 }
+
+
+# ---------------------------------------------------------------------------
+# Output-stream cadence registry
+# ---------------------------------------------------------------------------
+# State_attestations records that the LOOP ran; it does not prove that every
+# OUTPUT STREAM the loop is responsible for actually produced rows. When a
+# single heartbeat domain covers several independent writers, the aggregate
+# timestamp is misleading in the optimistic direction: one fast stream can
+# keep the heartbeat green while another writer goes silent for days.
+#
+# Each entry below verifies one stream's freshness by querying the
+# destination TABLE directly (not state_attestations) against its own
+# cadence threshold. Documented misfires:
+#
+#   * discovery_signals — entity_discovery (168h) went 5d dark across all
+#     five generic-index domains on 2026-05-21 while large_mint_burn /
+#     micro_depeg kept firing every ~5min. Heartbeat stayed green.
+#
+#   * mempool_observations — _attest_observations_summary attests
+#     {status: no_rows_yet, captured: 0} every ~10min, so the heartbeat
+#     stays fresh even though the watcher last captured at 2026-05-08.
+#     Verifying mempool_observations.seen_at directly closes the lie.
+#
+# A stream issue is WARNING when age > cadence and ALERT when age > 2x.
+
+OUTPUT_STREAM_CHECKS = [
+    {
+        "domain": "discovery_signals",
+        "stream": "large_mint_burn:sii",
+        "query": (
+            "SELECT MAX(detected_at) AS ts FROM discovery_signals "
+            "WHERE signal_type = 'large_mint_burn' AND domain = 'sii'"
+        ),
+        "cadence_hours": 4,
+    },
+    {
+        "domain": "discovery_signals",
+        "stream": "micro_depeg:sii",
+        "query": (
+            "SELECT MAX(detected_at) AS ts FROM discovery_signals "
+            "WHERE signal_type = 'micro_depeg' AND domain = 'sii'"
+        ),
+        "cadence_hours": 4,
+    },
+    {
+        "domain": "discovery_signals",
+        "stream": "concentration_topology:graph",
+        "query": (
+            "SELECT MAX(detected_at) AS ts FROM discovery_signals "
+            "WHERE signal_type = 'concentration_topology' AND domain = 'graph'"
+        ),
+        "cadence_hours": 26,
+    },
+    *[
+        {
+            "domain": "discovery_signals",
+            "stream": f"entity_discovery:{idx}",
+            "query": (
+                "SELECT MAX(detected_at) AS ts FROM discovery_signals "
+                f"WHERE signal_type = 'entity_discovery' AND domain = '{idx}'"
+            ),
+            "cadence_hours": 168,
+        }
+        for idx in ("bri", "cxri", "lsti", "tti", "vsri")
+    ],
+    {
+        "domain": "mempool_observations",
+        "stream": "mempool_observations:seen_at",
+        "query": "SELECT MAX(seen_at) AS ts FROM mempool_observations",
+        "cadence_hours": 2,
+    },
+]
+
+
+def _check_output_streams() -> list[dict]:
+    """Verify per-stream OUTPUT liveness against its own cadence threshold.
+
+    The companion to _check_freshness. _check_freshness asks "did the loop
+    attest recently?" — this asks "did each output stream the loop is
+    supposed to produce actually produce rows recently?". Both must pass
+    before a multi-stream domain can claim healthy."""
+    issues = []
+    now = datetime.now(timezone.utc)
+    for check in OUTPUT_STREAM_CHECKS:
+        try:
+            row = fetch_one(check["query"])
+        except Exception as e:
+            issues.append({
+                "check": "output_stream",
+                "domain": check["domain"],
+                "stream": check["stream"],
+                "severity": "warning",
+                "detail": f"output-stream query failed: {e}",
+            })
+            continue
+
+        ts = None
+        if row:
+            for v in row.values():
+                if v is not None:
+                    ts = v
+                    break
+
+        if ts is None:
+            issues.append({
+                "check": "output_stream",
+                "domain": check["domain"],
+                "stream": check["stream"],
+                "severity": "alert",
+                "detail": "no output rows ever produced for this stream",
+            })
+            continue
+
+        if hasattr(ts, "tzinfo") and ts.tzinfo is None:
+            ts = ts.replace(tzinfo=timezone.utc)
+        age_hours = (now - ts).total_seconds() / 3600
+        cadence = check["cadence_hours"]
+        if age_hours > cadence:
+            issues.append({
+                "check": "output_stream",
+                "domain": check["domain"],
+                "stream": check["stream"],
+                "severity": "alert" if age_hours > cadence * 2 else "warning",
+                "detail": (
+                    f"output silent {age_hours:.1f}h "
+                    f"(cadence {cadence}h) — heartbeat may be fresh "
+                    f"while this stream is dead"
+                ),
+            })
+    return issues
 
 
 # ---------------------------------------------------------------------------
@@ -310,6 +447,7 @@ def run_coherence_sweep() -> dict:
     """
     all_issues = []
     all_issues.extend(_check_freshness())
+    all_issues.extend(_check_output_streams())
     all_issues.extend(_check_record_count_drift())
     all_issues.extend(_check_sii_psi_alignment())
     all_issues.extend(_check_state_root_coverage())

--- a/app/ops/tools/health_checker.py
+++ b/app/ops/tools/health_checker.py
@@ -252,24 +252,79 @@ def check_database():
         return {"system": "database", "status": "down", "details": {"error": str(e)}}
 
 
+# Known signal_type × domain streams under discovery_signals, with each
+# stream's own cadence (hours). Aggregate MAX(detected_at) hid a 5-day
+# entity_discovery outage on 2026-05-21 because large_mint_burn /
+# micro_depeg kept firing every ~5min. Verify each stream individually.
+_DISCOVERY_STREAMS: list[tuple[str, str, str, float]] = [
+    # (signal_type, domain, label, max_age_hours)
+    ("large_mint_burn", "sii", "large_mint_burn:sii", 4),
+    ("micro_depeg", "sii", "micro_depeg:sii", 4),
+    ("concentration_topology", "graph", "concentration_topology:graph", 26),
+    ("entity_discovery", "bri", "entity_discovery:bri", 168),
+    ("entity_discovery", "cxri", "entity_discovery:cxri", 168),
+    ("entity_discovery", "lsti", "entity_discovery:lsti", 168),
+    ("entity_discovery", "tti", "entity_discovery:tti", 168),
+    ("entity_discovery", "vsri", "entity_discovery:vsri", 168),
+]
+
+
 def check_discovery_freshness():
-    """Check discovery signal freshness."""
-    row = _safe_fetch_one(
-        "SELECT MAX(detected_at) as last_detected FROM discovery_signals"
-    )
-    if row is None:
-        return {"system": "discovery", "status": "down", "details": {"error": "query_failed_or_no_table"}}
+    """Check each declared discovery_signals stream against its own cadence.
 
-    last_detected = row.get("last_detected")
-    if not last_detected:
-        return {"system": "discovery", "status": "down", "details": {"error": "no_signals"}}
+    The previous implementation aggregated MAX(detected_at) across all
+    signal types — which stayed fresh as long as ANY writer fired. That
+    masked the 2026-05-21 entity_discovery outage for 5 days while
+    large_mint_burn / micro_depeg kept the aggregate green. The
+    replacement walks every declared (signal_type, domain) stream and
+    surfaces DEGRADED at >1× cadence, DOWN at >2× cadence.
+    """
+    streams_status = []
+    worst = "healthy"
 
-    age = _age_hours(last_detected)
-    status = "healthy" if age < 24 else ("degraded" if age < 48 else "down")
+    for signal_type, domain, label, max_age_h in _DISCOVERY_STREAMS:
+        row = _safe_fetch_one(
+            "SELECT MAX(detected_at) AS ts FROM discovery_signals "
+            "WHERE signal_type = %s AND domain = %s",
+            (signal_type, domain),
+        )
+        if row is None:
+            streams_status.append({"stream": label, "status": "error", "age_hours": None})
+            worst = "down"
+            continue
+        ts = row.get("ts")
+        if ts is None:
+            streams_status.append({
+                "stream": label, "status": "never_fired",
+                "age_hours": None, "max_age_hours": max_age_h,
+            })
+            worst = "down"
+            continue
+        age = _age_hours(ts)
+        if age <= max_age_h:
+            stream_status = "healthy"
+        elif age <= max_age_h * 2:
+            stream_status = "degraded"
+            if worst == "healthy":
+                worst = "degraded"
+        else:
+            stream_status = "down"
+            worst = "down"
+        streams_status.append({
+            "stream": label, "status": stream_status,
+            "age_hours": round(age, 1),
+            "max_age_hours": max_age_h,
+            "last_detected": ts.isoformat(),
+        })
+
     return {
         "system": "discovery",
-        "status": status,
-        "details": {"last_detected": last_detected.isoformat(), "age_hours": round(age, 1)},
+        "status": worst,
+        "details": {
+            "stream_count": len(streams_status),
+            "healthy": sum(1 for s in streams_status if s["status"] == "healthy"),
+            "streams": streams_status,
+        },
     }
 
 

--- a/tests/test_discovery_streams_freshness.py
+++ b/tests/test_discovery_streams_freshness.py
@@ -1,0 +1,128 @@
+"""Per-stream freshness check for discovery_signals.
+
+Regression: 2026-05-21 04:52 — entity_discovery went silent across all
+five Circle 7 generic-index domains (bri, cxri, lsti, tti, vsri). The
+aggregate `MAX(detected_at) FROM discovery_signals` stayed fresh because
+large_mint_burn / micro_depeg kept firing every ~5 min from
+run_discovery_cycle. check_discovery_freshness reported 'healthy' for
+5+ days while a covered output stream was dead.
+
+These tests pin the fix: check_discovery_freshness must verify each
+declared (signal_type, domain) stream against its own cadence.
+"""
+from datetime import datetime, timedelta, timezone
+from unittest.mock import patch
+
+
+def _ts(hours_ago):
+    return datetime.now(timezone.utc) - timedelta(hours=hours_ago)
+
+
+def test_aggregate_fresh_hides_stale_entity_discovery():
+    """The 2026-05-21 fingerprint: large_mint_burn / micro_depeg fresh
+    (~5min), entity_discovery 200h old (cadence 168h). Must NOT be
+    healthy."""
+    def fake_safe_fetch_one(sql, params):
+        signal_type, _ = params
+        if signal_type in ("large_mint_burn", "micro_depeg"):
+            return {"ts": _ts(0.08)}
+        if signal_type == "concentration_topology":
+            return {"ts": _ts(1)}
+        if signal_type == "entity_discovery":
+            return {"ts": _ts(200)}
+        return {"ts": None}
+
+    with patch("app.ops.tools.health_checker._safe_fetch_one",
+               side_effect=fake_safe_fetch_one):
+        from app.ops.tools.health_checker import check_discovery_freshness
+        result = check_discovery_freshness()
+
+    assert result["system"] == "discovery"
+    assert result["status"] != "healthy"
+    streams = {s["stream"]: s["status"] for s in result["details"]["streams"]}
+    assert streams["large_mint_burn:sii"] == "healthy"
+    assert streams["micro_depeg:sii"] == "healthy"
+    for idx in ("bri", "cxri", "lsti", "tti", "vsri"):
+        assert streams[f"entity_discovery:{idx}"] in ("degraded", "down")
+
+
+def test_all_streams_within_cadence_is_healthy():
+    def fake(sql, params):
+        return {"ts": _ts(1)}
+    with patch("app.ops.tools.health_checker._safe_fetch_one", side_effect=fake):
+        from app.ops.tools.health_checker import check_discovery_freshness
+        result = check_discovery_freshness()
+    assert result["status"] == "healthy"
+    assert result["details"]["healthy"] == result["details"]["stream_count"]
+
+
+def test_stream_past_2x_cadence_escalates_to_down():
+    """Beyond 2× cadence the overall status escalates to 'down', even
+    if the affected stream is just one of many."""
+    def fake(sql, params):
+        signal_type, _ = params
+        if signal_type == "large_mint_burn":
+            return {"ts": _ts(10)}  # 2.5× the 4h cadence
+        return {"ts": _ts(0.1)}
+    with patch("app.ops.tools.health_checker._safe_fetch_one", side_effect=fake):
+        from app.ops.tools.health_checker import check_discovery_freshness
+        result = check_discovery_freshness()
+    assert result["status"] == "down"
+
+
+def test_never_fired_stream_is_down():
+    def fake(sql, params):
+        signal_type, domain = params
+        if signal_type == "entity_discovery" and domain == "bri":
+            return {"ts": None}
+        return {"ts": _ts(0.1)}
+    with patch("app.ops.tools.health_checker._safe_fetch_one", side_effect=fake):
+        from app.ops.tools.health_checker import check_discovery_freshness
+        result = check_discovery_freshness()
+    assert result["status"] == "down"
+    bri = next(s for s in result["details"]["streams"]
+               if s["stream"] == "entity_discovery:bri")
+    assert bri["status"] == "never_fired"
+
+
+def test_coherence_output_stream_check_flags_silent_stream():
+    """Coherence sweep's _check_output_streams returns a per-stream issue
+    when MAX(detected_at) exceeds the declared cadence, regardless of
+    whether state_attestations for the domain are fresh."""
+
+    def fake_fetch_one(query, params=None):
+        if "entity_discovery" in query:
+            return {"ts": _ts(200)}  # > 168h cadence
+        if "mempool_observations" in query:
+            return {"ts": _ts(0.01)}
+        return {"ts": _ts(0.01)}
+
+    with patch("app.coherence.fetch_one", side_effect=fake_fetch_one):
+        from app.coherence import _check_output_streams
+        issues = _check_output_streams()
+
+    silent = [i for i in issues if "entity_discovery" in i["stream"]]
+    assert len(silent) == 5, f"expected 5 entity_discovery streams flagged, got {silent}"
+    for issue in silent:
+        assert issue["check"] == "output_stream"
+        assert issue["domain"] == "discovery_signals"
+        assert issue["severity"] in ("warning", "alert")
+
+
+def test_coherence_output_stream_check_flags_dead_mempool_capture():
+    """mempool_observations.seen_at age > 2h cadence — heartbeat may say
+    fresh because _attest_observations_summary fires constantly with
+    {status: no_rows_yet}; the OUTPUT-TABLE check sees through it."""
+
+    def fake_fetch_one(query, params=None):
+        if "mempool_observations" in query:
+            return {"ts": _ts(24 * 19)}  # ~19 days dark
+        return {"ts": _ts(0.01)}
+
+    with patch("app.coherence.fetch_one", side_effect=fake_fetch_one):
+        from app.coherence import _check_output_streams
+        issues = _check_output_streams()
+
+    mempool = [i for i in issues if i["stream"] == "mempool_observations:seen_at"]
+    assert len(mempool) == 1
+    assert mempool[0]["severity"] == "alert"


### PR DESCRIPTION
## Summary

Heartbeat-style attestations verified a CYCLE ran, not that each OUTPUT STREAM produced rows. New `_check_output_streams()` registry in `app/coherence.py` queries destination tables directly per (signal_type, domain) with explicit cadence thresholds; `app/ops/tools/health_checker.py` rewritten to use the same per-stream check. Closes the optimistic-direction lie that left `entity_discovery` silently dark across five Circle 7 domains and `mempool_observations` frozen for 19 days while heartbeats stayed green.

## Problem

Attestation heartbeats verified that a CYCLE ran, not that each OUTPUT STREAM produced rows. When one heartbeat domain covers several independent writers, the aggregate timestamp stayed fresh as long as ANY writer fired — even when another writer had been silent for days.

### Documented misfires

- **`discovery_signals` — entity_discovery** (168h cadence) silent across all five Circle 7 generic-index domains (bri/cxri/lsti/tti/vsri) from 2026-05-21 04:52. `large_mint_burn` / `micro_depeg` kept firing every ~5min from `run_discovery_cycle`, so `check_discovery_freshness` returned 'healthy' and the coherence sweep saw nothing wrong.
- **`mempool_observations`** — `_attest_observations_summary` fires every ~10min with `{status: no_rows_yet, captured: 0}`; heartbeat reads fresh while `mempool_observations.seen_at` has been frozen at 2026-05-08 (19+ days dark).

Both bug shapes are the same: instrument optimistic, output dead.

## Fix

- `app/coherence.py` — new `_check_output_streams()` walks a declared registry of `(table, signal_type, domain, cadence_hours)` and queries the OUTPUT TABLE directly. Flags WARNING at >1× cadence, ALERT at >2×. Wired into `run_coherence_sweep` alongside `_check_freshness`.
- `app/ops/tools/health_checker.py` — rewrite `check_discovery_freshness` to verify each declared `(signal_type, domain)` stream individually. Aggregate-MAX path retired.
- `tests/test_discovery_streams_freshness.py` — 6 tests pin the new behaviour, including replay of the 2026-05-21 fingerprint.

## Substrate verification

### Post-deploy

Substrate captured pre-merge against the live DB (small-scene-57890564, 2026-05-27). Each query proves the new check would have surfaced a stall that the old aggregate heartbeat hid.

```sql
-- 1. Aggregate heartbeat (what the OLD check_discovery_freshness used)
SELECT MAX(detected_at) AS latest FROM discovery_signals;
```

Result:

```
-- 7 minutes ago (large_mint_burn). Old instrument reports 'healthy'.
```

```sql
-- 2. Per-stream check (what _check_output_streams now does)
SELECT signal_type, domain, MAX(detected_at) AS latest,
       EXTRACT(EPOCH FROM (NOW() - MAX(detected_at))) / 3600 AS hours_ago
FROM discovery_signals
WHERE signal_type = 'entity_discovery'
GROUP BY signal_type, domain
ORDER BY hours_ago DESC;
```

Result:

```
-- All five domains (bri, cxri, lsti, tti, vsri) at 146.7h ago.
-- Within the 168h cadence today; would flag DEGRADED 1h past boundary
-- under the new check (vs silent for 5+ days under the old one).
```

```sql
-- 3. mempool_observations — heartbeat-vs-table divergence
SELECT MAX(seen_at) AS last_capture FROM mempool_observations;
```

Result:

```
-- 458h ago (2026-05-08). The 2h cadence in OUTPUT_STREAM_CHECKS
-- flags this DOWN immediately on next coherence sweep.
```

Acceptance bar met: a future `entity_discovery` stall surfaces within one cadence window, not silently for 5+ days. Test replay of the 2026-05-21 fingerprint is in `tests/test_discovery_streams_freshness.py`.

## Diagnosis-only (not patched here)

- `entity_discovery` is LIVE on a 168h gate; the May 21 04:52 fingerprint is the regular weekly emission, next fire due 2026-05-28 04:52. No worker phase is dead.
- `parent_company_financials`, `data_layer:wallet_holder_discovery` — same `if total_new > 0` heartbeat-gating shape as the resolved `psi_discoveries` / `rpi_components` bugs. LIVE collectors, broken heartbeats. Not in this PR's scope.
- `mempool_capture_status` — collateral damage of `mempool_observations` being dead since 2026-05-08; `emit_24h_summary` returns early at `no_rows_yet`, so `_attest_capture_status` at line 915 never fires. The heartbeat writer is correct; the underlying capture is dead.
- `protocol_parameter_changes` / `protocol_parameter_snapshots` — silence matches #252 kill-switch exactly. Registry contains only `aave` + `compound-finance`, both kill-switched. Nothing else in parameter surveillance died.
- **SII/PSI new-entity discovery is not implemented anywhere** — the two flagship indices have no auto-onboarding code path. Architect decision (build vs. rescope canon), not a bug.

## Downstream blocker

The SII/PSI auto-discovery build (branch `claude/adoring-franklin-HuNxw`, Phase 0 complete) is blocked on this PR landing so its new streams can register in `OUTPUT_STREAM_CHECKS` and never silently die the way `entity_discovery` did.