### PR TITLE
fix(attest): RAN-gate four heartbeat-lie attestations (scenario 006 sweep)

### DIFF
--- a/app/collectors/rated_validators.py
+++ b/app/collectors/rated_validators.py
@@ -220,25 +220,29 @@ def collect_validator_performance() -> dict:
             except Exception:
                 pass
 
-    # Attest batch
-    if snapshots_stored > 0:
+    # Attest batch — RAN-gated, not DELTA-gated. Always attest once the scan
+    # completes, even when operators_stored == 0. The payload already carries
+    # the count, so "ran, stored 0" is an honest heartbeat. Gating on
+    # `snapshots_stored > 0` let the validator_performance domain (24h
+    # coherence floor) go perpetually stale whenever no new snapshots landed —
+    # the same heartbeat-lie as parent_company_financials / holder_ingestion.
+    try:
+        from app.state_attestation import attest_state
+        attest_state("validator_performance", [{
+            "snapshot_date": today.isoformat(),
+            "operators_stored": snapshots_stored,
+        }], writer_id="module.rated_validators")
+    except Exception as e:
+        logger.warning(f"Validator performance attestation failed: {e}")
         try:
-            from app.state_attestation import attest_state
-            attest_state("validator_performance", [{
-                "snapshot_date": today.isoformat(),
-                "operators_stored": snapshots_stored,
-            }], writer_id="module.rated_validators")
-        except Exception as e:
-            logger.warning(f"Validator performance attestation failed: {ae}")
-            try:
-                from app.worker import _record_cycle_error
-                _record_cycle_error(
-                    error_type="collectors_collect_validator_performance_failure",
-                    error_message=str(e)[:500],
-                    cycle_phase="rated_validators",
-                )
-            except Exception:
-                pass
+            from app.worker import _record_cycle_error
+            _record_cycle_error(
+                error_type="collectors_collect_validator_performance_failure",
+                error_message=str(e)[:500],
+                cycle_phase="rated_validators",
+            )
+        except Exception:
+            pass
 
     summary = {
         "operators_checked": operators_checked,

--- a/app/collectors/sanctions_screening.py
+++ b/app/collectors/sanctions_screening.py
@@ -191,26 +191,30 @@ def run_sanctions_screening() -> dict:
             except Exception:
                 pass
 
-    # Attest batch
-    if targets_screened > 0:
+    # Attest batch — RAN-gated, not DELTA-gated. Always attest once the screen
+    # completes, even when targets_screened == 0. The payload already carries
+    # the count, so "ran, screened 0" is an honest heartbeat. Gating on
+    # `targets_screened > 0` let the sanctions_screening domain (24h coherence
+    # floor) go silent whenever the target query returned nothing — the same
+    # heartbeat-lie as parent_company_financials / holder_ingestion.
+    try:
+        from app.state_attestation import attest_state
+        attest_state("sanctions_screening", [{
+            "date": today.isoformat(),
+            "targets_screened": targets_screened,
+            "matches_found": matches_found,
+        }], writer_id="module.sanctions_screening")
+    except Exception as e:
+        logger.warning(f"Sanctions screening attestation failed: {e}")
         try:
-            from app.state_attestation import attest_state
-            attest_state("sanctions_screening", [{
-                "date": today.isoformat(),
-                "targets_screened": targets_screened,
-                "matches_found": matches_found,
-            }], writer_id="module.sanctions_screening")
-        except Exception as e:
-            logger.warning(f"Sanctions screening attestation failed: {ae}")
-            try:
-                from app.worker import _record_cycle_error
-                _record_cycle_error(
-                    error_type="collectors_run_sanctions_screening_failure",
-                    error_message=str(e)[:500],
-                    cycle_phase="sanctions_screening",
-                )
-            except Exception:
-                pass
+            from app.worker import _record_cycle_error
+            _record_cycle_error(
+                error_type="collectors_run_sanctions_screening_failure",
+                error_message=str(e)[:500],
+                cycle_phase="sanctions_screening",
+            )
+        except Exception:
+            pass
 
     summary = {
         "targets_screened": targets_screened,

--- a/app/enrichment_worker.py
+++ b/app/enrichment_worker.py
@@ -765,12 +765,22 @@ async def run_enrichment_pipeline() -> dict:
         try:
             from app.state_attestation import attest_state
             signals = result.get("divergence_signals", []) if isinstance(result, dict) else []
+            # RAN-gated, not DELTA-gated. detect_all_divergences() runs every
+            # enrichment cycle; in steady state it frequently finds zero
+            # divergences (capital flows track quality). Gating the attest on
+            # `if signals:` let the divergence_signals domain (4h coherence
+            # floor) go silent on any quiet cycle while the detector was
+            # healthy — the same heartbeat-lie as parent_company_financials /
+            # holder_ingestion. Attest the cycle either way; an empty cycle is
+            # a valid "ran, no divergences" statement.
             if signals:
                 records = [
                     {"type": s.get("type"), "severity": s.get("severity")}
                     for s in signals
                 ]
-                await asyncio.to_thread(attest_state, "divergence_signals", records, None, "enrichment.divergence_detection")
+            else:
+                records = [{"status": "ran_no_results", "results_count": 0}]
+            await asyncio.to_thread(attest_state, "divergence_signals", records, None, "enrichment.divergence_detection")
         except Exception as e:
             logger.error(f"[enrichment] divergence attestation failed: {e}")
             try:
@@ -1238,8 +1248,17 @@ async def run_enrichment_pipeline() -> dict:
                 fetch_all,
                 "SELECT source_domain, attestation_hash, proved_at FROM provenance_proofs WHERE proved_at > NOW() - INTERVAL '2 hours'",
             )
+            # RAN-gated, not DELTA-gated. The guard counts proofs that landed
+            # in a trailing 2h SELECT window, NOT what this run did — exactly
+            # the lookback-window shape that left cda_extractions empty for
+            # 30+ days (see cda_collector.py:34). When the linking run lands
+            # nothing new inside the window (steady state, slow proof cadence)
+            # the provenance domain (24h coherence floor) goes silent while
+            # run_provenance_linking() ran fine. Attest the cycle either way.
             if prov_rows:
                 await asyncio.to_thread(attest_state, "provenance", [dict(r) for r in prov_rows], None, "enrichment.provenance_update")
+            else:
+                await asyncio.to_thread(attest_state, "provenance", [{"status": "ran_no_results", "window_hours": 2, "proofs_in_window": 0}], None, "enrichment.provenance_update")
         except Exception as e:
             logger.error(f"[enrichment] provenance attestation failed: {e}")
             try:


### PR DESCRIPTION
## Heartbeat-gating antipattern sweep (scenario 006)

Sweep for the bug class from the May 27 instrumentation audit (#268): collectors that gate their `state_attestations` write on a **DELTA** condition (rows produced *this run*) instead of a **RAN** condition (the collector ran). When the delta legitimately goes to zero in steady state, the heartbeat goes silent while the collector keeps working — so `coherence` falsely reports the domain dead, or (worse) the gap masks a real outage.

### Scope discipline
- **Monitored domains only.** The genuine heartbeat-lie surface is the non-prefixed domains in `coherence.ALL_DOMAINS` written via `attest_state`. The `attest_data_batch(...)` calls in `app/data_layer/*` write `data_layer:*` domains that are **not** in `ALL_DOMAINS` — they are provenance records, health-verified by direct output-table queries (`OUTPUT_STREAM_CHECKS`), not by attestation freshness. Their `if total_* > 0:` guards are therefore **not** this antipattern and were left alone (per "do not touch OUTPUT_STREAM_CHECKS").
- Did **not** re-fix the confirmed/known instances (`parent_company_financials.py:282`, `holder_ingestion_collector.py:401`) or the mempool case.
- Verified `divergence_signals` and `provenance` are **not** in `OUTPUT_STREAM_CHECKS` (which only covers `discovery_signals` streams + `mempool_observations`) — so their attestation is the *only* freshness signal and the fix is not redundant.

Substrate: live queries against Neon `small-scene-57890564` (BasisProtocol), 2026-05-29 ~18:30Z.

---

## FIXED (4) — clean RAN-gate

| # | File:line | Guard (delta) | "Ran" means | Domain / floor | Live? |
|---|-----------|---------------|-------------|----------------|-------|
| 1 | `enrichment_worker.py:768` | `if signals:` | divergence detector ran a cycle | `divergence_signals` / 4h | **Live, fragile.** attest fresh 1.5h; `divergence_signals` output 9,725 rows, last `16:59Z`. Fires only because divergences are currently non-zero — a quiet cycle silently breaches the 4h floor. |
| 2 | `enrichment_worker.py:1241` | `if prov_rows:` (proofs in trailing **2h SELECT window**) | `run_provenance_linking()` ran | `provenance` / 24h | **Live, fragile.** attest fresh 1.5h; `provenance_proofs` 16,798 rows, last `18:14Z`. Same lookback-window shape that left `cda_extractions` dark 30+ days (`cda_collector.py:34`); goes silent the moment proof cadence slows below the window. |
| 3 | `rated_validators.py:224` | `if snapshots_stored > 0:` | validator scan completed | `validator_performance` / 24h | **Actively dead.** `state_attestations` domain has **0 rows ever**; `validator_performance_snapshots` **0 rows**. Gate guarantees it can never heartbeat → perpetual false stale-alert. Fix emits an honest "ran, stored 0". *(Note: output also empty — confirm the collector is actually scheduled.)* |
| 4 | `sanctions_screening.py:195` | `if targets_screened > 0:` | screening pass completed | `sanctions_screening` / 24h | **Live.** attest 17.6h old (n=19); `sanctions_screening_results` 418 rows, last `00:56Z`. Fires when targets exist; silent on any empty-target run. |

Each fix attests on cycle completion with the count carried in the payload (`operators_stored`/`targets_screened`/`results_count`), so a quiet cycle records a truthful `ran, 0` heartbeat instead of nothing. Also corrects a latent `NameError` (`{ae}` → `{e}`) in the two `except` handlers being rewritten in #3/#4.

---

## QUESTIONABLE — flagged for architect ruling (not touched)

These are either structural (per-row-in-loop, not a one-line guard move), arguably deliberate "event-write only" designs, or a real outage rather than a lie:

- **`governance_proposals.py:401`** — per-proposal attest inside the store loop. Substrate is damning: `governance_proposals` output is **live** (216 rows, last `2026-05-28 22:40Z`) but the `governance_proposals` attestation domain has **0 rows ever** → the heartbeat is dead while the collector produces. Likely the worst real lie in the sweep, but the fix is structural (needs a post-loop summary heartbeat) and the zero-attestation root cause needs confirming (possible second write path). **Recommend a follow-up.**
- **`enforcement_history.py:270`** — `if new_records > 0:` *inside the per-symbol loop*. Substrate: 0 attestations, 0 output rows, 168h floor → guaranteed perpetual false-alert. Enforcement actions are genuinely rare, so this may be a deliberate event-write; honest fix is a post-loop "scanned N entities, 0 records" heartbeat (structural).
- **`parameter_history.py:487` / `:565`** (`protocol_parameter_changes` 4h, `protocol_parameter_snapshots` 24h) — **NOT a lie.** Both attestation *and* output stalled together on `2026-05-14` (~15.7 days). The collector itself stopped; the silence is honest. Root cause is a collector outage upstream, not the guard. Flagged so it isn't mistaken for this bug class.
- **`flows.py:445` / `smart_contract.py:944`** (`if components:`) — guard is effectively always-true (the component list is built unconditionally above and `attest_state` already no-ops on empty), domains fresh (0.0h). Low risk; left as-is.
- **Event-write-by-design** (`contract_upgrades.py:331`, `contagion_archive.py:280`, `clustered_concentration.py:339`, `contract_dependencies.py:375`, `oracle_behavior.py:629` oracle_readings, `vault_collector.py:743`) — write-on-change semantics; several are covered by a sibling unconditional heartbeat (e.g. `oracle_stress_events:679`, `contract_dependencies_snapshot:460`) or currently fresh. Left for the architect to decide whether each needs a per-cycle heartbeat like the `oracle_stress_events` precedent.

---

## Scenario note (006: heartbeat_attests_while_output_stream_dead)
The sweep surfaced **three distinct sub-shapes** worth covering separately in a scenarios session (not authored here):
1. **delta-rowcount guard** — `if count > 0:` wrapping a single post-loop attest (rated_validators, sanctions_screening; matches the confirmed templates).
2. **lookback-window guard** — `if rows:` where `rows` come from a trailing time-window `SELECT`, not this run (provenance; the `cda_extractions` 30-day variant).
3. **per-iteration-in-loop attest** — attest lives *inside* the row-write loop, so an entirely quiet cycle writes nothing at all (enforcement, governance_proposals). Distinct from 1–2 because there is no single guard to move.

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01S8sASkDSjVGVNUZhiDKtBd)_