### PR TITLE
fix(attest): cycle-completion attestation for three remaining loop-only collectors

### DIFF
--- a/app/collectors/enforcement_history.py
+++ b/app/collectors/enforcement_history.py
@@ -301,6 +301,42 @@ def collect_enforcement_records() -> dict:
             except Exception:
                 pass
 
+    # Cycle-completion attestation — RAN-gated heartbeat. The per-entity attest
+    # above only fires when `new_records > 0`; with enforcement records landing
+    # rarely (often zero new rows for weeks), that branch left the
+    # enforcement_records domain (168h coherence floor) unable to distinguish
+    # "scanned, found nothing" from "collector never ran" — 0 output rows, 0
+    # attestations ever (Neon prod 2026-05-29). The collector IS registered and
+    # runs (app/worker.py Pipeline 20). Attest once the scan completes, with the
+    # live table count, so a quiet scan records an honest "ran, N total"
+    # heartbeat.
+    try:
+        from app.state_attestation import compute_batch_hash, store_attestation
+        total_row = fetch_one("SELECT COUNT(*) AS n FROM enforcement_records")
+        total_records = int(total_row["n"]) if total_row else 0
+        store_attestation(
+            "enforcement_records",
+            compute_batch_hash([{
+                "entities_scanned": entities_scanned,
+                "new_records": new_records,
+                "skipped_recent": skipped_recent,
+                "scanned_at": datetime.now(timezone.utc).isoformat(),
+            }]),
+            record_count=total_records,
+            writer_id="module.enforcement_history",
+        )
+    except Exception as e:
+        logger.warning(f"Enforcement cycle attestation failed: {e}")
+        try:
+            from app.worker import _record_cycle_error
+            _record_cycle_error(
+                error_type="collectors_collect_enforcement_records_failure",
+                error_message=str(e)[:500],
+                cycle_phase="enforcement_history",
+            )
+        except Exception:
+            pass
+
     summary = {
         "entities_scanned": entities_scanned,
         "new_records": new_records,

--- a/app/collectors/governance_proposals.py
+++ b/app/collectors/governance_proposals.py
@@ -521,6 +521,40 @@ async def collect_governance_proposals() -> dict:
 
         results["protocols_checked"] += 1
 
+    # Cycle-completion attestation — RAN-gated heartbeat. The inner per-proposal
+    # attest in _upsert_proposal() only fires on a NEW proposal (it proves
+    # individual proposal-body capture and is left intact). For slow-moving
+    # governance the steady state is zero new proposals per cycle, so that inner
+    # attest never fired and the governance_proposals domain (24h coherence
+    # floor) read as perpetually stale despite the collector running every
+    # cycle — 217 output rows, 0 attestations ever (Neon prod 2026-05-29). Attest
+    # once the sweep completes, with the cycle's captured+updated count, so a
+    # quiet cycle still records an honest "ran, 0" heartbeat.
+    try:
+        from app.state_attestation import compute_batch_hash, store_attestation
+        store_attestation(
+            "governance_proposals",
+            compute_batch_hash([{
+                "protocols_checked": results["protocols_checked"],
+                "proposals_captured": results["proposals_captured"],
+                "proposals_updated": results["proposals_updated"],
+                "swept_at": datetime.now(timezone.utc).isoformat(),
+            }]),
+            record_count=results["proposals_captured"] + results["proposals_updated"],
+            writer_id="module.governance_proposals",
+        )
+    except Exception as e:
+        logger.warning(f"Governance proposals cycle attestation failed: {e}")
+        try:
+            from app.worker import _record_cycle_error
+            _record_cycle_error(
+                error_type="collectors_collect_governance_proposals_failure",
+                error_message=str(e)[:500],
+                cycle_phase="governance_proposals",
+            )
+        except Exception:
+            pass
+
     logger.info(
         f"Governance proposals: protocols={results['protocols_checked']} "
         f"captured={results['proposals_captured']} "

--- a/app/collectors/parameter_history.py
+++ b/app/collectors/parameter_history.py
@@ -735,6 +735,51 @@ async def collect_parameter_history() -> dict:
             except Exception:
                 pass
 
+    # Cycle-completion attestation — RAN-gated heartbeat for both output
+    # domains. The inner attests (_handle_parameter_change /
+    # _store_daily_snapshot) only fire when a change or snapshot is actually
+    # written. Since the May-14 kill switch (#252) every registry protocol is in
+    # KILLED_PROTOCOLS, so a normal cycle writes nothing new and those inner
+    # attests never fire — protocol_parameter_changes (4h floor) and
+    # protocol_parameter_snapshots (24h floor) have read stale since their last
+    # write on 2026-05-14 despite the collector running every cycle (55 + 4
+    # output rows, last attest 2026-05-14; Neon prod 2026-05-29). Scope was
+    # reduced, not removed, so the heartbeat must still fire. Attest once the run
+    # completes, with the live table counts, so a quiet cycle records an honest
+    # "ran, N total".
+    try:
+        from app.state_attestation import compute_batch_hash, store_attestation
+        now_iso = datetime.now(timezone.utc).isoformat()
+        heartbeat_hash = compute_batch_hash([{
+            "protocols_checked": results["protocols_checked"],
+            "changes_detected": results["changes_detected"],
+            "snapshots_stored": results["snapshots_stored"],
+            "ran_at": now_iso,
+        }])
+        for _domain in ("protocol_parameter_changes", "protocol_parameter_snapshots"):
+            total_row = await fetch_one_async(f"SELECT COUNT(*) AS n FROM {_domain}")
+            total = int(total_row["n"]) if total_row else 0
+            await asyncio.to_thread(
+                store_attestation,
+                _domain,
+                heartbeat_hash,
+                total,
+                writer_id="module.parameter_history",
+            )
+    except asyncio.CancelledError:
+        raise
+    except Exception as e:
+        logger.warning(f"Parameter history cycle attestation failed: {e}")
+        try:
+            from app.worker import _record_cycle_error
+            _record_cycle_error(
+                error_type="collectors_collect_parameter_history_failure",
+                error_message=str(e)[:500],
+                cycle_phase="parameter_history",
+            )
+        except Exception:
+            pass
+
     logger.info(
         f"Parameter history: protocols={results['protocols_checked']} "
         f"params={results['parameters_checked']} "


### PR DESCRIPTION
## Summary

Third and final sweep of the heartbeat-lie antipattern. PR #271 swept four obvious lies (`divergence_signals`, `provenance`, `validator_performance`, `sanctions_screening`) and flagged **three more as QUESTIONABLE** pending architect ruling. The architect ruled (live prod query 2026-05-29 ~23:23 UTC): **all three are real lies, not off-by-design.** This PR fixes them.

All three are the same sub-shape — **loop-only attestation with no cycle-completion fire**: `attest_state` is called only conditionally *inside an iteration* (a new-row branch), with no attestation at the outer scope. When the work produces nothing new — the steady state for slow-moving inputs — **no heartbeat fires at all**, so the coherence freshness monitor (`app/coherence.py` `ALL_DOMAINS`) reads the domain as dead while the collector is in fact running.

This is **distinct from scenario 006** (delta-gated attestation *within a guard*). Here the attestation is loop-only with *no outer-scope guard at all*. New scenario proposed below; follow-up issue #272 tracks authoring.

The fix is **purely additive**: each outer collector now attests once on cycle completion with a real count. Every inner per-iteration attest is left untouched (they serve a different purpose — proving individual row capture).

## Fixes

### 1. `app/collectors/governance_proposals.py` — `collect_governance_proposals()`
- **Missing attest:** outer scope after the `for protocol_slug` loop. Inner attest at `_upsert_proposal()` (new-proposal branch, ~line 400) only fires on a NEW proposal.
- **Fix:** unconditional cycle-completion attest after the loop, `record_count = proposals_captured + proposals_updated`. Inner per-proposal attest left as-is (proves individual body capture).

### 2. `app/collectors/enforcement_history.py` — `collect_enforcement_records()`
- **Missing attest:** outer scope after the `for symbol` loop. Inner attest gated on `if new_records > 0` (line ~270).
- **Precondition verified:** collector **is** registered and runs — `app/worker.py` Pipeline 20 (`collect_enforcement_records` via `asyncio.to_thread`). So the fix is warranted.
- **Fix:** cycle-completion attest after the loop, `record_count = SELECT COUNT(*) FROM enforcement_records` (live table state).

### 3. `app/collectors/parameter_history.py` — `collect_parameter_history()`
- **Missing attest:** outer scope after the snapshot loop. Inner attests at `_handle_parameter_change` (line ~486) and `_store_daily_snapshot` (line ~564) fire only on a written change/snapshot.
- **Not off-by-design:** the May-14 kill switch (#252) put both registry protocols in `KILLED_PROTOCOLS`, so a normal cycle writes nothing new — scope was *reduced*, not removed. Both `protocol_parameter_changes` (4h floor) and `protocol_parameter_snapshots` (24h floor) are `ALL_DOMAINS` members and must still emit a heartbeat.
- **Fix:** cycle-completion attest for **both** domains after the run, `record_count = live table count` per domain.

## Implementation note

The task specified an explicit `record_count` for each heartbeat (real output / table count, including an honest `0` or `N total`). `attest_state()` derives `record_count` from `len(records)`, so to carry the real value I use the lower-level `compute_batch_hash` + `store_attestation` pair from the same module. Same effect as the PR #271 pattern, but `record_count` reflects actual state rather than `1`.

## Substrate verification

Per lesson 7. Queries run against Neon `small-scene-57890564` (branch `br-round-feather-ajk3ofap`).

### Pre-deploy (theoretical / pure docs / no runtime contract)

The new heartbeats only fire once the worker runs each collector post-deploy, so the fix's effect is pre-deploy. **Known now** is the substrate state proving each lie is current (the bug evidence):

```sql
-- run 2026-05-30 ~01:5x UTC, br-round-feather-ajk3ofap
SELECT domain, COUNT(*) AS n, MAX(cycle_timestamp) AS last_attest,
       NOW() - MAX(cycle_timestamp) AS staleness
FROM state_attestations
WHERE domain IN ('governance_proposals','enforcement_records',
                 'protocol_parameter_changes','protocol_parameter_snapshots')
GROUP BY domain;
```

Result (confirms the lie):
```
governance_proposals          -> 0 rows  (217 output rows; 0 attestations ever)
enforcement_records           -> 0 rows  (0 output rows; cannot tell ran-vs-never-ran)
protocol_parameter_changes    -> 55 rows; last_attest 2026-05-14  (~16d stale)
protocol_parameter_snapshots  ->  4 rows; last_attest 2026-05-14  (~16d stale)
```

**Query the deploy verifier will run after the next slow cycle elapses** (collectors are daily/weekly-gated; wait ≥1 slow cycle, ≤24h for governance/parameter-snapshots, ≤1 week for enforcement):

```sql
SELECT domain, writer_id, COUNT(*), AVG(record_count) AS avg_rc, MAX(cycle_timestamp)
FROM state_attestations
WHERE domain IN ('governance_proposals','enforcement_records',
                 'protocol_parameter_changes','protocol_parameter_snapshots')
  AND cycle_timestamp > '2026-05-30T02:00:00Z'::timestamptz
GROUP BY domain, writer_id
ORDER BY domain, COUNT(*) DESC;
```

Expected post-deploy:
- `governance_proposals` freshness < 24h with `writer_id = 'module.governance_proposals'`; `record_count` = that cycle's captured+updated (honest `0` in steady state).
- `enforcement_records` freshness < 168h with `writer_id = 'module.enforcement_history'`; `record_count` = live table COUNT.
- `protocol_parameter_changes` (< 4h) and `protocol_parameter_snapshots` (< 24h) both fresh with `writer_id = 'module.parameter_history'`; `record_count` = live table COUNT per domain.

Writer-provenance distinguisher: the cycle-completion heartbeat carries `record_count` = real output/table count under `module.<name>`, separable from any inner per-row attest by `WHERE writer_id LIKE 'module.%'`. This is a RAN-gated heartbeat, not a wrapper-canonical write, so the `record_count != 1` signature is expected and intended.

## Verification (CI)

- `invoke-regression-matrix`: **success** — all existing scenarios pass (purely additive; no existing attestation logic changed).
- `python -m py_compile` clean on all three files.

## Standing scenario obligation

This sub-shape needs its own guard, distinct from scenario 006. **Not authored here** (protected test content → separate scenarios-session, per Holdout Isolation). Follow-up: **#272**.

- **Suggested slug:** `008-loop-only-attestation-no-cycle-completion-fire`
- **`bug.patch` shape:** revert the cycle-completion block from one representative collector (governance_proposals — single output domain), leaving only the inner per-proposal attest. Reproduces "collector runs, zero new rows, zero heartbeats."
- **`stage_1.sql` shape:** seed the output table with rows (output exists) and leave `state_attestations` with no recent row for the domain; drive one steady-state cycle. Assert the buggy patch writes **zero** new attestations while the fix lands exactly one cycle-completion row with a fresh `cycle_timestamp` and `record_count` = live table count.

## Scope discipline

- Does **not** touch the four already-fixed PR #271 items, the keeper, mempool, or any SII/PSI work.
- Does **not** modify existing attestation logic — only ADDs cycle-completion attestations where missing.
- Does **not** author the new scenario.

Tracks #272.

https://claude.ai/code/session_015nj3K8kh4hu8NvaqhvznSB